### PR TITLE
Corrected spelling of Canada's capital city.

### DIFF
--- a/countries.csv
+++ b/countries.csv
@@ -38,7 +38,7 @@ Burkina Faso;.bf;BF;854;BFA;XOF;226;Ouagadougou;BF;0;Africa;Western Africa
 Burundi;.bi;BI;108;BDI;BIF;257;Bujumbura;BI;0;Africa;Eastern Africa
 Cambodia;.kh;KH;116;KHM;KHR;855;Phnom Penh;KH;0;Asia;South-Eastern,Asia
 Cameroon;.cm;CM;120;CMR;XAF;237;Yaoundé;CM;0;Africa;Middle Africa
-Canada;.ca;CA;124;CAN;CAD;1;Ottowa;CA;2;Americas;Northern America
+Canada;.ca;CA;124;CAN;CAD;1;Ottawa;CA;2;Americas;Northern America
 Cape Verde;.cv;CV;132;CPV;CVE;238;Praia;CV,Cabo;0;Africa;Western Africa
 Cayman Islands;.ky;KY;136;CYM;KYD;1345;George Town;KY;0.5;Americas;Caribbean
 Central African Republic;.cf;CF;140;CAF;XAF;236;Bangui;CF;0;Africa;Middle Africa


### PR DESCRIPTION
Noticed that Ottawa was spelled as "Ottowa," so thought I'd send you a quick pull request to fix it. It's also showing I deleted and rewrote Zimbabwe, but I didn't. Not sure why that is. Maybe the Web editor has a quirk in it. 
