### PR TITLE
Allow setting a custom command name

### DIFF
--- a/src/MLD/Console/Command/ExportCommand.php
+++ b/src/MLD/Console/Command/ExportCommand.php
@@ -44,7 +44,7 @@ class ExportCommand extends Command {
 	 * @param string $outputDirectory Full path to output directory for converted files.
 	 * @param string|null $name
 	 */
-	public function __construct($inputFile, $outputDirectory, $name = null) {
+	public function __construct($inputFile, $outputDirectory, $name = 'convert') {
 		$this->inputFile = $inputFile;
 		$this->outputDirectory = $outputDirectory;
 
@@ -56,7 +56,6 @@ class ExportCommand extends Command {
 	 */
 	protected function configure() {
 		$this
-			->setName('convert')
 			->setDescription('Converts source country data to various output formats')
 			->addOption(
 				'exclude-field',


### PR DESCRIPTION
This change allow overriding the default command name "convert" to use whatever is passed in the third parameter to the constructor.  This was previously ignored due to the forced setName() in configure().