### PR TITLE
added Sardinian

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5052,7 +5052,8 @@
 		"subregion": "Southern Europe",
 		"languages": {
 			"bar": "Austro-Bavarian German",
-			"ita": "Italian"
+			"ita": "Italian",
+			"srd": "Sardinian"
 		},
 		"translations": {
 			"deu": {"official": "italienische Republik", "common": "Italien"},


### PR DESCRIPTION
Sardinian is a recognized minority language in Italy.