### PR TITLE
Fix Libya CCA3 in Algeria's borders

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -119,7 +119,7 @@
 		},
 		"latlng": [28, 3],
 		"demonym": "Algerian",
-		"borders": ["TUN", "LDY", "NER", "ESH", "MRT", "MLI", "MAR"],
+		"borders": ["TUN", "LBY", "NER", "ESH", "MRT", "MLI", "MAR"],
 		"area": 2381741
 	},
 	{


### PR DESCRIPTION
Hi,

I've fixed the Libya CCA3 code in Algeria's borders.

This PR is related to: #61

Thanks,
Bye,
Andrea
