### PR TITLE
fix spelling in german translation for Egypt in countries.json

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -3025,7 +3025,7 @@
 		},
 		"translations": {
 			"cym": {"official": "Arab Republic of Egypt", "common": "Yr Aifft"},
-			"deu": {"official": "Arabischen Republik \u00c4gypten", "common": "\u00c4gypten"},
+			"deu": {"official": "Arabische Republik \u00c4gypten", "common": "\u00c4gypten"},
 			"fra": {"official": "R\u00e9publique arabe d'\u00c9gypte", "common": "\u00c9gypte"},
 			"hrv": {"official": "Arapska Republika Egipat", "common": "Egipat"},
 			"ita": {"official": "Repubblica araba d'Egitto", "common": "Egitto"},


### PR DESCRIPTION
Not much to it. Just a 'n' too many.