### PR TITLE
Fix currency and alt-spelling for Slovakia

### DIFF
--- a/countries.csv
+++ b/countries.csv
@@ -199,7 +199,7 @@ Seychelles;.sc;SC;690;SYC;SCR;248;Victoria;SC;0.5;Africa;Eastern Africa
 Sierra Leone;.sl;SL;694;SLE;SLL;232;Freetown;SL;0;Africa;Western Africa
 Singapore;.sg;SG;702;SGP;SGD;65;Singapore;SG,Singapura;0;Asia;South-Eastern,Asia
 Sint Maarten;.sx;SX;534;SXM;ANG;1721;Philipsburg;SX;0;;
-Slovakia;.sk;SK;703;SVK;XSU;421;Bratislava;SK,Slovenská,Slovensko;0;Europe;Eastern Europe
+Slovakia;.sk;SK;703;SVK;EUR;421;Bratislava;SK,Slovenská republika,Slovensko;0;Europe;Eastern Europe
 Slovenia;.si;SI;705;SVN;EUR;386;Ljubljana;SI,Slovenija;0;Europe;Southern Europe
 Solomon Islands;.sb;SB;90;SLB;EUR;677;Honiara;SB;0;Oceania;Melanesia
 Somalia;.so;SO;706;SOM;SBD;252;Mogadishu;SO;0;Africa;Eastern Africa

--- a/countries.json
+++ b/countries.json
@@ -198,7 +198,7 @@
 {"name":"Sierra Leone","tld":".sl","cca2":"SL","ccn3":694,"cca3":"SLE","currency":"SLL","calling-code":"232","capital":"Freetown","alt-spellings":"SL","relevance":0,"region":"Africa","subregion":"Western Africa"},
 {"name":"Singapore","tld":".sg","cca2":"SG","ccn3":702,"cca3":"SGP","currency":"SGD","calling-code":"65","capital":"Singapore","alt-spellings":"SG,Singapura","relevance":0,"region":"Asia","subregion":"South-Eastern,Asia"},
 {"name":"Sint Maarten","tld":".sx","cca2":"SX","ccn3":534,"cca3":"SXM","currency":"ANG","calling-code":"1721","capital":"Philipsburg","alt-spellings":"SX","relevance":0,"region":"","subregion":""},
-{"name":"Slovakia","tld":".sk","cca2":"SK","ccn3":703,"cca3":"SVK","currency":"XSU","calling-code":"421","capital":"Bratislava","alt-spellings":"SK,Slovensk\u00e1,Slovensko","relevance":0,"region":"Europe","subregion":"Eastern Europe"},
+{"name":"Slovakia","tld":".sk","cca2":"SK","ccn3":703,"cca3":"SVK","currency":"EUR","calling-code":"421","capital":"Bratislava","alt-spellings":"SK,Slovensk\u00e1 republika,Slovensko","relevance":0,"region":"Europe","subregion":"Eastern Europe"},
 {"name":"Slovenia","tld":".si","cca2":"SI","ccn3":705,"cca3":"SVN","currency":"EUR","calling-code":"386","capital":"Ljubljana","alt-spellings":"SI,Slovenija","relevance":0,"region":"Europe","subregion":"Southern Europe"},
 {"name":"Solomon Islands","tld":".sb","cca2":"SB","ccn3":90,"cca3":"SLB","currency":"EUR","calling-code":"677","capital":"Honiara","alt-spellings":"SB","relevance":0,"region":"Oceania","subregion":"Melanesia"},
 {"name":"Somalia","tld":".so","cca2":"SO","ccn3":706,"cca3":"SOM","currency":"SBD","calling-code":"252","capital":"Mogadishu","alt-spellings":"SO","relevance":0,"region":"Africa","subregion":"Eastern Africa"},

--- a/countries.xml
+++ b/countries.xml
@@ -200,7 +200,7 @@
   <country name="Sierra Leone" tld=".sl" cca2="SL" ccn3="694" cca3="SLE" currency="SLL" calling-code="232" capital="Freetown" alt-spellings="SL" relevance="0" region="Africa" subregion="Western Africa"/>
   <country name="Singapore" tld=".sg" cca2="SG" ccn3="702" cca3="SGP" currency="SGD" calling-code="65" capital="Singapore" alt-spellings="SG,Singapura" relevance="0" region="Asia" subregion="South-Eastern,Asia"/>
   <country name="Sint Maarten" tld=".sx" cca2="SX" ccn3="534" cca3="SXM" currency="ANG" calling-code="1721" capital="Philipsburg" alt-spellings="SX" relevance="0" region="" subregion=""/>
-  <country name="Slovakia" tld=".sk" cca2="SK" ccn3="703" cca3="SVK" currency="XSU" calling-code="421" capital="Bratislava" alt-spellings="SK,Slovenská,Slovensko" relevance="0" region="Europe" subregion="Eastern Europe"/>
+  <country name="Slovakia" tld=".sk" cca2="SK" ccn3="703" cca3="SVK" currency="EUR" calling-code="421" capital="Bratislava" alt-spellings="SK,Slovenská republika,Slovensko" relevance="0" region="Europe" subregion="Eastern Europe"/>
   <country name="Slovenia" tld=".si" cca2="SI" ccn3="705" cca3="SVN" currency="EUR" calling-code="386" capital="Ljubljana" alt-spellings="SI,Slovenija" relevance="0" region="Europe" subregion="Southern Europe"/>
   <country name="Solomon Islands" tld=".sb" cca2="SB" ccn3="90" cca3="SLB" currency="EUR" calling-code="677" capital="Honiara" alt-spellings="SB" relevance="0" region="Oceania" subregion="Melanesia"/>
   <country name="Somalia" tld=".so" cca2="SO" ccn3="706" cca3="SOM" currency="SBD" calling-code="252" capital="Mogadishu" alt-spellings="SO" relevance="0" region="Africa" subregion="Eastern Africa"/>


### PR DESCRIPTION
Slovakia uses EUR as its currency and the alternative spelling was missing the word "republika".
