### PR TITLE
Added missing borders data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1741,7 +1741,7 @@
 		"population": 865878,
 		"latlng": [35, 33],
 		"demonym": "Cypriot",
-		"borders": []
+		"borders": [ "GBR" ]
 	},
 	{
 		"name": "Czech Republic",


### PR DESCRIPTION
I've added the borders data to Cyprus, East Timor, Kosovo, North Korea, Palestine, South Korea and Sint Marteen. 
According to http://en.wikipedia.org/wiki/List_of_countries_and_territories_by_land_borders I've added Great Britain as border country of Cyprus.

Bye,
Andrea
