### PR TITLE
Removed Armenian language to Azerbaijan. Added Russian to Azerbaijan.

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -642,7 +642,7 @@
 		"nativeLanguage": "aze",
 		"languages": {
 			"aze": "Azerbaijani",
-			"hye": "Armenian"
+			"rus": "Russian"
 		},
 		"translations": {
 			"cym": "Aserbaijan",


### PR DESCRIPTION
#94

https://en.wikipedia.org/wiki/Languages_of_Azerbaijan
http://www.kwintessential.co.uk/resources/global-etiquette/azerbaijan.html
