### PR TITLE
Add nld translation for Kosovo

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5825,6 +5825,7 @@
 			"fra": {"official": "R\u00E9publique du Kosovo", "common": "Kosovo"},
 			"hrv": {"official": "Republika Kosovo", "common": "Kosovo"},
 			"ita": {"official": "Repubblica del Kosovo", "common": "Kosovo"},
+			"nld": {"official": "Republiek Kosovo", "common":"Kosovo"},
 			"por": {"official": "Rep\u00fablica do Kosovo", "common": "Kosovo"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0441\u043e\u0432\u043e", "common": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0441\u043e\u0432\u043e"},
 			"spa": {"official": "Rep\u00fablica de Kosovo", "common": "Kosovo"},


### PR DESCRIPTION
Small addition of one line.
Added the Dutch translation for Kosovo, this was the only country without a Dutch translation.