### PR TITLE
Fixes #162

### DIFF
--- a/src/MLD/Converter/AbstractJsonConverter.php
+++ b/src/MLD/Converter/AbstractJsonConverter.php
@@ -11,7 +11,7 @@ abstract class AbstractJsonConverter extends AbstractConverter {
 	 */
 	protected function processEmptyArrays() {
 		array_walk($this->aCountries, function (&$aCountry) {
-			if (empty($aCountry['languages'])) {
+			if (isset($aCountry['languages']) && empty($aCountry['languages'])) {
 				$aCountry['languages'] = new \stdClass();
 			}
 		});


### PR DESCRIPTION
If the `languages` key was excluded it would still appear in the JSON output files.