### PR TITLE
Czech Republic short names

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -2821,7 +2821,7 @@
 			"ita": {"official": "Repubblica Ceca", "common": "Cechia"},
 			"jpn": {"official": "\u30c1\u30a7\u30b3\u5171\u548c\u56fd", "common": "\u30c1\u30a7\u30b3"},
 			"nld": {"official": "Tsjechische Republiek", "common": "Tsjechi\u00eb"},
-			"por": {"official": "Rep\u00fablica Checa", "common": "Tcheca"},
+			"por": {"official": "Rep\u00fablica Checa", "common": "Ch\u00e9quia"},
 			"rus": {"official": "\u0427\u0435\u0448\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0427\u0435\u0445\u0438\u044f"},
 			"spa": {"official": "Rep\u00fablica Checa", "common": "Chequia"},
 			"svk": {"official": "\u010cesk\u00e1 republika", "common": "\u010cesko"},

--- a/countries.json
+++ b/countries.json
@@ -38,8 +38,8 @@
 			"nld": {"official": "Aruba", "common": "Aruba"},
 			"por": {"official": "Aruba", "common": "Aruba"},
 			"rus": {"official": "\u0410\u0440\u0443\u0431\u0430", "common": "\u0410\u0440\u0443\u0431\u0430"},
+			"slk": {"official": "Aruba", "common": "Aruba"},
 			"spa": {"official": "Aruba", "common": "Aruba"},
-			"svk": {"official": "Aruba", "common": "Aruba"},
 			"fin": {"official": "Aruba", "common": "Aruba"},
 			"zho": {"official": "\u963F\u9C81\u5DF4", "common": "\u963F\u9C81\u5DF4"}
 		},
@@ -94,8 +94,8 @@
 			"nld": {"official": "Islamitische Republiek Afghanistan", "common": "Afghanistan"},
 			"por": {"official": "Rep\u00fablica Isl\u00e2mica do Afeganist\u00e3o", "common": "Afeganist\u00e3o"},
 			"rus": {"official": "\u0418\u0441\u043b\u0430\u043c\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0410\u0444\u0433\u0430\u043d\u0438\u0441\u0442\u0430\u043d", "common": "\u0410\u0444\u0433\u0430\u043d\u0438\u0441\u0442\u0430\u043d"},
+			"slk": {"official": "Afg\u00e1nsky islamsk\u00fd \u0161t\u00e1t", "common": "Afganistan"},
 			"spa": {"official": "Rep\u00fablica Isl\u00e1mica de Afganist\u00e1n", "common": "Afganist\u00e1n"},
-			"svk": {"official": "Afg\u00e1nsky islamsk\u00fd \u0161t\u00e1t", "common": "Afganistan"},
 			"fin": {"official": "Afganistanin islamilainen tasavalta", "common": "Afganistan"},
 			"zho": {"official": "\u963F\u5BCC\u6C57\u4F0A\u65AF\u5170\u5171\u548C\u56FD", "common": "\u963F\u5BCC\u6C57"}
 		},
@@ -140,8 +140,8 @@
 			"nld": {"official": "Republiek Angola", "common": "Angola"},
 			"por": {"official": "Rep\u00fablica de Angola", "common": "Angola"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0410\u043d\u0433\u043e\u043b\u0430", "common": "\u0410\u043d\u0433\u043e\u043b\u0430"},
+			"slk": {"official": "Angolsk\u00e1 republika", "common": "Angola"},
 			"spa": {"official": "Rep\u00fablica de Angola", "common": "Angola"},
-			"svk": {"official": "Angolsk\u00e1 republika", "common": "Angola"},
 			"fin": {"official": "Angolan tasavalta", "common": "Angola"},
 			"zho": {"official": "\u5B89\u54E5\u62C9\u5171\u548C\u56FD", "common": "\u5B89\u54E5\u62C9"}
 		},
@@ -185,8 +185,8 @@
 			"nld": {"official": "Anguilla", "common": "Anguilla"},
 			"por": {"official": "Anguilla", "common": "Anguilla"},
 			"rus": {"official": "\u0410\u043d\u0433\u0438\u043b\u044c\u044f", "common": "\u0410\u043d\u0433\u0438\u043b\u044c\u044f"},
+			"slk": {"official": "Anguilla", "common": "Anguilla"},
 			"spa": {"official": "Anguila", "common": "Anguilla"},
-			"svk": {"official": "Anguilla", "common": "Anguilla"},
 			"fin": {"official": "Anguilla", "common": "Anguilla"},
 			"zho": {"official": "\u5B89\u572D\u62C9", "common": "\u5B89\u572D\u62C9"}
 		},
@@ -230,8 +230,8 @@
 			"nld": {"official": "\u00c5land eilanden", "common": "\u00c5landeilanden"},
 			"por": {"official": "Ilhas \u00c5land", "common": "Al\u00e2ndia"},
 			"rus": {"official": "\u0410\u043b\u0430\u043d\u0434\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0410\u043b\u0430\u043d\u0434\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Alandsk\u00e9 ostrovy", "common": "Alandy"},
 			"spa": {"official": "Islas \u00c5land", "common": "Alandia"},
-			"svk": {"official": "Alandsk\u00e9 ostrovy", "common": "Alandy"},
 			"fin": {"official": "Ahvenanmaan maakunta", "common": "Ahvenanmaa"},
 			"zho": {"official": "\u5965\u5170\u7FA4\u5C9B", "common": "\u5965\u5170\u7FA4\u5C9B"}
 		},
@@ -276,8 +276,8 @@
 			"nld": {"official": "Republiek Albani\u00eb", "common": "Albani\u00eb"},
 			"por": {"official": "Rep\u00fablica da Alb\u00e2nia", "common": "Alb\u00e2nia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0410\u043b\u0431\u0430\u043d\u0438\u044f", "common": "\u0410\u043b\u0431\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "Alb\u00e1nska republika", "common": "Alb\u00e1nsko"},
 			"spa": {"official": "Rep\u00fablica de Albania", "common": "Albania"},
-			"svk": {"official": "Alb\u00e1nska republika", "common": "Alb\u00e1nsko"},
 			"fin": {"official": "Albanian tasavalta", "common": "Albania"},
 			"zho": {"official": "\u963F\u5C14\u5DF4\u5C3C\u4E9A\u5171\u548C\u56FD", "common": "\u963F\u5C14\u5DF4\u5C3C\u4E9A"}
 		},
@@ -322,8 +322,8 @@
 			"nld": {"official": "Prinsdom Andorra", "common": "Andorra"},
 			"por": {"official": "Principado de Andorra", "common": "Andorra"},
 			"rus": {"official": "\u041a\u043d\u044f\u0436\u0435\u0441\u0442\u0432\u043e \u0410\u043d\u0434\u043e\u0440\u0440\u0430", "common": "\u0410\u043d\u0434\u043e\u0440\u0440\u0430"},
+			"slk": {"official": "Andorrsk\u00e9 knie\u017eatstvo", "common": "Andorra"},
 			"spa": {"official": "Principado de Andorra", "common": "Andorra"},
-			"svk": {"official": "Andorrsk\u00e9 knie\u017eatstvo", "common": "Andorra"},
 			"fin": {"official": "Andorran ruhtinaskunta", "common": "Andorra"},
 			"zho": {"official": "\u5B89\u9053\u5C14\u516C\u56FD", "common": "\u5B89\u9053\u5C14"}
 		},
@@ -367,8 +367,8 @@
 			"nld": {"official": "Verenigde Arabische Emiraten", "common": "Verenigde Arabische Emiraten"},
 			"por": {"official": "Emirados \u00c1rabes Unidos", "common": "Emirados \u00c1rabes Unidos"},
 			"rus": {"official": "\u041e\u0431\u044a\u0435\u0434\u0438\u043d\u0435\u043d\u043d\u044b\u0435 \u0410\u0440\u0430\u0431\u0441\u043a\u0438\u0435 \u042d\u043c\u0438\u0440\u0430\u0442\u044b", "common": "\u041e\u0431\u044a\u0435\u0434\u0438\u043d\u0451\u043d\u043d\u044b\u0435 \u0410\u0440\u0430\u0431\u0441\u043a\u0438\u0435 \u042d\u043c\u0438\u0440\u0430\u0442\u044b"},
+			"slk": {"official": "Spojen\u00e9 arabsk\u00e9 emir\u00e1ty", "common": "Spojen\u00e9 arabsk\u00e9 emir\u00e1ty"},
 			"spa": {"official": "Emiratos \u00c1rabes Unidos", "common": "Emiratos \u00c1rabes Unidos"},
-			"svk": {"official": "Spojen\u00e9 arabsk\u00e9 emir\u00e1ty", "common": "Spojen\u00e9 arabsk\u00e9 emir\u00e1ty"},
 			"fin": {"official": "Yhdistyneet arabiemiirikunnat", "common": "Arabiemiraatit"},
 			"zho": {"official": "\u963F\u62C9\u4F2F\u8054\u5408\u914B\u957F\u56FD", "common": "\u963F\u62C9\u4F2F\u8054\u5408\u914B\u957F\u56FD"}
 		},
@@ -418,8 +418,8 @@
 			"nld": {"official": "Argentijnse Republiek", "common": "Argentini\u00eb"},
 			"por": {"official": "Rep\u00fablica Argentina", "common": "Argentina"},
 			"rus": {"official": "\u0410\u0440\u0433\u0435\u043d\u0442\u0438\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0410\u0440\u0433\u0435\u043d\u0442\u0438\u043d\u0430"},
+			"slk": {"official": "Argent\u00ednska republika", "common": "Argent\u00edna"},
 			"spa": {"official": "Rep\u00fablica Argentina", "common": "Argentina"},
-			"svk": {"official": " Argent\u00ednska republika", "common": "Argent\u00edna"},
 			"fin": {"official": "Argentiinan tasavalta", "common": "Argentiina"},
 			"zho": {"official": "\u963F\u6839\u5EF7\u5171\u548C\u56FD", "common": "\u963F\u6839\u5EF7"}
 		},
@@ -469,8 +469,8 @@
 			"nld": {"official": "Republiek Armeni\u00eb", "common": "Armeni\u00eb"},
 			"por": {"official": "Rep\u00fablica da Arm\u00e9nia", "common": "Arm\u00e9nia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0410\u0440\u043c\u0435\u043d\u0438\u044f", "common": "\u0410\u0440\u043c\u0435\u043d\u0438\u044f"},
+			"slk": {"official": "Arm\u00e9nska republika", "common": "Arm\u00e9nsko"},
 			"spa": {"official": "Rep\u00fablica de Armenia", "common": "Armenia"},
-			"svk": {"official": "Arm\u00e9nska republika", "common": "Arm\u00e9nsko"},
 			"fin": {"official": "Armenian tasavalta", "common": "Armenia"},
 			"zho": {"official": "\u4E9A\u7F8E\u5C3C\u4E9A\u5171\u548C\u56FD", "common": "\u4E9A\u7F8E\u5C3C\u4E9A"}
 		},
@@ -519,8 +519,8 @@
 			"nld": {"official": "Amerikaans Samoa", "common": "Amerikaans Samoa"},
 			"por": {"official": "Samoa americana", "common": "Samoa Americana"},
 			"rus": {"official": "\u0430\u043c\u0435\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u043e\u0435 \u0421\u0430\u043c\u043e\u0430", "common": "\u0410\u043c\u0435\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u043e\u0435 \u0421\u0430\u043c\u043e\u0430"},
+			"slk": {"official": "Americk\u00e1 Samoa", "common": "Americk\u00e1 Samoa"},
 			"spa": {"official": "Samoa Americana", "common": "Samoa Americana"},
-			"svk": {"official": "Americk\u00e1 Samoa", "common": "Americk\u00e1 Samoa"},
 			"fin": {"official": "Amerikan Samoa", "common": "Amerikan Samoa"},
 			"zho": {"official": "\u7F8E\u5C5E\u8428\u6469\u4E9A", "common": "\u7F8E\u5C5E\u8428\u6469\u4E9A"}
 		},
@@ -558,8 +558,8 @@
 			"nld": {"official": "Antarctica", "common": "Antarctica"},
 			"por": {"official": "Ant\u00e1rtica", "common": "Ant\u00e1rtida"},
 			"rus": {"official": "\u0410\u043d\u0442\u0430\u0440\u043a\u0442\u0438\u0434\u0430", "common": "\u0410\u043d\u0442\u0430\u0440\u043a\u0442\u0438\u0434\u0430"},
+			"slk": {"official": "Antarkt\u00edda", "common": "Antarkt\u00edda"},
 			"spa": {"official": "Ant\u00e1rtida", "common": "Ant\u00e1rtida"},
-			"svk": {"official": "Antarkt\u00edda", "common": "Antarkt\u00edda"},
 			"fin": {"official": "Etel\u00e4manner", "common": "Etel\u00e4manner"},
 			"zho": {"official": "\u5357\u6781\u6D32", "common": "\u5357\u6781\u6D32"}
 		},
@@ -603,8 +603,8 @@
 			"nld": {"official": "Grondgebied van de Franse Zuidelijke en Antarctische gebieden", "common": "Franse Gebieden in de zuidelijke Indische Oceaan"},
 			"por": {"official": "Territ\u00f3rio do Sul e Ant\u00e1rtica Francesa", "common": "Terras Austrais e Ant\u00e1rticas Francesas"},
 			"rus": {"official": "\u0422\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u044f \u0424\u0440\u0430\u043d\u0446\u0443\u0437\u0441\u043a\u0438\u0435 \u042e\u0436\u043d\u044b\u0435 \u0438 \u0410\u043d\u0442\u0430\u0440\u043a\u0442\u0438\u0447\u0435\u0441\u043a\u0438\u0435 \u0437\u0435\u043c\u043b\u0438", "common": "\u0424\u0440\u0430\u043d\u0446\u0443\u0437\u0441\u043a\u0438\u0435 \u042e\u0436\u043d\u044b\u0435 \u0438 \u0410\u043d\u0442\u0430\u0440\u043a\u0442\u0438\u0447\u0435\u0441\u043a\u0438\u0435 \u0442\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u0438"},
+			"slk": {"official": "Franc\u00fazske ju\u017en\u00e9 a antarktick\u00e9 \u00fazemia", "common": "Franc\u00fazske ju\u017dn\u00e9 a antarktick\u00e9 \u00fazemia"},
 			"spa": {"official": "Territorio del Franc\u00e9s Tierras australes y ant\u00e1rticas", "common": "Tierras Australes y Ant\u00e1rticas Francesas"},
-			"svk": {"official": "Franc\u00fazske ju\u017en\u00e9 a antarktick\u00e9 \u00fazemia", "common": "Franc\u00fazske ju\u017dn\u00e9 a antarktick\u00e9 \u00fazemia"},
 			"fin": {"official": "Ranskan etel\u00e4iset ja antarktiset alueet", "common": "Ranskan etel\u00e4iset ja antarktiset alueet"},
 			"zho": {"official": "\u6CD5\u56FD\u5357\u90E8\u548C\u5357\u6781\u571F\u5730", "common": "\u6CD5\u56FD\u5357\u90E8\u548C\u5357\u6781\u571F\u5730"}
 		},
@@ -649,8 +649,8 @@
 			"nld": {"official": "Antigua en Barbuda", "common": "Antigua en Barbuda"},
 			"por": {"official": "Antigua e Barbuda", "common": "Ant\u00edgua e Barbuda"},
 			"rus": {"official": "\u0410\u043d\u0442\u0438\u0433\u0443\u0430 \u0438 \u0411\u0430\u0440\u0431\u0443\u0434\u0430", "common": "\u0410\u043d\u0442\u0438\u0433\u0443\u0430 \u0438 \u0411\u0430\u0440\u0431\u0443\u0434\u0430"},
+			"slk": {"official": "Antigua a Barbuda", "common": "Antigua a Barbuda"},
 			"spa": {"official": "Antigua y Barbuda", "common": "Antigua y Barbuda"},
-			"svk": {"official": "Antigua a Barbuda", "common": "Antigua a Barbuda"},
 			"fin": {"official": "Antigua ja Barbuda", "common": "Antigua ja Barbuda"},
 			"zho": {"official": "\u5B89\u63D0\u74DC\u548C\u5DF4\u5E03\u8FBE", "common": "\u5B89\u63D0\u74DC\u548C\u5DF4\u5E03\u8FBE"}
 		},
@@ -695,8 +695,8 @@
 			"nld": {"official": "Gemenebest van Australi\u00eb", "common": "Australi\u00eb"},
 			"por": {"official": "Comunidade da Austr\u00e1lia", "common": "Austr\u00e1lia"},
 			"rus": {"official": "\u0421\u043e\u0434\u0440\u0443\u0436\u0435\u0441\u0442\u0432\u043e \u0410\u0432\u0441\u0442\u0440\u0430\u043b\u0438\u0438", "common": "\u0410\u0432\u0441\u0442\u0440\u0430\u043b\u0438\u044f"},
+			"slk": {"official": "Austr\u00e1lsky zv\u00e4z", "common": "Austr\u00e1lia"},
 			"spa": {"official": "Mancomunidad de Australia", "common": "Australia"},
-			"svk": {"official": "Austr\u00e1lsky zv\u00e4z", "common": "Austr\u00e1lia"},
 			"fin": {"official": "Australian liittovaltio", "common": "Australia"},
 			"zho": {"official": "\u6FB3\u5927\u5229\u4E9A\u8054\u90A6", "common": "\u6FB3\u5927\u5229\u4E9A"}
 		},
@@ -741,8 +741,8 @@
 			"nld": {"official": "Republiek Oostenrijk", "common": "Oostenrijk"},
 			"por": {"official": "Rep\u00fablica da \u00c1ustria", "common": "\u00c1ustria"},
 			"rus": {"official": "\u0410\u0432\u0441\u0442\u0440\u0438\u0439\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0410\u0432\u0441\u0442\u0440\u0438\u044f"},
+			"slk": {"official": "Rak\u00faska republika", "common": "Rak\u00fasko"},
 			"spa": {"official": "Rep\u00fablica de Austria", "common": "Austria"},
-			"svk": {"official": "Rak\u00faska republika", "common": "Rak\u00fasko"},
 			"fin": {"official": "It\u00e4vallan tasavalta", "common": "It\u00e4valta"},
 			"zho": {"official": "\u5965\u5730\u5229\u5171\u548C\u56FD", "common": "\u5965\u5730\u5229"}
 		},
@@ -792,8 +792,8 @@
 			"nld": {"official": "Republiek Azerbeidzjan", "common": "Azerbeidzjan"},
 			"por": {"official": "Rep\u00fablica do Azerbaij\u00e3o", "common": "Azerbeij\u00e3o"},
 			"rus": {"official": "\u0410\u0437\u0435\u0440\u0431\u0430\u0439\u0434\u0436\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0410\u0437\u0435\u0440\u0431\u0430\u0439\u0434\u0436\u0430\u043d"},
+			"slk": {"official": "Azerbaj\u01c6ansk\u00e1 republika", "common": "Azerbaj\u01c7an"},
 			"spa": {"official": "Rep\u00fablica de Azerbaiy\u00e1n", "common": "Azerbaiy\u00e1n"},
-			"svk": {"official": "Azerbaj\u01c6ansk\u00e1 republika", "common": "Azerbaj\u01c7an"},
 			"fin": {"official": "Azerbaidzanin tasavalta", "common": "Azerbaidzan"},
 			"zho": {"official": "\u963F\u585E\u62DC\u7586\u5171\u548C\u56FD", "common": "\u963F\u585E\u62DC\u7586"}
 		},
@@ -843,8 +843,8 @@
 			"nld": {"official": "Republiek Burundi", "common": "Burundi"},
 			"por": {"official": "Rep\u00fablica do Burundi", "common": "Burundi"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0411\u0443\u0440\u0443\u043d\u0434\u0438", "common": "\u0411\u0443\u0440\u0443\u043d\u0434\u0438"},
+			"slk": {"official": "Burundsk\u00e1 republika", "common": "Burundi"},
 			"spa": {"official": "Rep\u00fablica de Burundi", "common": "Burundi"},
-			"svk": {"official": "Burundsk\u00e1 republika", "common": "Burundi"},
 			"fin": {"official": "Burundin tasavalta", "common": "Burundi"},
 			"zho": {"official": "\u5E03\u9686\u8FEA\u5171\u548C\u56FD", "common": "\u5E03\u9686\u8FEA"}
 		},
@@ -899,8 +899,8 @@
 			"nld": {"official": "Koninkrijk Belgi\u00eb", "common": "Belgi\u00eb"},
 			"por": {"official": "Reino da B\u00e9lgica", "common": "B\u00e9lgica"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0411\u0435\u043b\u044c\u0433\u0438\u044f", "common": "\u0411\u0435\u043b\u044c\u0433\u0438\u044f"},
+			"slk": {"official": "Belgick\u00e9 kr\u00e1\u013eovstvo", "common": "Belgicko"},
 			"spa": {"official": "Reino de B\u00e9lgica", "common": "B\u00e9lgica"},
-			"svk": {"official": "Belgick\u00e9 kr\u00e1\u013eovstvo", "common": "Belgicko"},
 			"fin": {"official": "Belgian kuningaskunta", "common": "Belgia"},
 			"zho": {"official": "\u6BD4\u5229\u65F6\u738B\u56FD", "common": "\u6BD4\u5229\u65F6"}
 		},
@@ -945,8 +945,8 @@
 			"nld": {"official": "Republiek Benin", "common": "Benin"},
 			"por": {"official": "Rep\u00fablica do Benin", "common": "Benin"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0411\u0435\u043d\u0438\u043d", "common": "\u0411\u0435\u043d\u0438\u043d"},
+			"slk": {"official": "Beninsk\u00e1 republika", "common": "Benin"},
 			"spa": {"official": "Rep\u00fablica de Benin", "common": "Ben\u00edn"},
-			"svk": {"official": "Beninsk\u00e1 republika", "common": "Benin"},
 			"fin": {"official": "Beninin tasavalta", "common": "Benin"},
 			"zho": {"official": "\u8D1D\u5B81\u5171\u548C\u56FD", "common": "\u8D1D\u5B81"}
 		},
@@ -991,8 +991,8 @@
 			"nld": {"official": "Burkina Faso", "common": "Burkina Faso"},
 			"por": {"official": "Burkina Faso", "common": "Burkina Faso"},
 			"rus": {"official": "\u0411\u0443\u0440\u043a\u0438\u043d\u0430 -\u0424\u0430\u0441\u043e", "common": "\u0411\u0443\u0440\u043a\u0438\u043d\u0430-\u0424\u0430\u0441\u043e"},
+			"slk": {"official": "Burkina Faso", "common": "Burkina Faso"},
 			"spa": {"official": "Burkina Faso", "common": "Burkina Faso"},
-			"svk": {"official": "Burkina Faso", "common": "Burkina Faso"},
 			"fin": {"official": "Burkina Faso", "common": "Burkina Faso"},
 			"zho": {"official": "\u5E03\u57FA\u7EB3\u6CD5\u7D22", "common": "\u5E03\u57FA\u7EB3\u6CD5\u7D22"}
 		},
@@ -1037,8 +1037,8 @@
 			"nld": {"official": "Volksrepubliek Bangladesh", "common": "Bangladesh"},
 			"por": {"official": "Rep\u00fablica Popular do Bangladesh", "common": "Bangladesh"},
 			"rus": {"official": "\u041d\u0430\u0440\u043e\u0434\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0411\u0430\u043d\u0433\u043b\u0430\u0434\u0435\u0448", "common": "\u0411\u0430\u043d\u0433\u043b\u0430\u0434\u0435\u0448"},
+			"slk": {"official": "Banglad\u00e9\u0161ska \u013eudov\u00e1 republika", "common": "Banglad\u00e9\u0161"},
 			"spa": {"official": "Rep\u00fablica Popular de Bangladesh", "common": "Bangladesh"},
-			"svk": {"official": "Banglad\u00e9\u0161ska \u013eudov\u00e1 republika", "common": "Banglad\u00e9\u0161"},
 			"fin": {"official": "Bangladeshin kansantasavalta", "common": "Bangladesh"},
 			"zho": {"official": "\u5B5F\u52A0\u62C9\u4EBA\u6C11\u5171\u548C\u56FD", "common": "\u5B5F\u52A0\u62C9\u56FD"}
 		},
@@ -1083,8 +1083,8 @@
 			"nld": {"official": "Republiek Bulgarije", "common": "Bulgarije"},
 			"por": {"official": "Rep\u00fablica da Bulg\u00e1ria", "common": "Bulg\u00e1ria"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0411\u043e\u043b\u0433\u0430\u0440\u0438\u044f", "common": "\u0411\u043e\u043b\u0433\u0430\u0440\u0438\u044f"},
+			"slk": {"official": "Bulharsk\u00e1 republika", "common": "Bulharsko"},
 			"spa": {"official": "Rep\u00fablica de Bulgaria", "common": "Bulgaria"},
-			"svk": {"official": "Bulharsk\u00e1 republika", "common": "Bulharsko"},
 			"fin": {"official": "Bulgarian tasavalta", "common": "Bulgaria"},
 			"zho": {"official": "\u4FDD\u52A0\u5229\u4E9A\u5171\u548C\u56FD", "common": "\u4FDD\u52A0\u5229\u4E9A"}
 		},
@@ -1129,8 +1129,8 @@
 			"nld": {"official": "Koninkrijk Bahrein", "common": "Bahrein"},
 			"por": {"official": "Reino do Bahrein", "common": "Bahrein"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0411\u0430\u0445\u0440\u0435\u0439\u043d", "common": "\u0411\u0430\u0445\u0440\u0435\u0439\u043d"},
+			"slk": {"official": "Bahrajnsk\u00e9 kr\u00e1\u013eovstvo", "common": "Bahrajn"},
 			"spa": {"official": "Reino de Bahrein", "common": "Bahrein"},
-			"svk": {"official": "Bahrajnsk\u00e9 kr\u00e1\u013eovstvo", "common": "Bahrajn"},
 			"fin": {"official": "Bahrainin kuningaskunta", "common": "Bahrain"},
 			"zho": {"official": "\u5DF4\u6797\u738B\u56FD", "common": "\u5DF4\u6797"}
 		},
@@ -1175,8 +1175,8 @@
 			"nld": {"official": "Gemenebest van de Bahama's", "common": "Bahama\u2019s"},
 			"por": {"official": "Comunidade das Bahamas", "common": "Bahamas"},
 			"rus": {"official": "\u0421\u043e\u0434\u0440\u0443\u0436\u0435\u0441\u0442\u0432\u043e \u0411\u0430\u0433\u0430\u043c\u0441\u043a\u0438\u0445 \u041e\u0441\u0442\u0440\u043e\u0432\u043e\u0432", "common": "\u0411\u0430\u0433\u0430\u043c\u0441\u043a\u0438\u0435 \u041e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Bahamsk\u00e9 spolo\u010denstvo", "common": "Bahamy"},
 			"spa": {"official": "Commonwealth de las Bahamas", "common": "Bahamas"},
-			"svk": {"official": "Bahamsk\u00e9 spolo\u010denstvo", "common": "Bahamy"},
 			"fin": {"official": "Bahaman liittovaltio", "common": "Bahamasaaret"},
 			"zho": {"official": "\u5DF4\u54C8\u9A6C\u8054\u90A6", "common": "\u5DF4\u54C8\u9A6C"}
 		},
@@ -1231,8 +1231,8 @@
 			"nld": {"official": "Bosni\u00eb-Herzegovina", "common": "Bosni\u00eb en Herzegovina"},
 			"por": {"official": "B\u00f3snia e Herzegovina", "common": "B\u00f3snia e Herzegovina"},
 			"rus": {"official": "\u0411\u043e\u0441\u043d\u0438\u044f \u0438 \u0413\u0435\u0440\u0446\u0435\u0433\u043e\u0432\u0438\u043d\u0430", "common": "\u0411\u043e\u0441\u043d\u0438\u044f \u0438 \u0413\u0435\u0440\u0446\u0435\u0433\u043e\u0432\u0438\u043d\u0430"},
+			"slk": {"official": "Republika Bosny a Hercegoviny", "common": "Bosna a Hercegovina"},
 			"spa": {"official": "Bosnia y Herzegovina", "common": "Bosnia y Herzegovina"},
-			"svk": {"official": "Republika Bosny a Hercegoviny", "common": "Bosna a Hercegovina"},
 			"fin": {"official": "Bosnia ja Hertsegovina", "common": "Bosnia ja Hertsegovina"},
 			"zho": {"official": "\u6CE2\u65AF\u5C3C\u4E9A\u548C\u9ED1\u585E\u54E5\u7EF4\u90A3", "common": "\u6CE2\u65AF\u5C3C\u4E9A\u548C\u9ED1\u585E\u54E5\u7EF4\u90A3"}
 		},
@@ -1276,8 +1276,8 @@
 			"nld": {"official": "Gemeenschap Saint Barth\u00e9lemy", "common": "Saint Barth\u00e9lemy"},
 			"por": {"official": "Coletividade de Saint Barth\u00e9lemy", "common": "S\u00e3o Bartolomeu"},
 			"rus": {"official": "\u041a\u043e\u043b\u043b\u0435\u043a\u0442\u0438\u0432\u043d\u043e\u0441\u0442\u044c \u0421\u0430\u043d\u043a\u0442 -\u0411\u0430\u0440\u0442\u0435\u043b\u044c\u043c\u0438", "common": "\u0421\u0435\u043d-\u0411\u0430\u0440\u0442\u0435\u043b\u0435\u043c\u0438"},
+			"slk": {"official": "Sv\u00e4t\u00fd Bartolomej", "common": "Sv\u00e4t\u00fd Bartolomej"},
 			"spa": {"official": "Colectividad de San Barth\u00e9lemy", "common": "San Bartolom\u00e9"},
-			"svk": {"official": "Sv\u00e4t\u00fd Bartolomej", "common": "Sv\u00e4t\u00fd Bartolomej"},
 			"fin": {"official": "Saint-Barth\u00e9lemyn yhteis\u00f6", "common": "Saint-Barth\u00e9lemy"},
 			"zho": {"official": "\u5723\u5DF4\u6CF0\u52D2\u7C73\u96C6\u4F53", "common": "\u5723\u5DF4\u6CF0\u52D2\u7C73"}
 		},
@@ -1327,8 +1327,8 @@
 			"nld": {"official": "Republiek Belarus", "common": "Wit-Rusland"},
 			"por": {"official": "Rep\u00fablica da Bielorr\u00fassia", "common": "Bielor\u00fassia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c", "common": "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u044c"},
+			"slk": {"official": "Bielorusk\u00e1 republika", "common": "Bielorusko"},
 			"spa": {"official": "Rep\u00fablica de Belar\u00fas", "common": "Bielorrusia"},
-			"svk": {"official": "Bielorusk\u00e1 republika", "common": "Bielorusko"},
 			"fin": {"official": "Valko-Ven\u00e4j\u00e4n tasavalta", "common": "Valko-Ven\u00e4j\u00e4"},
 			"zho": {"official": "\u767D\u4FC4\u7F57\u65AF\u5171\u548C\u56FD", "common": "\u767D\u4FC4\u7F57\u65AF"}
 		},
@@ -1383,8 +1383,8 @@
 			"nld": {"official": "Belize", "common": "Belize"},
 			"por": {"official": "Belize", "common": "Belize"},
 			"rus": {"official": "\u0411\u0435\u043b\u0438\u0437", "common": "\u0411\u0435\u043b\u0438\u0437"},
+			"slk": {"official": "Belize", "common": "Belize"},
 			"spa": {"official": "Belice", "common": "Belice"},
-			"svk": {"official": "Belize", "common": "Belize"},
 			"fin": {"official": "Belize", "common": "Belize"},
 			"zho": {"official": "\u4F2F\u5229\u5179", "common": "\u4F2F\u5229\u5179"}
 		},
@@ -1429,8 +1429,8 @@
 			"nld": {"official": "Bermuda", "common": "Bermuda"},
 			"por": {"official": "Bermudas", "common": "Bermudas"},
 			"rus": {"official": "\u0411\u0435\u0440\u043c\u0443\u0434\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0411\u0435\u0440\u043c\u0443\u0434\u0441\u043a\u0438\u0435 \u041e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Bermudy", "common": "Bermudy"},
 			"spa": {"official": "Bermuda", "common": "Bermudas"},
-			"svk": {"official": "Bermudy", "common": "Bermudy"},
 			"fin": {"official": "Bermuda", "common": "Bermuda"},
 			"zho": {"official": "\u767E\u6155\u5927", "common": "\u767E\u6155\u5927"}
 		},
@@ -1490,8 +1490,8 @@
 			"nld": {"official": "Plurinationale Staat van Bolivia", "common": "Bolivia"},
 			"por": {"official": "Estado Plurinacional da Bol\u00edvia", "common": "Bol\u00edvia"},
 			"rus": {"official": "\u041c\u043d\u043e\u0433\u043e\u043d\u0430\u0446\u0438\u043e\u043d\u0430\u043b\u044c\u043d\u043e\u0435 \u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u0411\u043e\u043b\u0438\u0432\u0438\u044f", "common": "\u0411\u043e\u043b\u0438\u0432\u0438\u044f"},
+			"slk": {"official": "Bol\u00edvijsk\u00e1 republika", "common": "Bol\u00edvia"},
 			"spa": {"official": "Estado Plurinacional de Bolivia", "common": "Bolivia"},
-			"svk": {"official": "Bol\u00edvijsk\u00e1 republika", "common": "Bol\u00edvia"},
 			"fin": {"official": "Bolivian monikansainen valtio", "common": "Bolivia"},
 			"zho": {"official": "\u591A\u6C11\u65CF\u73BB\u5229\u7EF4\u4E9A\u56FD", "common": "\u73BB\u5229\u7EF4\u4E9A"}
 		},
@@ -1536,8 +1536,8 @@
 			"nld": {"official": "Federale Republiek Brazili\u00eb", "common": "Brazili\u00eb"},
 			"por": {"official": "Rep\u00fablica Federativa do Brasil", "common": "Brasil"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0411\u0440\u0430\u0437\u0438\u043b\u0438\u044f", "common": "\u0411\u0440\u0430\u0437\u0438\u043b\u0438\u044f"},
+			"slk": {"official": "Braz\u00edlska federat\u00edvna republika", "common": "Braz\u00edlia"},
 			"spa": {"official": "Rep\u00fablica Federativa del Brasil", "common": "Brasil"},
-			"svk": {"official": "Braz\u00edlska federat\u00edvna republika", "common": "Braz\u00edlia"},
 			"fin": {"official": "Brasilian liittotasavalta", "common": "Brasilia"},
 			"zho": {"official": "\u5DF4\u897F\u8054\u90A6\u5171\u548C\u56FD", "common": "\u5DF4\u897F"}
 		},
@@ -1582,8 +1582,8 @@
 			"nld": {"official": "Barbados", "common": "Barbados"},
 			"por": {"official": "Barbados", "common": "Barbados"},
 			"rus": {"official": "\u0411\u0430\u0440\u0431\u0430\u0434\u043e\u0441", "common": "\u0411\u0430\u0440\u0431\u0430\u0434\u043e\u0441"},
+			"slk": {"official": "Barbados", "common": "Barbados"},
 			"spa": {"official": "Barbados", "common": "Barbados"},
-			"svk": {"official": "Barbados", "common": "Barbados"},
 			"fin": {"official": "Barbados", "common": "Barbados"},
 			"zho": {"official": "\u5DF4\u5DF4\u591A\u65AF", "common": "\u5DF4\u5DF4\u591A\u65AF"}
 		},
@@ -1628,8 +1628,8 @@
 			"nld": {"official": "Natie van Brunei, de verblijfplaats van de Vrede", "common": "Brunei"},
 			"por": {"official": "Na\u00e7\u00e3o do Brunei, Morada da Paz", "common": "Brunei"},
 			"rus": {"official": "\u041d\u0430\u0446\u0438\u044f \u0411\u0440\u0443\u043d\u0435\u0439, \u043e\u0431\u0438\u0442\u0435\u043b\u044c \u043c\u0438\u0440\u0430", "common": "\u0411\u0440\u0443\u043d\u0435\u0439"},
+			"slk": {"official": "Brunejsk\u00fd sultan\u00e2t", "common": "Brunej"},
 			"spa": {"official": "Naci\u00f3n de Brunei, Morada de la Paz", "common": "Brunei"},
-			"svk": {"official": "Brunejsk\u00fd sultan\u00e2t", "common": "Brunej"},
 			"fin": {"official": "Brunei Darussalamin valtio", "common": "Brunei"},
 			"zho": {"official": "\u6587\u83B1\u548C\u5E73\u4E4B\u56FD", "common": "\u6587\u83B1"}
 		},
@@ -1674,8 +1674,8 @@
 			"nld": {"official": "Koninkrijk Bhutan", "common": "Bhutan"},
 			"por": {"official": "Reino do But\u00e3o", "common": "But\u00e3o"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0411\u0443\u0442\u0430\u043d", "common": "\u0411\u0443\u0442\u0430\u043d"},
+			"slk": {"official": "Bhut\u00e1nske kr\u00e2\u013eovstvo", "common": "Bhut\u00e1n"},
 			"spa": {"official": "Reino de But\u00e1n", "common": "But\u00e1n"},
-			"svk": {"official": "Bhut\u00e1nske kr\u00e2\u013eovstvo", "common": "Bhut\u00e1n"},
 			"fin": {"official": "Bhutanin kuningaskunta", "common": "Bhutan"},
 			"zho": {"official": "\u4E0D\u4E39\u738B\u56FD", "common": "\u4E0D\u4E39"}
 		},
@@ -1719,8 +1719,8 @@
 			"nld": {"official": "Bouvet Island", "common": "Bouveteiland"},
 			"por": {"official": "Ilha Bouvet", "common": "Ilha Bouvet"},
 			"rus": {"official": "\u041e\u0441\u0442\u0440\u043e\u0432 \u0411\u0443\u0432\u0435", "common": "\u041e\u0441\u0442\u0440\u043e\u0432 \u0411\u0443\u0432\u0435"},
+			"slk": {"official": "Bouvetov ostrov", "common": "Bouvetov ostrov"},
 			"spa": {"official": "Isla Bouvet", "common": "Isla Bouvet"},
-			"svk": {"official": "Bouvetov ostrov", "common": "Bouvetov ostrov"},
 			"fin": {"official": "Bouvet'nsaari", "common": "Bouvet'nsaari"},
 			"zho": {"official": "\u5E03\u7EF4\u5C9B", "common": "\u5E03\u7EF4\u5C9B"}
 		},
@@ -1769,8 +1769,8 @@
 			"nld": {"official": "Republiek Botswana", "common": "Botswana"},
 			"por": {"official": "Rep\u00fablica do Botswana", "common": "Botswana"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0430", "common": "\u0411\u043e\u0442\u0441\u0432\u0430\u043d\u0430"},
+			"slk": {"official": "Botswansk\u00e1 republika", "common": "Botswana"},
 			"spa": {"official": "Rep\u00fablica de Botswana", "common": "Botswana"},
-			"svk": {"official": "Botswansk\u00e1 republika", "common": "Botswana"},
 			"fin": {"official": "Botswanan tasavalta", "common": "Botswana"},
 			"zho": {"official": "\u535A\u8328\u74E6\u7EB3\u5171\u548C\u56FD", "common": "\u535A\u8328\u74E6\u7EB3"}
 		},
@@ -1820,8 +1820,8 @@
 			"nld": {"official": "Centraal-Afrikaanse Republiek", "common": "Centraal-Afrikaanse Republiek"},
 			"por": {"official": "Rep\u00fablica Centro-Africano", "common": "Rep\u00fablica Centro-Africana"},
 			"rus": {"official": "\u0426\u0435\u043d\u0442\u0440\u0430\u043b\u044c\u043d\u043e-\u0410\u0444\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0426\u0435\u043d\u0442\u0440\u0430\u043b\u044c\u043d\u043e\u0430\u0444\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"},
+			"slk": {"official": "Stredoafrick\u00e1 republika", "common": "Stredoafrick\u00e1 republika"},
 			"spa": {"official": "Rep\u00fablica Centroafricana", "common": "Rep\u00fablica Centroafricana"},
-			"svk": {"official": "Stredoafrick\u00e1 republika", "common": "Stredoafrick\u00e1 republika"},
 			"fin": {"official": "Keski-Afrikan tasavalta", "common": "Keski-Afrikan tasavalta"},
 			"zho": {"official": "\u4E2D\u975E\u5171\u548C\u56FD", "common": "\u4E2D\u975E\u5171\u548C\u56FD"}
 		},
@@ -1871,8 +1871,8 @@
 			"nld": {"official": "Canada", "common": "Canada"},
 			"por": {"official": "Canad\u00e1", "common": "Canad\u00e1"},
 			"rus": {"official": "\u041a\u0430\u043d\u0430\u0434\u0430", "common": "\u041a\u0430\u043d\u0430\u0434\u0430"},
+			"slk": {"official": "Kanada", "common": "Kanada"},
 			"spa": {"official": "Canad\u00e1", "common": "Canad\u00e1"},
-			"svk": {"official": "Kanada", "common": "Kanada"},
 			"fin": {"official": "Kanada", "common": "Kanada"},
 			"zho": {"official": "\u52A0\u62FF\u5927", "common": "\u52A0\u62FF\u5927"}
 		},
@@ -1917,8 +1917,8 @@
 			"nld": {"official": "Grondgebied van de Eilanden Cocos (Keeling )", "common": "Cocoseilanden"},
 			"por": {"official": "Territ\u00f3rio dos Cocos (Keeling)", "common": "Ilhas Cocos (Keeling)"},
 			"rus": {"official": "\u0422\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u044f \u041a\u043e\u043a\u043e\u0441\u043e\u0432\u044b\u0435 (\u041a\u0438\u043b\u0438\u043d\u0433) \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u041a\u043e\u043a\u043e\u0441\u043e\u0432\u044b\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Kokosov\u00e9 ostrovy", "common": "Kokosov\u00e9 ostrovy"},
 			"spa": {"official": "Territorio de los (Keeling) Islas Cocos", "common": "Islas Cocos o Islas Keeling"},
-			"svk": {"official": "Kokosov\u00e9 ostrovy", "common": "Kokosov\u00e9 ostrovy"},
 			"fin": {"official": "Kookossaaret", "common": "Kookossaaret"},
 			"zho": {"official": "\u79D1\u79D1\u65AF", "common": "\u79D1\u79D1\u65AF"}
 		},
@@ -1977,8 +1977,8 @@
 			"nld": {"official": "Zwitserse Confederatie", "common": "Zwitserland"},
 			"por": {"official": "Confedera\u00e7\u00e3o Su\u00ed\u00e7a", "common": "Su\u00ed\u00e7a"},
 			"rus": {"official": "\u0428\u0432\u0435\u0439\u0446\u0430\u0440\u0441\u043a\u0430\u044f \u041a\u043e\u043d\u0444\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", "common": "\u0428\u0432\u0435\u0439\u0446\u0430\u0440\u0438\u044f"},
+			"slk": {"official": "\u0160vaj\u010diarska konfeder\u00e1cia", "common": "\u0160vaj\u010diarsko"},
 			"spa": {"official": "Confederaci\u00f3n Suiza", "common": "Suiza"},
-			"svk": {"official": "\u0160vaj\u010diarska konfeder\u00e1cia", "common": "\u0160vaj\u010diarsko"},
 			"fin": {"official": "Sveitsin valaliitto", "common": "Sveitsi"},
 			"zho": {"official": "\u745E\u58EB\u8054\u90A6", "common": "\u745E\u58EB"}
 		},
@@ -2023,8 +2023,8 @@
 			"nld": {"official": "Republiek Chili", "common": "Chili"},
 			"por": {"official": "Rep\u00fablica do Chile", "common": "Chile"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0427\u0438\u043b\u0438", "common": "\u0427\u0438\u043b\u0438"},
+			"slk": {"official": "\u010c\u00edlska republika", "common": "\u010cile"},
 			"spa": {"official": "Rep\u00fablica de Chile", "common": "Chile"},
-			"svk": {"official": "\u010c\u00edlska republika", "common": "\u010cile"},
 			"fin": {"official": "Chilen tasavalta", "common": "Chile"},
 			"zho": {"official": "\u667A\u5229\u5171\u548C\u56FD", "common": "\u667A\u5229"}
 		},
@@ -2069,8 +2069,8 @@
 			"nld": {"official": "Volksrepubliek China", "common": "China"},
 			"por": {"official": "Rep\u00fablica Popular da China", "common": "China"},
 			"rus": {"official": "\u041d\u0430\u0440\u043e\u0434\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0438\u0442\u0430\u0439", "common": "\u041a\u0438\u0442\u0430\u0439"},
+			"slk": {"official": "\u010c\u00ednska \u013eudov\u00e1 republika", "common": "\u010c\u00edna"},
 			"spa": {"official": "Rep\u00fablica Popular de China", "common": "China"},
-			"svk": {"official": "\u010c\u00ednska \u013eudov\u00e1 republika", "common": "\u010c\u00edna"},
 			"fin": {"official": "Kiinan kansantasavalta", "common": "Kiina"}
 		},
 		"latlng": [35, 105],
@@ -2113,8 +2113,8 @@
 			"nld": {"official": "Republiek Ivoorkust", "common": "Ivoorkust"},
 			"por": {"official": "Rep\u00fablica da C\u00f4te d'Ivoire", "common": "Costa do Marfim"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0442-\u0434'\u0418\u0432\u0443\u0430\u0440\u0435", "common": "\u041a\u043e\u0442-\u0434\u2019\u0418\u0432\u0443\u0430\u0440"},
+			"slk": {"official": "Republika Pobre\u017eie Slonoviny", "common": "Pobr\u017eie Slonoviny"},
 			"spa": {"official": "Rep\u00fablica de C\u00f4te d'Ivoire", "common": "Costa de Marfil"},
-			"svk": {"official": "Republika Pobre\u017eie Slonoviny", "common": "Pobr\u017eie Slonoviny"},
 			"fin": {"official": "Norsunluurannikon tasavalta", "common": "Norsunluurannikko"},
 			"zho": {"official": "\u79D1\u7279\u8FEA\u74E6\u5171\u548C\u56FD", "common": "\u79D1\u7279\u8FEA\u74E6"}
 		},
@@ -2164,8 +2164,8 @@
 			"nld": {"official": "Republiek Kameroen", "common": "Kameroen"},
 			"por": {"official": "Rep\u00fablica dos Camar\u00f5es", "common": "Camar\u00f5es"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0430\u043c\u0435\u0440\u0443\u043d", "common": "\u041a\u0430\u043c\u0435\u0440\u0443\u043d"},
+			"slk": {"official": "Kamerunsk\u00e1 republika", "common": "Kamerun"},
 			"spa": {"official": "Rep\u00fablica de Camer\u00fan", "common": "Camer\u00fan"},
-			"svk": {"official": "Kamerunsk\u00e1 republika", "common": "Kamerun"},
 			"fin": {"official": "Kamerunin tasavalta", "common": "Kamerun"},
 			"zho": {"official": "\u5580\u9EA6\u9686\u5171\u548C\u56FD", "common": "\u5580\u9EA6\u9686"}
 		},
@@ -2230,8 +2230,8 @@
 			"nld": {"official": "Democratische Republiek Congo", "common": "Congo (DRC)"},
 			"por": {"official": "Rep\u00fablica Democr\u00e1tica do Congo", "common": "Rep\u00fablica Democr\u00e1tica do Congo"},
 			"rus": {"official": "\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u043d\u0433\u043e", "common": "\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u043d\u0433\u043e"},
+			"slk": {"official": "Kon\u017esk\u00e1 demokratick\u00e1 republika", "common": "Kongo"},
 			"spa": {"official": "Rep\u00fablica Democr\u00e1tica del Congo", "common": "Congo (Rep. Dem.)"},
-			"svk": {"official": "Kon\u017esk\u00e1 demokratick\u00e1 republika", "common": "Kongo"},
 			"fin": {"official": "Kongon demokraattinen tasavalta", "common": "Kongon demokraattinen tasavalta"},
 			"zho": {"official": "\u521A\u679C\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u6C11\u4E3B\u521A\u679C"}
 		},
@@ -2286,8 +2286,8 @@
 			"nld": {"official": "Republiek Congo", "common": "Congo"},
 			"por": {"official": "Rep\u00fablica do Congo", "common": "Congo"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u043d\u0433\u043e", "common": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u043d\u0433\u043e"},
+			"slk": {"official": "Kon\u017esk\u00e1 republika", "common": "Kongo"},
 			"spa": {"official": "Rep\u00fablica del Congo", "common": "Congo"},
-			"svk": {"official": "Kon\u017esk\u00e1 republika", "common": "Kongo"},
 			"fin": {"official": "Kongon tasavalta", "common": "Kongo-Brazzaville"},
 			"zho": {"official": "\u521A\u679C\u5171\u548C\u56FD", "common": "\u521A\u679C"}
 		},
@@ -2337,8 +2337,8 @@
 			"nld": {"official": "Cook eilanden", "common": "Cookeilanden"},
 			"por": {"official": "Ilhas Cook", "common": "Ilhas Cook"},
 			"rus": {"official": "\u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u041a\u0443\u043a\u0430", "common": "\u041e\u0441\u0442\u0440\u043e\u0432\u0430 \u041a\u0443\u043a\u0430"},
+			"slk": {"official": "Cookove ostrovy", "common": "Cookove ostrovy"},
 			"spa": {"official": "Islas Cook", "common": "Islas Cook"},
-			"svk": {"official": "Cookove ostrovy", "common": "Cookove ostrovy"},
 			"fin": {"official": "Cookinsaaret", "common": "Cookinsaaret"},
 			"zho": {"official": "\u5E93\u514B\u7FA4\u5C9B", "common": "\u5E93\u514B\u7FA4\u5C9B"}
 		},
@@ -2383,8 +2383,8 @@
 			"nld": {"official": "Republiek Colombia", "common": "Colombia"},
 			"por": {"official": "Rep\u00fablica da Col\u00f4mbia", "common": "Col\u00f4mbia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u043b\u0443\u043c\u0431\u0438\u044f", "common": "\u041a\u043e\u043b\u0443\u043c\u0431\u0438\u044f"},
+			"slk": {"official": "Kolumbijsk\u00e1 republika", "common": "Kolumbia"},
 			"spa": {"official": "Rep\u00fablica de Colombia", "common": "Colombia"},
-			"svk": {"official": "Kolumbijsk\u00e1 republika", "common": "Kolumbia"},
 			"fin": {"official": "Kolumbian tasavalta", "common": "Kolumbia"},
 			"zho": {"official": "\u54E5\u4F26\u6BD4\u4E9A\u5171\u548C\u56FD", "common": "\u54E5\u4F26\u6BD4\u4E9A"}
 		},
@@ -2439,8 +2439,8 @@
 			"nld": {"official": "Unie van de Comoren", "common": "Comoren"},
 			"por": {"official": "Uni\u00e3o das Comores", "common": "Comores"},
 			"rus": {"official": "\u0421\u043e\u044e\u0437 \u041a\u043e\u043c\u043e\u0440\u0441\u043a\u0438\u0445 \u041e\u0441\u0442\u0440\u043e\u0432\u043e\u0432", "common": "\u041a\u043e\u043c\u043e\u0440\u044b"},
+			"slk": {"official": "Komorsk\u00e1 \u00fania", "common": "Komory"},
 			"spa": {"official": "Uni\u00f3n de las Comoras", "common": "Comoras"},
-			"svk": {"official": "Komorsk\u00e1 \u00fania", "common": "Komory"},
 			"fin": {"official": "Komorien liitto", "common": "Komorit"},
 			"zho": {"official": "\u79D1\u6469\u7F57\u8054\u76DF", "common": "\u79D1\u6469\u7F57"}
 		},
@@ -2485,8 +2485,8 @@
 			"nld": {"official": "Republiek van Cabo Verde", "common": "Kaapverdi\u00eb"},
 			"por": {"official": "Rep\u00fablica de Cabo Verde", "common": "Cabo Verde"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0430\u0431\u043e -\u0412\u0435\u0440\u0434\u0435", "common": "\u041a\u0430\u0431\u043e-\u0412\u0435\u0440\u0434\u0435"},
+			"slk": {"official": "Kapverdsk\u00e1 republika", "common": "Kapverdy"},
 			"spa": {"official": "Rep\u00fablica de Cabo Verde", "common": "Cabo Verde"},
-			"svk": {"official": "Kapverdsk\u00e1 republika", "common": "Kapverdy"},
 			"fin": {"official": "Kap Verden tasavalta", "common": "Kap Verde"},
 			"zho": {"official": "\u4F5B\u5F97\u89D2\u5171\u548C\u56FD", "common": "\u4F5B\u5F97\u89D2"}
 		},
@@ -2531,8 +2531,8 @@
 			"nld": {"official": "Republiek Costa Rica", "common": "Costa Rica"},
 			"por": {"official": "Rep\u00fablica da Costa Rica", "common": "Costa Rica"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0441\u0442\u0430-\u0420\u0438\u043a\u0430", "common": "\u041a\u043e\u0441\u0442\u0430-\u0420\u0438\u043a\u0430"},
+			"slk": {"official": "Kostarick\u00e1 republika", "common": "Kostarika"},
 			"spa": {"official": "Rep\u00fablica de Costa Rica", "common": "Costa Rica"},
-			"svk": {"official": "Kostarick\u00e1 republika", "common": "Kostarika"},
 			"fin": {"official": "Costa Rican tasavalta", "common": "Costa Rica"},
 			"zho": {"official": "\u54E5\u65AF\u8FBE\u9ECE\u52A0\u5171\u548C\u56FD", "common": "\u54E5\u65AF\u8FBE\u9ECE\u52A0"}
 		},
@@ -2577,8 +2577,8 @@
 			"nld": {"official": "Republiek Cuba", "common": "Cuba"},
 			"por": {"official": "Rep\u00fablica de Cuba", "common": "Cuba"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0443\u0431\u0430", "common": "\u041a\u0443\u0431\u0430"},
+			"slk": {"official": "Kub\u00e1nska republika", "common": "Kuba"},
 			"spa": {"official": "Rep\u00fablica de Cuba", "common": "Cuba"},
-			"svk": {"official": "Kub\u00e1nska republika", "common": "Kuba"},
 			"fin": {"official": "Kuuban tasavalta", "common": "Kuuba"},
 			"zho": {"official": "\u53E4\u5DF4\u5171\u548C\u56FD", "common": "\u53E4\u5DF4"}
 		},
@@ -2629,8 +2629,8 @@
 			"nld": {"official": "Land Cura\u00e7ao", "common": "Cura\u00e7ao"},
 			"por": {"official": "Pa\u00eds de Cura\u00e7ao", "common": "ilha da Cura\u00e7\u00e3o"},
 			"rus": {"official": "\u0421\u0442\u0440\u0430\u043d\u0430 \u041a\u044e\u0440\u0430\u0441\u0430\u043e", "common": "\u041a\u044e\u0440\u0430\u0441\u0430\u043e"},
+			"slk": {"official": "Curacao", "common": "Curacao"},
 			"spa": {"official": "Pa\u00eds de Curazao", "common": "Curazao"},
-			"svk": {"official": "Curacao", "common": "Curacao"},
 			"fin": {"official": "Cura\u00e7ao", "common": "Cura\u00e7ao"},
 			"zho": {"official": "\u5E93\u62C9\u7D22", "common": "\u5E93\u62C9\u7D22"}
 		},
@@ -2675,8 +2675,8 @@
 			"nld": {"official": "Grondgebied van Christmas Island", "common": "Christmaseiland"},
 			"por": {"official": "Territ\u00f3rio da Ilha Christmas", "common": "Ilha do Natal"},
 			"rus": {"official": "\u0422\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u044f \u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u0420\u043e\u0436\u0434\u0435\u0441\u0442\u0432\u0430", "common": "\u041e\u0441\u0442\u0440\u043e\u0432 \u0420\u043e\u0436\u0434\u0435\u0441\u0442\u0432\u0430"},
+			"slk": {"official": "Terit\u00f3rium Viano\u010dn\u00e9ho ostrova", "common": "Viano\u010dn\u00fa ostrov"},
 			"spa": {"official": "Territorio de la Isla de Navidad", "common": "Isla de Navidad"},
-			"svk": {"official": "Terit\u00f3rium Viano\u010dn\u00e9ho ostrova", "common": "Viano\u010dn\u00fa ostrov"},
 			"fin": {"official": "Joulusaaren alue", "common": "Joulusaari"},
 			"zho": {"official": "\u5723\u8BDE\u5C9B", "common": "\u5723\u8BDE\u5C9B"}
 		},
@@ -2721,8 +2721,8 @@
 			"nld": {"official": "Caymaneilanden", "common": "Caymaneilanden"},
 			"por": {"official": "Ilhas Cayman", "common": "Ilhas Caim\u00e3o"},
 			"rus": {"official": "\u041a\u0430\u0439\u043c\u0430\u043d\u043e\u0432\u044b \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u041a\u0430\u0439\u043c\u0430\u043d\u043e\u0432\u044b \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Kajmanie ostrovy", "common": "Kajmanie ostrovy"},
 			"spa": {"official": "Islas Caim\u00e1n", "common": "Islas Caim\u00e1n"},
-			"svk": {"official": "Kajmanie ostrovy", "common": "Kajmanie ostrovy"},
 			"fin": {"official": "Caymansaaret", "common": "Caymansaaret"},
 			"zho": {"official": "\u5F00\u66FC\u7FA4\u5C9B", "common": "\u5F00\u66FC\u7FA4\u5C9B"}
 		},
@@ -2772,8 +2772,8 @@
 			"nld": {"official": "Republiek Cyprus", "common": "Cyprus"},
 			"por": {"official": "Rep\u00fablica de Chipre", "common": "Chipre"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0438\u043f\u0440", "common": "\u041a\u0438\u043f\u0440"},
+			"slk": {"official": "Cypersk\u00e1 republika", "common": "Cyprus"},
 			"spa": {"official": "Rep\u00fablica de Chipre", "common": "Chipre"},
-			"svk": {"official": " Cypersk\u00e1 republika", "common": "Cyprus"},
 			"fin": {"official": "Kyproksen tasavalta", "common": "Kypros"},
 			"zho": {"official": "\u585E\u6D66\u8DEF\u65AF\u5171\u548C\u56FD", "common": "\u585E\u6D66\u8DEF\u65AF"}
 		},
@@ -2823,8 +2823,8 @@
 			"nld": {"official": "Tsjechische Republiek", "common": "Tsjechi\u00eb"},
 			"por": {"official": "Rep\u00fablica Checa", "common": "Ch\u00e9quia"},
 			"rus": {"official": "\u0427\u0435\u0448\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0427\u0435\u0445\u0438\u044f"},
+			"slk": {"official": "\u010cesk\u00e1 republika", "common": "\u010cesko"},
 			"spa": {"official": "Rep\u00fablica Checa", "common": "Chequia"},
-			"svk": {"official": "\u010cesk\u00e1 republika", "common": "\u010cesko"},
 			"fin": {"official": "T\u0161ekin tasavalta", "common": "T\u0161ekki"},
 			"zho": {"official": "\u6377\u514B\u5171\u548C\u56FD", "common": "\u6377\u514B"}
 		},
@@ -2868,8 +2868,8 @@
 			"nld": {"official": "Bondsrepubliek Duitsland", "common": "Duitsland"},
 			"por": {"official": "Rep\u00fablica Federal da Alemanha", "common": "Alemanha"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0435\u0440\u043c\u0430\u043d\u0438\u044f", "common": "\u0413\u0435\u0440\u043c\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "Nemeck\u00e1 spolkov\u00e1 republika", "common": "Nemecko"},
 			"spa": {"official": "Rep\u00fablica Federal de Alemania", "common": "Alemania"},
-			"svk": {"official": "Nemeck\u00e1 spolkov\u00e1 republika", "common": "Nemecko"},
 			"fin": {"official": "Saksan liittotasavalta", "common": "Saksa"},
 			"zho": {"official": "\u5FB7\u610F\u5FD7\u8054\u90A6\u5171\u548C\u56FD", "common": "\u5FB7\u56FD"}
 		},
@@ -2919,8 +2919,8 @@
 			"nld": {"official": "Republiek Djibouti", "common": "Djibouti"},
 			"por": {"official": "Rep\u00fablica do Djibouti", "common": "Djibouti"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0414\u0436\u0438\u0431\u0443\u0442\u0438", "common": "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"},
+			"slk": {"official": "\u01c5ibutsk\u00e1 republika", "common": "\u01c5ibutsko"},
 			"spa": {"official": "Rep\u00fablica de Djibouti", "common": "Djibouti"},
-			"svk": {"official": "\u01c5ibutsk\u00e1 republika", "common": "\u01c5ibutsko"},
 			"fin": {"official": "Dijiboutin tasavalta", "common": "Dijibouti"},
 			"zho": {"official": "\u5409\u5E03\u63D0\u5171\u548C\u56FD", "common": "\u5409\u5E03\u63D0"}
 		},
@@ -2965,8 +2965,8 @@
 			"nld": {"official": "Gemenebest Dominica", "common": "Dominica"},
 			"por": {"official": "Comunidade da Dominica", "common": "Dominica"},
 			"rus": {"official": "\u0421\u043e\u0434\u0440\u0443\u0436\u0435\u0441\u0442\u0432\u043e \u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0438", "common": "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"},
+			"slk": {"official": "Dominick\u00e9 spolo\u010denstvo", "common": "Dominika"},
 			"spa": {"official": "Mancomunidad de Dominica", "common": "Dominica"},
-			"svk": {"official": "Dominick\u00e9 spolo\u010denstvo", "common": "Dominika"},
 			"fin": {"official": "Dominican liittovaltio", "common": "Dominica"},
 			"zho": {"official": "\u591A\u7C73\u5C3C\u52A0\u5171\u548C\u56FD", "common": "\u591A\u7C73\u5C3C\u52A0"}
 		},
@@ -3011,8 +3011,8 @@
 			"nld": {"official": "Koninkrijk Denemarken", "common": "Denemarken"},
 			"por": {"official": "Reino da Dinamarca", "common": "Dinamarca"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0414\u0430\u043d\u0438\u044f", "common": "\u0414\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "D\u00e1nske kr\u00e1\u013eovstvo", "common": "D\u00e1nsko"},
 			"spa": {"official": "Reino de Dinamarca", "common": "Dinamarca"},
-			"svk": {"official": "D\u00e1nske kr\u00e1\u013eovstvo", "common": "D\u00e1nsko"},
 			"fin": {"official": "Tanskan kuningaskunta", "common": "Tanska"},
 			"zho": {"official": "\u4E39\u9EA6\u738B\u56FD", "common": "\u4E39\u9EA6"}
 		},
@@ -3057,8 +3057,8 @@
 			"nld": {"official": "Dominicaanse Republiek", "common": "Dominicaanse Republiek"},
 			"por": {"official": "Rep\u00fablica Dominicana", "common": "Rep\u00fablica Dominicana"},
 			"rus": {"official": "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"},
+			"slk": {"official": "Dominik\u00e1nska republika", "common": "Dominik\u00e1nska republika"},
 			"spa": {"official": "Rep\u00fablica Dominicana", "common": "Rep\u00fablica Dominicana"},
-			"svk": {"official": "Dominik\u00e1nska republika", "common": "Dominik\u00e1nska republika"},
 			"fin": {"official": "Dominikaaninen tasavalta", "common": "Dominikaaninen tasavalta"},
 			"zho": {"official": "\u591A\u660E\u5C3C\u52A0\u5171\u548C\u56FD", "common": "\u591A\u660E\u5C3C\u52A0"}
 		},
@@ -3103,8 +3103,8 @@
 			"nld": {"official": "Democratische Volksrepubliek Algerije", "common": "Algerije"},
 			"por": {"official": "Rep\u00fablica Argelina Democr\u00e1tica e Popular", "common": "Arg\u00e9lia"},
 			"rus": {"official": "\u041d\u0430\u0440\u043e\u0434\u043d\u043e-\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0410\u043b\u0436\u0438\u0440", "common": "\u0410\u043b\u0436\u0438\u0440"},
+			"slk": {"official": "Al\u017e\u00edrska demokratick\u00e1 \u013eudová republika", "common": "Al\u017e\u00edrsko"},
 			"spa": {"official": "Rep\u00fablica Argelina Democr\u00e1tica y Popular", "common": "Argelia"},
-			"svk": {"official": "Al\u017e\u00edrska demokratick\u00e1 \u013eudová republika", "common": "Al\u017e\u00edrsko"},
 			"fin": {"official": "Algerian demokraattinen kansantasavalta", "common": "Algeria"},
 			"zho": {"official": "\u963F\u5C14\u53CA\u5229\u4E9A\u4EBA\u6C11\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u963F\u5C14\u53CA\u5229\u4E9A"}
 		},
@@ -3149,8 +3149,8 @@
 			"nld": {"official": "Republiek Ecuador", "common": "Ecuador"},
 			"por": {"official": "Rep\u00fablica do Equador", "common": "Equador"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u042d\u043a\u0432\u0430\u0434\u043e\u0440", "common": "\u042d\u043a\u0432\u0430\u0434\u043e\u0440"},
+			"slk": {"official": "Ekv\u00e1dorsk\u00e1 republika", "common": "Ekv\u00e1dor"},
 			"spa": {"official": "Rep\u00fablica del Ecuador", "common": "Ecuador"},
-			"svk": {"official": "Ekv\u00e1dorsk\u00e1 republika", "common": "Ekv\u00e1dor"},
 			"fin": {"official": "Ecuadorin tasavalta", "common": "Ecuador"},
 			"zho": {"official": "\u5384\u74DC\u591A\u5C14\u5171\u548C\u56FD", "common": "\u5384\u74DC\u591A\u5C14"}
 		},
@@ -3195,8 +3195,8 @@
 			"nld": {"official": "Arabische Republiek Egypte", "common": "Egypte"},
 			"por": {"official": "Rep\u00fablica \u00c1rabe do Egipto", "common": "Egito"},
 			"rus": {"official": "\u0410\u0440\u0430\u0431\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0415\u0433\u0438\u043f\u0435\u0442", "common": "\u0415\u0433\u0438\u043f\u0435\u0442"},
+			"slk": {"official": "Egyptsk\u00e1 arabsk\u00e1 republika", "common": "Egypt"},
 			"spa": {"official": "Rep\u00fablica \u00c1rabe de Egipto", "common": "Egipto"},
-			"svk": {"official": "Egyptsk\u00e1 arabsk\u00e1 republika", "common": "Egypt"},
 			"fin": {"official": "Egyptin arabitasavalta", "common": "Egypti"},
 			"zho": {"official": "\u963F\u62C9\u4F2F\u57C3\u53CA\u5171\u548C\u56FD", "common": "\u57C3\u53CA"}
 		},
@@ -3251,8 +3251,8 @@
 			"nld": {"official": "Staat Eritrea", "common": "Eritrea"},
 			"por": {"official": "Estado da Eritreia", "common": "Eritreia"},
 			"rus": {"official": "\u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u042d\u0440\u0438\u0442\u0440\u0435\u044f", "common": "\u042d\u0440\u0438\u0442\u0440\u0435\u044f"},
+			"slk": {"official": "Eritrejsk\u00fd \u0161t\u00e1t", "common": "Eritrea"},
 			"spa": {"official": "Estado de Eritrea", "common": "Eritrea"},
-			"svk": {"official": "Eritrejsk\u00fd \u0161t\u00e1t", "common": "Eritrea"},
 			"fin": {"official": "Eritrean valtio", "common": "Eritrea"},
 			"zho": {"official": "\u5384\u7ACB\u7279\u91CC\u4E9A", "common": "\u5384\u7ACB\u7279\u91CC\u4E9A"}
 		},
@@ -3306,8 +3306,8 @@
 			"nld": {"official": "Sahrawi Arabische Democratische Republiek", "common": "Westelijke Sahara"},
 			"por": {"official": "Rep\u00fablica \u00c1rabe Saharaui Democr\u00e1tica", "common": "Saara Ocidental"},
 			"rus": {"official": "Sahrawi \u0410\u0440\u0430\u0431\u0441\u043a\u0430\u044f \u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0417\u0430\u043f\u0430\u0434\u043d\u0430\u044f \u0421\u0430\u0445\u0430\u0440\u0430"},
+			"slk": {"official": "Z\u00e1padn\u00e1 Sahara", "common": "Z\u00e1padn\u00e1 Sahara"},
 			"spa": {"official": "Rep\u00fablica \u00c1rabe Saharaui Democr\u00e1tica", "common": "Sahara Occidental"},
-			"svk": {"official": "Z\u00e1padn\u00e1 Sahara", "common": "Z\u00e1padn\u00e1 Sahara"},
 			"fin": {"official": "L\u00e4nsi-Sahara", "common": "L\u00e4nsi-Sahara"},
 			"zho": {"official": "\u963F\u62C9\u4F2F\u6492\u54C8\u62C9\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u897F\u6492\u54C8\u62C9"}
 		},
@@ -3371,8 +3371,8 @@
 			"nld": {"official": "Koninkrijk Spanje", "common": "Spanje"},
 			"por": {"official": "Reino de Espanha", "common": "Espanha"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0418\u0441\u043f\u0430\u043d\u0438\u044f", "common": "\u0418\u0441\u043f\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "\u0160panielske kr\u00e1\u013eovstvo", "common": "\u0160panielsko"},
 			"spa": {"official": "Reino de Espa\u00f1a", "common": "Espa\u00f1a"},
-			"svk": {"official": "\u0160panielske kr\u00e1\u013eovstvo", "common": "\u0160panielsko"},
 			"fin": {"official": "Espanjan kuningaskunta", "common": "Espanja"},
 			"zho": {"official": "\u897F\u73ED\u7259\u738B\u56FD", "common": "\u897F\u73ED\u7259"}
 		},
@@ -3417,8 +3417,8 @@
 			"nld": {"official": "Republiek Estland", "common": "Estland"},
 			"por": {"official": "Rep\u00fablica da Est\u00f3nia", "common": "Est\u00f3nia"},
 			"rus": {"official": "\u042d\u0441\u0442\u043e\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u042d\u0441\u0442\u043e\u043d\u0438\u044f"},
+			"slk": {"official": "Est\u00f3nska republika", "common": "Est\u00f3nsko"},
 			"spa": {"official": "Rep\u00fablica de Estonia", "common": "Estonia"},
-			"svk": {"official": "Est\u00f3nska republika", "common": "Est\u00f3nsko"},
 			"fin": {"official": "Viron tasavalta", "common": "Viro"},
 			"zho": {"official": "\u7231\u6C99\u5C3C\u4E9A\u5171\u548C\u56FD", "common": "\u7231\u6C99\u5C3C\u4E9A"}
 		},
@@ -3463,8 +3463,8 @@
 			"nld": {"official": "Federale Democratische Republiek Ethiopi\u00eb", "common": "Ethiopi\u00eb"},
 			"por": {"official": "Rep\u00fablica Federal Democr\u00e1tica da Eti\u00f3pia", "common": "Eti\u00f3pia"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u0430\u044f \u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u042d\u0444\u0438\u043e\u043f\u0438\u044f", "common": "\u042d\u0444\u0438\u043e\u043f\u0438\u044f"},
+			"slk": {"official": "Eti\u00f3pska federat\u00edvna demokratick\u00e1 republika", "common": "Eti\u00f3pia"},
 			"spa": {"official": "Rep\u00fablica Democr\u00e1tica Federal de Etiop\u00eda", "common": "Etiop\u00eda"},
-			"svk": {"official": "Eti\u00f3pska federat\u00edvna demokratick\u00e1 republika", "common": "Eti\u00f3pia"},
 			"fin": {"official": "Etiopian demokraattinen liittotasavalta", "common": "Etiopia"},
 			"zho": {"official": "\u57C3\u585E\u4FC4\u6BD4\u4E9A\u8054\u90A6\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u57C3\u585E\u4FC4\u6BD4\u4E9A"}
 		},
@@ -3513,8 +3513,8 @@
 			"nld": {"official": "Republiek Finland", "common": "Finland"},
 			"por": {"official": "Rep\u00fablica da Finl\u00e2ndia", "common": "Finl\u00e2ndia"},
 			"rus": {"official": "\u0424\u0438\u043d\u043b\u044f\u043d\u0434\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0424\u0438\u043d\u043b\u044f\u043d\u0434\u0438\u044f"},
+			"slk": {"official": "F\u00ednska republika", "common": "F\u00ednsko"},
 			"spa": {"official": "Rep\u00fablica de Finlandia", "common": "Finlandia"},
-			"svk": {"official": "F\u00ednska republika", "common": "F\u00ednsko"},
 			"fin": {"official": "Suomen tasavalta", "common": "Suomi"},
 			"zho": {"official": "\u82AC\u5170\u5171\u548C\u56FD", "common": "\u82AC\u5170"}
 		},
@@ -3568,8 +3568,8 @@
 			"nld": {"official": "Republiek Fiji", "common": "Fiji"},
 			"por": {"official": "Rep\u00fablica de Fiji", "common": "Fiji"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0424\u0438\u0434\u0436\u0438", "common": "\u0424\u0438\u0434\u0436\u0438"},
+			"slk": {"official": "Fi\u01c6ijsk\u00e1 republika", "common": "Fi\u01c6i"},
 			"spa": {"official": "Rep\u00fablica de Fiji", "common": "Fiyi"},
-			"svk": {"official": "Fi\u01c6ijsk\u00e1 republika", "common": "Fi\u01c6i"},
 			"fin": {"official": "Fid\u017ein tasavalta", "common": "Fid\u017ei"},
 			"zho": {"official": "\u6590\u6D4E\u5171\u548C\u56FD", "common": "\u6590\u6D4E"}
 		},
@@ -3613,8 +3613,8 @@
 			"nld": {"official": "Falkland eilanden", "common": "Falklandeilanden"},
 			"por": {"official": "Ilhas Malvinas", "common": "Ilhas Malvinas"},
 			"rus": {"official": "\u0424\u043e\u043b\u043a\u043b\u0435\u043d\u0434\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0424\u043e\u043b\u043a\u043b\u0435\u043d\u0434\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Falklandsk\u00e9 ostrovy", "common": "Falklandy"},
 			"spa": {"official": "islas Malvinas", "common": "Islas Malvinas"},
-			"svk": {"official": "Falklandsk\u00e9 ostrovy", "common": "Falklandy"},
 			"fin": {"official": "Falkandinsaaret", "common": "Falkandinsaaret"},
 			"zho": {"official": "\u798F\u514B\u5170\u7FA4\u5C9B", "common": "\u798F\u514B\u5170\u7FA4\u5C9B"}
 		},
@@ -3658,8 +3658,8 @@
 			"nld": {"official": "Franse Republiek", "common": "Frankrijk"},
 			"por": {"official": "Rep\u00fablica Francesa", "common": "Fran\u00e7a"},
 			"rus": {"official": "\u0424\u0440\u0430\u043d\u0446\u0443\u0437\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0424\u0440\u0430\u043d\u0446\u0438\u044f"},
+			"slk": {"official": "Franc\u00fazska republika", "common": "Franc\u00fazsko"},
 			"spa": {"official": "Rep\u00fablica franc\u00e9s", "common": "Francia"},
-			"svk": {"official": "Franc\u00fazska republika", "common": "Franc\u00fazsko"},
 			"fin": {"official": "Ranskan tasavalta", "common": "Ranska"},
 			"zho": {"official": "\u6CD5\u5170\u897F\u5171\u548C\u56FD", "common": "\u6CD5\u56FD"}
 		},
@@ -3708,8 +3708,8 @@
 			"nld": {"official": "Faer\u00f6er", "common": "Faer\u00f6er"},
 			"por": {"official": "Ilhas Faroe", "common": "Ilhas Faro\u00e9"},
 			"rus": {"official": "\u0424\u0430\u0440\u0435\u0440\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0424\u0430\u0440\u0435\u0440\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Faersk\u00e9 ostrovy", "common": "Faersk\u00e9 ostrovy"},
 			"spa": {"official": "Islas Feroe", "common": "Islas Faroe"},
-			"svk": {"official": "Faersk\u00e9 ostrovy", "common": "Faersk\u00e9 ostrovy"},
 			"fin": {"official": "F\u00e4rsaaret", "common": "F\u00e4rsaaret"},
 			"zho": {"official": "\u6CD5\u7F57\u7FA4\u5C9B", "common": "\u6CD5\u7F57\u7FA4\u5C9B"}
 		},
@@ -3753,8 +3753,8 @@
 			"nld": {"official": "Federale Staten van Micronesia", "common": "Micronesi\u00eb"},
 			"por": {"official": "Estados Federados da Micron\u00e9sia", "common": "Micron\u00e9sia"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u044b\u0435 \u0428\u0442\u0430\u0442\u044b \u041c\u0438\u043a\u0440\u043e\u043d\u0435\u0437\u0438\u0438", "common": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u044b\u0435 \u0428\u0442\u0430\u0442\u044b \u041c\u0438\u043a\u0440\u043e\u043d\u0435\u0437\u0438\u0438"},
+			"slk": {"official": "Mikron/u00e9zske federat\u00edvne \u0161t\u00e1ty", "common": "Mikron\u00e9zia"},
 			"spa": {"official": "Estados Federados de Micronesia", "common": "Micronesia"},
-			"svk": {"official": "Mikron/u00e9zske federat\u00edvne \u0161t\u00e1ty", "common": "Mikron\u00e9zia"},
 			"fin": {"official": "Mikronesian liittovaltio", "common": "Mikronesia"},
 			"zho": {"official": "\u5BC6\u514B\u7F57\u5C3C\u897F\u4E9A\u8054\u90A6", "common": "\u5BC6\u514B\u7F57\u5C3C\u897F\u4E9A"}
 		},
@@ -3798,8 +3798,8 @@
 			"nld": {"official": "Republiek Gabon", "common": "Gabon"},
 			"por": {"official": "Rep\u00fablica do Gab\u00e3o", "common": "Gab\u00e3o"},
 			"rus": {"official": "\u0413\u0430\u0431\u043e\u043d\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0413\u0430\u0431\u043e\u043d"},
+			"slk": {"official": "Gabonsk\u00e1 republika", "common": "Gabon"},
 			"spa": {"official": "Rep\u00fablica de Gab\u00f3n", "common": "Gab\u00f3n"},
-			"svk": {"official": "Gabonsk\u00e1 republika", "common": "Gabon"},
 			"fin": {"official": "Gabonin tasavalta", "common": "Gabon"},
 			"zho": {"official": "\u52A0\u84EC\u5171\u548C\u56FD", "common": "\u52A0\u84EC"}
 		},
@@ -3843,8 +3843,8 @@
 			"nld": {"official": "Verenigd Koninkrijk van Groot-Brittanni\u00eb en Noord-Ierland", "common": "Verenigd Koninkrijk"},
 			"por": {"official": "Reino Unido da Gr\u00e3-Bretanha e Irlanda do Norte", "common": "Reino Unido"},
 			"rus": {"official": "\u0421\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u043d\u043e\u0435 \u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0412\u0435\u043b\u0438\u043a\u043e\u0431\u0440\u0438\u0442\u0430\u043d\u0438\u0438 \u0438 \u0421\u0435\u0432\u0435\u0440\u043d\u043e\u0439 \u0418\u0440\u043b\u0430\u043d\u0434\u0438\u0438", "common": "\u0412\u0435\u043b\u0438\u043a\u043e\u0431\u0440\u0438\u0442\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "Spojen\u00e9 kr\u00e1\u013eovstvo Ve\u013ekej Brit\u00e1nie a Severn\u00e9ho\u00ccrska", "common": "Ve\u013ek\u00e1 Brit\u00e1nia (Spojen\u00e9 kr\u00e1\u013eovstvo)"},
 			"spa": {"official": "Reino Unido de Gran Breta\u00f1a e Irlanda del Norte", "common": "Reino Unido"},
-			"svk": {"official": "Spojen\u00e9 kr\u00e1\u013eovstvo Ve\u013ekej Brit\u00e1nie a Severn\u00e9ho\u00ccrska", "common": "Ve\u013ek\u00e1 Brit\u00e1nia (Spojen\u00e9 kr\u00e1\u013eovstvo)"},
 			"fin": {"official": "Ison-Britannian ja Pohjois-Irlannin yhdistynyt kuningaskunta", "common": "Yhdistynyt kuningaskunta"},
 			"zho": {"official": "\u5927\u4E0D\u5217\u98A0\u53CA\u5317\u7231\u5C14\u5170\u8054\u5408\u738B\u56FD", "common": "\u82F1\u56FD"}
 		},
@@ -3888,8 +3888,8 @@
 			"nld": {"official": "Georgia", "common": "Georgi\u00eb"},
 			"por": {"official": "Georgia", "common": "Ge\u00f3rgia"},
 			"rus": {"official": "\u0413\u0440\u0443\u0437\u0438\u044f", "common": "\u0413\u0440\u0443\u0437\u0438\u044f"},
+			"slk": {"official": "Gruz\u00ednsko", "common": "Gruz\u00ednsko"},
 			"spa": {"official": "Georgia", "common": "Georgia"},
-			"svk": {"official": "Gruz\u00ednsko", "common": "Gruz\u00ednsko"},
 			"fin": {"official": "Georgia", "common": "Georgia"},
 			"zho": {"official": "\u683C\u9C81\u5409\u4E9A", "common": "\u683C\u9C81\u5409\u4E9A"}
 		},
@@ -3943,8 +3943,8 @@
 			"nld": {"official": "Baljuwschap Guernsey", "common": "Guernsey"},
 			"por": {"official": "Bailiado de Guernsey", "common": "Guernsey"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043d\u043d\u043e\u0435 \u0432\u043b\u0430\u0434\u0435\u043d\u0438\u0435 \u0413\u0435\u0440\u043d\u0441\u0438", "common": "\u0413\u0435\u0440\u043d\u0441\u0438"},
+			"slk": {"official": "Guernsey", "common": "Guernsey"},
 			"spa": {"official": "Bail\u00eda de Guernsey", "common": "Guernsey"},
-			"svk": {"official": "Guernsey", "common": "Guernsey"},
 			"fin": {"official": "Guernsey", "common": "Guernsey"},
 			"zho": {"official": "\u6839\u897F\u5C9B", "common": "\u6839\u897F\u5C9B"}
 		},
@@ -3988,8 +3988,8 @@
 			"nld": {"official": "Republiek Ghana", "common": "Ghana"},
 			"por": {"official": "Rep\u00fablica do Gana", "common": "Gana"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0430\u043d\u0430", "common": "\u0413\u0430\u043d\u0430"},
+			"slk": {"official": "Ghansk/u00e1 republika", "common": "Ghana"},
 			"spa": {"official": "Rep\u00fablica de Ghana", "common": "Ghana"},
-			"svk": {"official": " Ghansk/u00e1 republika", "common": "Ghana"},
 			"fin": {"official": "Ghanan tasavalta", "common": "Ghana"},
 			"zho": {"official": "\u52A0\u7EB3\u5171\u548C\u56FD", "common": "\u52A0\u7EB3"}
 		},
@@ -4033,8 +4033,8 @@
 			"nld": {"official": "Gibraltar", "common": "Gibraltar"},
 			"por": {"official": "Gibraltar", "common": "Gibraltar"},
 			"rus": {"official": "\u0413\u0438\u0431\u0440\u0430\u043b\u0442\u0430\u0440", "common": "\u0413\u0438\u0431\u0440\u0430\u043b\u0442\u0430\u0440"},
+			"slk": {"official": "Gibralt\u00e1r", "common": "Gibralt\u00e1r"},
 			"spa": {"official": "Gibraltar", "common": "Gibraltar"},
-			"svk": {"official": " Gibralt\u00e1r", "common": "Gibralt\u00e1r"},
 			"fin": {"official": "Gibraltar", "common": "Gibraltar"},
 			"zho": {"official": "\u76F4\u5E03\u7F57\u9640", "common": "\u76F4\u5E03\u7F57\u9640"}
 		},
@@ -4078,8 +4078,8 @@
 			"nld": {"official": "Republiek Guinee", "common": "Guinee"},
 			"por": {"official": "Rep\u00fablica da Guin\u00e9", "common": "Guin\u00e9"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0432\u0438\u043d\u0435\u044f", "common": "\u0413\u0432\u0438\u043d\u0435\u044f"},
+			"slk": {"official": "Guinejsk\u00e1 republika", "common": "Guinea"},
 			"spa": {"official": "Rep\u00fablica de Guinea", "common": "Guinea"},
-			"svk": {"official": "Guinejsk\u00e1 republika", "common": "Guinea"},
 			"fin": {"official": "Guinean tasavalta", "common": "Guinea"},
 			"zho": {"official": "\u51E0\u5185\u4E9A\u5171\u548C\u56FD", "common": "\u51E0\u5185\u4E9A"}
 		},
@@ -4123,8 +4123,8 @@
 			"nld": {"official": "Guadeloupe", "common": "Guadeloupe"},
 			"por": {"official": "Guadalupe", "common": "Guadalupe"},
 			"rus": {"official": "\u0413\u0432\u0430\u0434\u0435\u043b\u0443\u043f\u0430", "common": "\u0413\u0432\u0430\u0434\u0435\u043b\u0443\u043f\u0430"},
+			"slk": {"official": "Guadeloupe", "common": "Guadeloupe"},
 			"spa": {"official": "Guadalupe", "common": "Guadalupe"},
-			"svk": {"official": "Guadeloupe", "common": "Guadeloupe"},
 			"fin": {"official": "Guadeloupen departmentti", "common": "Guadeloupe"},
 			"zho": {"official": "\u74DC\u5FB7\u7F57\u666E\u5C9B", "common": "\u74DC\u5FB7\u7F57\u666E\u5C9B"}
 		},
@@ -4168,8 +4168,8 @@
 			"nld": {"official": "Republiek Gambia", "common": "Gambia"},
 			"por": {"official": "Rep\u00fablica da G\u00e2mbia", "common": "G\u00e2mbia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0430\u043c\u0431\u0438\u044f", "common": "\u0413\u0430\u043c\u0431\u0438\u044f"},
+			"slk": {"official": "Gambijsk/u00e1 republika", "common": "Gambia"},
 			"spa": {"official": "Rep\u00fablica de Gambia", "common": "Gambia"},
-			"svk": {"official": "Gambijsk/u00e1 republika", "common": "Gambia"},
 			"fin": {"official": "Gambian tasavalta", "common": "Gambia"},
 			"zho": {"official": "\u5188\u6BD4\u4E9A\u5171\u548C\u56FD", "common": "\u5188\u6BD4\u4E9A"}
 		},
@@ -4213,8 +4213,8 @@
 			"nld": {"official": "Republiek Guinee-Bissau", "common": "Guinee-Bissau"},
 			"por": {"official": "Rep\u00fablica da Guin\u00e9-Bissau", "common": "Guin\u00e9-Bissau"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0432\u0438\u043d\u0435\u044f -\u0411\u0438\u0441\u0430\u0443", "common": "\u0413\u0432\u0438\u043d\u0435\u044f-\u0411\u0438\u0441\u0430\u0443"},
+			"slk": {"official": "Guinejsko-bissausk\u00e1 republika", "common": "Guinea-Bissau"},
 			"spa": {"official": "Rep\u00fablica de Guinea-Bissau", "common": "Guinea-Bis\u00e1u"},
-			"svk": {"official": "Guinejsko-bissausk\u00e1 republika", "common": "Guinea-Bissau"},
 			"fin": {"official": "Guinea-Bissaun tasavalta", "common": "Guinea-Bissau"},
 			"zho": {"official": "\u51E0\u5185\u4E9A\u6BD4\u7ECD\u5171\u548C\u56FD", "common": "\u51E0\u5185\u4E9A\u6BD4\u7ECD"}
 		},
@@ -4269,8 +4269,8 @@
 			"nld": {"official": "Republiek Equatoriaal-Guinea", "common": "Equatoriaal-Guinea"},
 			"por": {"official": "Rep\u00fablica da Guin\u00e9 Equatorial", "common": "Guin\u00e9 Equatorial"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u042d\u043a\u0432\u0430\u0442\u043e\u0440\u0438\u0430\u043b\u044c\u043d\u0430\u044f \u0413\u0432\u0438\u043d\u0435\u044f", "common": "\u042d\u043a\u0432\u0430\u0442\u043e\u0440\u0438\u0430\u043b\u044c\u043d\u0430\u044f \u0413\u0432\u0438\u043d\u0435\u044f"},
+			"slk": {"official": "Republika rovn\u00edkovej Guiney", "common": "Rovn\u00edkov\u00e1 Guinea"},
 			"spa": {"official": "Rep\u00fablica de Guinea Ecuatorial", "common": "Guinea Ecuatorial"},
-			"svk": {"official": "Republika rovn\u00edkovej Guiney", "common": "Rovn\u00edkov\u00e1 Guinea"},
 			"fin": {"official": "P\u00e4iv\u00e4ntasaajan Guinean tasavalta", "common": "P\u00e4iv\u00e4ntasaajan Guinea"},
 			"zho": {"official": "\u8D64\u9053\u51E0\u5185\u4E9A\u5171\u548C\u56FD", "common": "\u8D64\u9053\u51E0\u5185\u4E9A"}
 		},
@@ -4314,8 +4314,8 @@
 			"nld": {"official": "Helleense Republiek", "common": "Griekenland"},
 			"por": {"official": "Rep\u00fablica Hel\u00e9nica", "common": "Gr\u00e9cia"},
 			"rus": {"official": "\u0413\u0440\u0435\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0413\u0440\u0435\u0446\u0438\u044f"},
+			"slk": {"official": "Gr\u00e9cka republika", "common": "Gre\u00e9cko"},
 			"spa": {"official": "Rep\u00fablica Hel\u00e9nica", "common": "Grecia"},
-			"svk": {"official": "Gr\u00e9cka republika", "common": "Gre\u00e9cko"},
 			"fin": {"official": "Helleenien tasavalta", "common": "Kreikka"},
 			"zho": {"official": "\u5E0C\u814A\u5171\u548C\u56FD", "common": "\u5E0C\u814A"}
 		},
@@ -4359,8 +4359,8 @@
 			"nld": {"official": "Grenada", "common": "Grenada"},
 			"por": {"official": "Grenada", "common": "Granada"},
 			"rus": {"official": "\u0413\u0440\u0435\u043d\u0430\u0434\u0430", "common": "\u0413\u0440\u0435\u043d\u0430\u0434\u0430"},
+			"slk": {"official": "Grenada", "common": "Grenada"},
 			"spa": {"official": "Granada", "common": "Grenada"},
-			"svk": {"official": "Grenada", "common": "Grenada"},
 			"fin": {"official": "Grenada", "common": "Grenada"},
 			"zho": {"official": "\u683C\u6797\u7EB3\u8FBE", "common": "\u683C\u6797\u7EB3\u8FBE"}
 		},
@@ -4404,8 +4404,8 @@
 			"nld": {"official": "Groenland", "common": "Groenland"},
 			"por": {"official": "Groenl\u00e2ndia", "common": "Gronel\u00e2ndia"},
 			"rus": {"official": "\u0413\u0440\u0435\u043d\u043b\u0430\u043d\u0434\u0438\u044f", "common": "\u0413\u0440\u0435\u043d\u043b\u0430\u043d\u0434\u0438\u044f"},
+			"slk": {"official": "Gr\u00f3nsko", "common": "Gr\u00f3nsko"},
 			"spa": {"official": "Groenlandia", "common": "Groenlandia"},
-			"svk": {"official": "Gr\u00f3nsko", "common": "Gr\u00f3nsko"},
 			"fin": {"official": "Gro\u00f6nlanti", "common": "Gro\u00f6nlanti"},
 			"zho": {"official": "\u683C\u9675\u5170", "common": "\u683C\u9675\u5170"}
 		},
@@ -4449,8 +4449,8 @@
 			"nld": {"official": "Republiek Guatemala", "common": "Guatemala"},
 			"por": {"official": "Rep\u00fablica da Guatemala", "common": "Guatemala"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b\u0430", "common": "\u0413\u0432\u0430\u0442\u0435\u043c\u0430\u043b\u0430"},
+			"slk": {"official": "Guatemalsk\u00e1 republika", "common": "Guatemala"},
 			"spa": {"official": "Rep\u00fablica de Guatemala", "common": "Guatemala"},
-			"svk": {"official": "Guatemalsk\u00e1 republika", "common": "Guatemala"},
 			"fin": {"official": "Guatemalan tasavalta", "common": "Guatemala"},
 			"zho": {"official": "\u5371\u5730\u9A6C\u62C9\u5171\u548C\u56FD", "common": "\u5371\u5730\u9A6C\u62C9"}
 		},
@@ -4494,8 +4494,8 @@
 			"nld": {"official": "Guyana", "common": "Frans-Guyana"},
 			"por": {"official": "Guiana", "common": "Guiana Francesa"},
 			"rus": {"official": "\u0413\u0432\u0438\u0430\u043d\u0430", "common": "\u0424\u0440\u0430\u043d\u0446\u0443\u0437\u0441\u043a\u0430\u044f \u0413\u0432\u0438\u0430\u043d\u0430"},
+			"slk": {"official": "Franc\u00fazska Guyana", "common": "Guyana"},
 			"spa": {"official": "Guayana", "common": "Guayana Francesa"},
-			"svk": {"official": "Franc\u00fazska Guyana", "common": "Guyana"},
 			"fin": {"official": "Ranskan Guayana", "common": "Ranskan Guayana"},
 			"zho": {"official": "\u6CD5\u5C5E\u572D\u4E9A\u90A3", "common": "\u6CD5\u5C5E\u572D\u4E9A\u90A3"}
 		},
@@ -4549,8 +4549,8 @@
 			"nld": {"official": "Guam", "common": "Guam"},
 			"por": {"official": "Guam", "common": "Guam"},
 			"rus": {"official": "\u0413\u0443\u0430\u043c", "common": "\u0413\u0443\u0430\u043c"},
+			"slk": {"official": "Guam", "common": "Guam"},
 			"spa": {"official": "Guam", "common": "Guam"},
-			"svk": {"official": "Guam", "common": "Guam"},
 			"fin": {"official": "Guam", "common": "Guam"},
 			"zho": {"official": "\u5173\u5C9B", "common": "\u5173\u5C9B"}
 		},
@@ -4594,8 +4594,8 @@
 			"nld": {"official": "Co\u00f6peratieve Republiek Guyana", "common": "Guyana"},
 			"por": {"official": "Co -operative Rep\u00fablica da Guiana", "common": "Guiana"},
 			"rus": {"official": "\u041a\u043e\u043e\u043f\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0430\u0439\u0430\u043d\u0430", "common": "\u0413\u0430\u0439\u0430\u043d\u0430"},
+			"slk": {"official": "Guyansk\u00e1 kooperat\u00edvna republika", "common": "Guyana"},
 			"spa": {"official": "Rep\u00fablica Cooperativa de Guyana", "common": "Guyana"},
-			"svk": {"official": "Guyansk\u00e1 kooperat\u00edvna republika", "common": "Guyana"},
 			"fin": {"official": "Guayanan osuustoiminnallinen tasavalta", "common": "Guayana"},
 			"zho": {"official": "\u572D\u4E9A\u90A3\u5171\u548C\u56FD", "common": "\u572D\u4E9A\u90A3"}
 		},
@@ -4644,8 +4644,8 @@
 			"nld": {"official": "Hong Kong Speciale Administratieve Regio van de Volksrepubliek China", "common": "Hongkong"},
 			"por": {"official": "Hong Kong Regi\u00e3o Administrativa Especial da Rep\u00fablica Popular da China", "common": "Hong Kong"},
 			"rus": {"official": "Hong Kong \u0421\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u044b\u0439 \u0430\u0434\u043c\u0438\u043d\u0438\u0441\u0442\u0440\u0430\u0442\u0438\u0432\u043d\u044b\u0439 \u0440\u0430\u0439\u043e\u043d \u041a\u0438\u0442\u0430\u0439\u0441\u043a\u043e\u0439 \u041d\u0430\u0440\u043e\u0434\u043d\u043e\u0439 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438 \u041a\u0438\u0442\u0430\u044f", "common": "\u0413\u043e\u043d\u043a\u043e\u043d\u0433"},
+			"slk": {"official": "\u0160peci\u00e1lna administrat\u00edvna oblas\u0165\u010c\u00ednskej \u013eudovej republiky Hongkong", "common": "Hongkong"},
 			"spa": {"official": "Hong Kong Regi\u00f3n Administrativa Especial de la Rep\u00fablica Popular China", "common": "Hong Kong"},
-			"svk": {"official": "\u0160peci\u00e1lna administrat\u00edvna oblas\u0165\u010c\u00ednskej \u013eudovej republiky Hongkong", "common": "Hongkong"},
 			"fin": {"official": "Hong Kongin erityishallintoalue", "common": "Hongkong"}
 		},
 		"latlng": [22.267, 114.188],
@@ -4688,8 +4688,8 @@
 			"nld": {"official": "Heard en McDonaldeilanden", "common": "Heard-en McDonaldeilanden"},
 			"por": {"official": "Ilha Heard e Ilhas McDonald", "common": "Ilha Heard e Ilhas McDonald"},
 			"rus": {"official": "\u041e\u0441\u0442\u0440\u043e\u0432 \u0425\u0435\u0440\u0434 \u0438 \u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u041c\u0430\u043a\u0434\u043e\u043d\u0430\u043b\u044c\u0434", "common": "\u041e\u0441\u0442\u0440\u043e\u0432 \u0425\u0435\u0440\u0434 \u0438 \u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u041c\u0430\u043a\u0434\u043e\u043d\u0430\u043b\u044c\u0434"},
+			"slk": {"official": "Terit\u00f3rium Heardovho ostrova a Macdonaldov\u00fdch ostrovov", "common": "Heardov ostrov"},
 			"spa": {"official": "Islas Heard y McDonald", "common": "Islas Heard y McDonald"},
-			"svk": {"official": "Terit\u00f3rium Heardovho ostrova a Macdonaldov\u00fdch ostrovov", "common": "Heardov ostrov"},
 			"fin": {"official": "Heard ja McDonaldinsaaret", "common": "Heard ja McDonaldinsaaret"},
 			"zho": {"official": "\u8D6B\u5FB7\u5C9B\u548C\u9EA6\u5F53\u52B3\u7FA4\u5C9B", "common": "\u8D6B\u5FB7\u5C9B\u548C\u9EA6\u5F53\u52B3\u7FA4\u5C9B"}
 		},
@@ -4733,9 +4733,9 @@
 			"nld": {"official": "Republiek Honduras", "common": "Honduras"},
 			"por": {"official": "Rep\u00fablica de Honduras", "common": "Honduras"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u043e\u043d\u0434\u0443\u0440\u0430\u0441", "common": "\u0413\u043e\u043d\u0434\u0443\u0440\u0430\u0441"},
+			"slk": {"official": "Hondurask\u00e1 republika", "common": "Honduras"},
 			"spa": {"official": "Rep\u00fablica de Honduras", "common": "Honduras"},
 			"fin": {"official": "Hondurasin tasavalta", "common": "Honduras"},
-			"svk": {"official": "Hondurask\u00e1 republika", "common": "Honduras"},
 			"zho": {"official": "\u6D2A\u90FD\u62C9\u65AF\u5171\u548C\u56FD", "common": "\u6D2A\u90FD\u62C9\u65AF"}
 		},
 		"latlng": [15, -86.5],
@@ -4779,8 +4779,8 @@
 			"nld": {"official": "Republiek Kroati\u00eb", "common": "Kroati\u00eb"},
 			"por": {"official": "Rep\u00fablica da Cro\u00e1cia", "common": "Cro\u00e1cia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0425\u043e\u0440\u0432\u0430\u0442\u0438\u044f", "common": "\u0425\u043e\u0440\u0432\u0430\u0442\u0438\u044f"},
+			"slk": {"official": "Chorv\u00e1tska republika", "common": "Chorv\u00e1tsko"},
 			"spa": {"official": "Rep\u00fablica de Croacia", "common": "Croacia"},
-			"svk": {"official": "Chorv\u00e1tska republika", "common": "Chorv\u00e1tsko"},
 			"fin": {"official": "Kroatian tasavalta", "common": "Kroatia"},
 			"zho": {"official": "\u514B\u7F57\u5730\u4E9A\u5171\u548C\u56FD", "common": "\u514B\u7F57\u5730\u4E9A"}
 		},
@@ -4829,8 +4829,8 @@
 			"nld": {"official": "Republiek Ha\u00efti", "common": "Ha\u00efti"},
 			"por": {"official": "Rep\u00fablica do Haiti", "common": "Haiti"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0413\u0430\u0438\u0442\u0438", "common": "\u0413\u0430\u0438\u0442\u0438"},
+			"slk": {"official": "Haitsk\u00e1 republika", "common": "Haiti"},
 			"spa": {"official": "Rep\u00fablica de Hait\u00ed", "common": "Haiti"},
-			"svk": {"official": "Haitsk\u00e1 republika", "common": "Haiti"},
 			"fin": {"official": "Haitin tasavalta", "common": "Haiti"},
 			"zho": {"official": "\u6D77\u5730\u5171\u548C\u56FD", "common": "\u6D77\u5730"}
 		},
@@ -4874,8 +4874,8 @@
 			"nld": {"official": "Hongarije", "common": "Hongarije"},
 			"por": {"official": "Hungria", "common": "Hungria"},
 			"rus": {"official": "\u0412\u0435\u043d\u0433\u0440\u0438\u044f", "common": "\u0412\u0435\u043d\u0433\u0440\u0438\u044f"},
+			"slk": {"official": "Ma\u010farsko", "common": "Ma\u010farsko"},
 			"spa": {"official": "Hungr\u00eda", "common": "Hungr\u00eda"},
-			"svk": {"official": "Ma\u010farsko", "common": "Ma\u010farsko"},
 			"fin": {"official": "Unkari", "common": "Unkari"},
 			"zho": {"official": "\u5308\u7259\u5229", "common": "\u5308\u7259\u5229"}
 		},
@@ -4919,8 +4919,8 @@
 			"nld": {"official": "Republiek Indonesi\u00eb", "common": "Indonesi\u00eb"},
 			"por": {"official": "Rep\u00fablica da Indon\u00e9sia", "common": "Indon\u00e9sia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0418\u043d\u0434\u043e\u043d\u0435\u0437\u0438\u044f", "common": "\u0418\u043d\u0434\u043e\u043d\u0435\u0437\u0438\u044f"},
+			"slk": {"official": "Indon\u00e9zska republika", "common": "Indon\u00e9zia"},
 			"spa": {"official": "Rep\u00fablica de Indonesia", "common": "Indonesia"},
-			"svk": {"official": "Indon\u00e9zska republika", "common": "Indon\u00e9zia"},
 			"fin": {"official": "Indonesian tasavalta", "common": "Indonesia"},
 			"zho": {"official": "\u5370\u5EA6\u5C3C\u897F\u4E9A\u5171\u548C\u56FD", "common": "\u5370\u5EA6\u5C3C\u897F\u4E9A"}
 		},
@@ -4969,8 +4969,8 @@
 			"nld": {"official": "Isle of Man", "common": "Isle of Man"},
 			"por": {"official": "Isle of Man", "common": "Ilha de Man"},
 			"rus": {"official": "\u041e\u0441\u0442\u0440\u043e\u0432 \u041c\u044d\u043d", "common": "\u041e\u0441\u0442\u0440\u043e\u0432 \u041c\u044d\u043d"},
+			"slk": {"official": "Ostrov Man", "common": "Man"},
 			"spa": {"official": "Isla de Man", "common": "Isla de Man"},
-			"svk": {"official": "Ostrov Man", "common": "Man"},
 			"fin": {"official": "Mansaari", "common": "Mansaari"},
 			"zho": {"official": "\u9A6C\u6069\u5C9B", "common": "\u9A6C\u6069\u5C9B"}
 		},
@@ -5024,8 +5024,8 @@
 			"nld": {"official": "Republiek India", "common": "India"},
 			"por": {"official": "Rep\u00fablica da \u00cdndia", "common": "\u00cdndia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0418\u043d\u0434\u0438\u044f", "common": "\u0418\u043d\u0434\u0438\u044f"},
+			"slk": {"official": "Indick\u00e1 republika", "common": "India"},
 			"spa": {"official": "Rep\u00fablica de la India", "common": "India"},
-			"svk": {"official": "Indick\u00e1 republika", "common": "India"},
 			"fin": {"official": "Intian tasavalta", "common": "Intia"},
 			"zho": {"official": "\u5370\u5EA6\u5171\u548C\u56FD", "common": "\u5370\u5EA6"}
 		},
@@ -5070,8 +5070,8 @@
 			"nld": {"official": "Brits Indische Oceaan Territorium", "common": "Britse Gebieden in de Indische Oceaan"},
 			"por": {"official": "British Indian Ocean Territory", "common": "Territ\u00f3rio Brit\u00e2nico do Oceano \u00cdndico"},
 			"rus": {"official": "\u0411\u0440\u0438\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u0442\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u044f \u0418\u043d\u0434\u0438\u0439\u0441\u043a\u043e\u0433\u043e \u043e\u043a\u0435\u0430\u043d\u0430", "common": "\u0411\u0440\u0438\u0442\u0430\u043d\u0441\u043a\u0430\u044f \u0442\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u044f \u0432 \u0418\u043d\u0434\u0438\u0439\u0441\u043a\u043e\u043c \u043e\u043a\u0435\u0430\u043d\u0435"},
+			"slk": {"official": "Britsk\u00e9 indickooce\u00e1nske \u00fazemie", "common": "Britsk\u00e9 indickooce\u00e1nske \u00fazemie"},
 			"spa": {"official": "Territorio Brit\u00e1nico del Oc\u00e9ano \u00cdndico", "common": "Territorio Brit\u00e1nico del Oc\u00e9ano \u00cdndico"},
-			"svk": {"official": "Britsk\u00e9 indickooce\u00e1nske \u00fazemie", "common": "Britsk\u00e9 indickooce\u00e1nske \u00fazemie"},
 			"fin": {"official": "Brittil\u00e4inen Intian valtameren alue", "common": "Brittil\u00e4inen Intian valtameren alue"},
 			"zho": {"official": "\u82F1\u5C5E\u5370\u5EA6\u6D0B\u9886\u5730", "common": "\u82F1\u5C5E\u5370\u5EA6\u6D0B\u9886\u5730"}
 		},
@@ -5120,8 +5120,8 @@
 			"nld": {"official": "Republic of Ireland", "common": "Ierland"},
 			"por": {"official": "Rep\u00fablica da Irlanda", "common": "Irlanda"},
 			"rus": {"official": "\u0418\u0440\u043b\u0430\u043d\u0434\u0438\u044f", "common": "\u0418\u0440\u043b\u0430\u043d\u0434\u0438\u044f"},
+			"slk": {"official": "\u00cdrska republika", "common": "\u00cdrsko"},
 			"spa": {"official": "Rep\u00fablica de Irlanda", "common": "Irlanda"},
-			"svk": {"official": "\u00cdrska republika", "common": "\u00cdrsko"},
 			"fin": {"official": "Irlannin tasavalta", "common": "Irlanti"},
 			"zho": {"official": "\u7231\u5C14\u5170\u5171\u548C\u56FD", "common": "\u7231\u5C14\u5170"}
 		},
@@ -5165,8 +5165,8 @@
 			"nld": {"official": "Islamitische Republiek Iran", "common": "Iran"},
 			"por": {"official": "Rep\u00fablica Isl\u00e2mica do Ir\u00e3", "common": "Ir\u00e3o"},
 			"rus": {"official": "\u0418\u0441\u043b\u0430\u043c\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0418\u0440\u0430\u043d", "common": "\u0418\u0440\u0430\u043d"},
+			"slk": {"official": "Ir\u00e1nska islamsk\u00e1 republika", "common": "Ir\u00e1n"},
 			"spa": {"official": "Rep\u00fablica Isl\u00e1mica de Ir\u00e1n", "common": "Iran"},
-			"svk": {"official": "Ir\u00e1nska islamsk\u00e1 republika", "common": "Ir\u00e1n"},
 			"fin": {"official": "Iranin islamilainen tasavalta", "common": "Iran"},
 			"zho": {"official": "\u4F0A\u6717\u4F0A\u65AF\u5170\u5171\u548C\u56FD", "common": "\u4F0A\u6717"}
 		},
@@ -5220,8 +5220,8 @@
 			"nld": {"official": "Republiek Irak", "common": "Irak"},
 			"por": {"official": "Rep\u00fablica do Iraque", "common": "Iraque"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0418\u0440\u0430\u043a", "common": "\u0418\u0440\u0430\u043a"},
+			"slk": {"official": "Irack\u00e1 republika", "common": "Irak"},
 			"spa": {"official": "Rep\u00fablica de Irak", "common": "Irak"},
-			"svk": {"official": "Irack\u00e1 republika", "common": "Irak"},
 			"fin": {"official": "Irakin tasavalta", "common": "Irak"},
 			"zho": {"official": "\u4F0A\u62C9\u514B\u5171\u548C\u56FD", "common": "\u4F0A\u62C9\u514B"}
 		},
@@ -5265,8 +5265,8 @@
 			"nld": {"official": "IJsland", "common": "IJsland"},
 			"por": {"official": "Isl\u00e2ndia", "common": "Isl\u00e2ndia"},
 			"rus": {"official": "\u0418\u0441\u043b\u0430\u043d\u0434\u0438\u044f", "common": "\u0418\u0441\u043b\u0430\u043d\u0434\u0438\u044f"},
+			"slk": {"official": "Islandsk\u00e1 republika", "common": "Island"},
 			"spa": {"official": "Islandia", "common": "Islandia"},
-			"svk": {"official": "Islandsk\u00e1 republika", "common": "Island"},
 			"fin": {"official": "Islanti", "common": "Islanti"},
 			"zho": {"official": "\u51B0\u5C9B", "common": "\u51B0\u5C9B"}
 		},
@@ -5315,8 +5315,8 @@
 			"nld": {"official": "Staat Isra\u00ebl", "common": "Isra\u00ebl"},
 			"por": {"official": "Estado de Israel", "common": "Israel"},
 			"rus": {"official": "\u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u0418\u0437\u0440\u0430\u0438\u043b\u044c", "common": "\u0418\u0437\u0440\u0430\u0438\u043b\u044c"},
+			"slk": {"official": "Izraelsk\u00fd \u0161t\u00e1t", "common": "Izrael"},
 			"spa": {"official": "Estado de Israel", "common": "Israel"},
-			"svk": {"official": "Izraelsk\u00fd \u0161t\u00e1t", "common": "Izrael"},
 			"fin": {"official": "Israelin valtio", "common": "Israel"},
 			"zho": {"official": "\u4EE5\u8272\u5217\u56FD", "common": "\u4EE5\u8272\u5217"}
 		},
@@ -5370,8 +5370,8 @@
 			"nld": {"official": "Italiaanse Republiek", "common": "Itali\u00eb"},
 			"por": {"official": "Rep\u00fablica Italiana", "common": "It\u00e1lia"},
 			"rus": {"official": "\u0438\u0442\u0430\u043b\u044c\u044f\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0418\u0442\u0430\u043b\u0438\u044f"},
+			"slk": {"official": "Talianska republika", "common": "Taliansko"},
 			"spa": {"official": "Rep\u00fablica Italiana", "common": "Italia"},
-			"svk": {"official": "Talianska republika", "common": "Taliansko"},
 			"fin": {"official": "Italian tasavalta", "common": "Italia"},
 			"zho": {"official": "\u610F\u5927\u5229\u5171\u548C\u56FD", "common": "\u610F\u5927\u5229"}
 		},
@@ -5420,8 +5420,8 @@
 			"nld": {"official": "Jamaica", "common": "Jamaica"},
 			"por": {"official": "Jamaica", "common": "Jamaica"},
 			"rus": {"official": "\u042f\u043c\u0430\u0439\u043a\u0430", "common": "\u042f\u043c\u0430\u0439\u043a\u0430"},
+			"slk": {"official": "Jamajka", "common": "Jamajka"},
 			"spa": {"official": "Jamaica", "common": "Jamaica"},
-			"svk": {"official": "Jamajka", "common": "Jamajka"},
 			"fin": {"official": "Jamaika", "common": "Jamaika"},
 			"zho": {"official": "\u7259\u4E70\u52A0", "common": "\u7259\u4E70\u52A0"}
 		},
@@ -5475,8 +5475,8 @@
 			"nld": {"official": "Baljuwschap Jersey", "common": "Jersey"},
 			"por": {"official": "Bailiado de Jersey", "common": "Jersey"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043d\u043d\u043e\u0435 \u0432\u043b\u0430\u0434\u0435\u043d\u0438\u0435 \u0414\u0436\u0435\u0440\u0441\u0438", "common": "\u0414\u0436\u0435\u0440\u0441\u0438"},
+			"slk": {"official": "Bailiwick Jersey", "common": "Jersey"},
 			"spa": {"official": "Bail\u00eda de Jersey", "common": "Jersey"},
-			"svk": {"official": "Bailiwick Jersey", "common": "Jersey"},
 			"fin": {"official": "Jersey", "common": "Jersey"},
 			"zho": {"official": "\u6CFD\u897F\u5C9B", "common": "\u6CFD\u897F\u5C9B"}
 		},
@@ -5520,8 +5520,8 @@
 			"nld": {"official": "Hasjemitisch Koninkrijk Jordani\u00eb", "common": "Jordani\u00eb"},
 			"por": {"official": "Reino Hachemita da Jord\u00e2nia", "common": "Jord\u00e2nia"},
 			"rus": {"official": "\u0418\u043e\u0440\u0434\u0430\u043d\u0441\u043a\u043e\u0433\u043e \u0425\u0430\u0448\u0438\u043c\u0438\u0442\u0441\u043a\u043e\u0433\u043e \u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u0430", "common": "\u0418\u043e\u0440\u0434\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "Jord\u00e1nske h\u00e1\u0161imovsk\u00e9 kr\u00e1\u013eovstvo", "common": "Jord\u00e1nsko"},
 			"spa": {"official": "Reino Hachemita de Jordania", "common": "Jordania"},
-			"svk": {"official": "Jord\u00e1nske h\u00e1\u0161imovsk\u00e9 kr\u00e1\u013eovstvo", "common": "Jord\u00e1nsko"},
 			"fin": {"official": "Jordanian ha\u0161emiittinen kunigaskunta", "common": "Jordania"},
 			"zho": {"official": "\u7EA6\u65E6\u54C8\u5E0C\u59C6\u738B\u56FD", "common": "\u7EA6\u65E6"}
 		},
@@ -5565,8 +5565,8 @@
 			"nld": {"official": "Japan", "common": "Japan"},
 			"por": {"official": "Jap\u00e3o", "common": "Jap\u00e3o"},
 			"rus": {"official": "\u042f\u043f\u043e\u043d\u0438\u044f", "common": "\u042f\u043f\u043e\u043d\u0438\u044f"},
+			"slk": {"official": "Japonsko", "common": "Japonsko"},
 			"spa": {"official": "Jap\u00f3n", "common": "Jap\u00f3n"},
-			"svk": {"official": "Japonsko", "common": "Japonsko"},
 			"fin": {"official": "Japani", "common": "Japani"},
 			"zho": {"official": "\u65e5\u672c\u56fd", "common": "\u65E5\u672C"}
 		},
@@ -5615,8 +5615,8 @@
 			"nld": {"official": "Republiek Kazachstan", "common": "Kazachstan"},
 			"por": {"official": "Rep\u00fablica do Cazaquist\u00e3o", "common": "Cazaquist\u00e3o"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d", "common": "\u041a\u0430\u0437\u0430\u0445\u0441\u0442\u0430\u043d"},
+			"slk": {"official": "Kaza\u0161sk\u00e1 republika", "common": "Kazachstan"},
 			"spa": {"official": "Rep\u00fablica de Kazajst\u00e1n", "common": "Kazajist\u00e1n"},
-			"svk": {"official": "Kaza\u0161sk\u00e1 republika", "common": "Kazachstan"},
 			"fin": {"official": "Kazakstanin tasavalta", "common": "Kazakstan"},
 			"zho": {"official": "\u54C8\u8428\u514B\u65AF\u5766\u5171\u548C\u56FD", "common": "\u54C8\u8428\u514B\u65AF\u5766"}
 		},
@@ -5665,8 +5665,8 @@
 			"nld": {"official": "Republiek Kenia", "common": "Kenia"},
 			"por": {"official": "Rep\u00fablica do Qu\u00e9nia", "common": "Qu\u00e9nia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u0435\u043d\u0438\u044f", "common": "\u041a\u0435\u043d\u0438\u044f"},
+			"slk": {"official": "Kensk\u00e1 republika", "common": "Ke\u0148a"},
 			"spa": {"official": "Rep\u00fablica de Kenya", "common": "Kenia"},
-			"svk": {"official": "Kensk\u00e1 republika", "common": "Ke\u0148a"},
 			"fin": {"official": "Kenian tasavalta", "common": "Kenia"},
 			"zho": {"official": "\u80AF\u5C3C\u4E9A\u5171\u548C\u56FD", "common": "\u80AF\u5C3C\u4E9A"}
 		},
@@ -5715,8 +5715,8 @@
 			"nld": {"official": "Kirgizische Republiek", "common": "Kirgizi\u00eb"},
 			"por": {"official": "Rep\u00fablica do Quirguist\u00e3o", "common": "Quirguist\u00e3o"},
 			"rus": {"official": "\u041a\u044b\u0440\u0433\u044b\u0437\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u041a\u0438\u0440\u0433\u0438\u0437\u0438\u044f"},
+			"slk": {"official": "Kirgizsk\u00e1 republika", "common": "Kirgizsko"},
 			"spa": {"official": "Rep\u00fablica Kirguisa", "common": "Kirguizist\u00e1n"},
-			"svk": {"official": "Kirgizsk\u00e1 republika", "common": "Kirgizsko"},
 			"fin": {"official": "Kirgisian tasavalta", "common": "Kirgisia"},
 			"zho": {"official": "\u5409\u5C14\u5409\u65AF\u65AF\u5766\u5171\u548C\u56FD", "common": "\u5409\u5C14\u5409\u65AF\u65AF\u5766"}
 		},
@@ -5761,8 +5761,8 @@
 			"nld": {"official": "Koninkrijk Cambodja", "common": "Cambodja"},
 			"por": {"official": "Reino do Camboja", "common": "Camboja"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u041a\u0430\u043c\u0431\u043e\u0434\u0436\u0430", "common": "\u041a\u0430\u043c\u0431\u043e\u0434\u0436\u0430"},
+			"slk": {"official": "Kambo\u01c6sk\u00e9 kr\u00e1\u013eovstvo", "common": "Kambo\u01c6a"},
 			"spa": {"official": "Reino de Camboya", "common": "Camboya"},
-			"svk": {"official": "Kambo\u01c6sk\u00e9 kr\u00e1\u013eovstvo", "common": "Kambo\u01c6a"},
 			"fin": {"official": "Kambod\u017ean kuningaskunta", "common": "Kambod\u017ea"},
 			"zho": {"official": "\u67EC\u57D4\u5BE8\u738B\u56FD", "common": "\u67EC\u57D4\u5BE8"}
 		},
@@ -5811,8 +5811,8 @@
 			"nld": {"official": "Onafhankelijke en soevereine republiek Kiribati", "common": "Kiribati"},
 			"por": {"official": "Independente e soberano Rep\u00fablica de Kiribati", "common": "Kiribati"},
 			"rus": {"official": "\u041d\u0435\u0437\u0430\u0432\u0438\u0441\u0438\u043c\u043e\u0439 \u0438 \u0441\u0443\u0432\u0435\u0440\u0435\u043d\u043d\u043e\u0439 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438 \u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438", "common": "\u041a\u0438\u0440\u0438\u0431\u0430\u0442\u0438"},
+			"slk": {"official": "Kiribatsk\u00e1 republika", "common": "Kiribati"},
 			"spa": {"official": "Rep\u00fablica Independiente y Soberano de Kiribati", "common": "Kiribati"},
-			"svk": {"official": "Kiribatsk\u00e1 republika", "common": "Kiribati"},
 			"fin": {"official": "Kiribatin tasavalta", "common": "Kiribati"},
 			"zho": {"official": "\u57FA\u91CC\u5DF4\u65AF\u5171\u548C\u56FD", "common": "\u57FA\u91CC\u5DF4\u65AF"}
 		},
@@ -5856,8 +5856,8 @@
 			"nld": {"official": "Federatie van Saint Kitts en Nevisa", "common": "Saint Kitts en Nevis"},
 			"por": {"official": "Federa\u00e7\u00e3o de S\u00e3o Crist\u00f3v\u00e3o e Nevisa", "common": "S\u00e3o Crist\u00f3v\u00e3o e Nevis"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f \u0421\u0435\u043d\u0442-\u041a\u0440\u0438\u0441\u0442\u043e\u0444\u0435\u0440 \u0438 Nevisa", "common": "\u0421\u0435\u043d\u0442-\u041a\u0438\u0442\u0441 \u0438 \u041d\u0435\u0432\u0438\u0441"},
+			"slk": {"official": "Feder\u0ee1cia Sv\u00e4t\u00e9ho Kri\u0161tofa a Nevisu", "common": "Sv\u00e4t\u00fd Kri\u0161tof a Nevis"},
 			"spa": {"official": "Federaci\u00f3n de San Crist\u00f3bal y Nevisa", "common": "San Crist\u00f3bal y Nieves"},
-			"svk": {"official": "Feder\u0ee1cia Sv\u00e4t\u00e9ho Kri\u0161tofa a Nevisu", "common": "Sv\u00e4t\u00fd Kri\u0161tof a Nevis"},
 			"fin": {"official": "Saint Christopherin ja Nevisin federaatio", "common": "Saint Kitts ja Nevis"},
 			"zho": {"official": "\u5723\u514B\u91CC\u65AF\u6258\u5F17\u548C\u5C3C\u7EF4\u65AF\u8054\u90A6", "common": "\u5723\u57FA\u8328\u548C\u5C3C\u7EF4\u65AF"}
 		},
@@ -5901,8 +5901,8 @@
 			"nld": {"official": "Republiek Korea", "common": "Zuid-Korea"},
 			"por": {"official": "Rep\u00fablica da Coreia", "common": "Coreia do Sul"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0440\u0435\u044f", "common": "\u042e\u0436\u043d\u0430\u044f \u041a\u043e\u0440\u0435\u044f"},
+			"slk": {"official": "K\u00f3rejsk\u00e1 republika", "common": "Ju\u017en\u00e1 K\u00f3rea"},
 			"spa": {"official": "Rep\u00fablica de Corea", "common": "Corea del Sur"},
-			"svk": {"official": "K\u00f3rejsk\u00e1 republika", "common": "Ju\u017en\u00e1 K\u00f3rea"},
 			"fin": {"official": "Korean tasavalta", "common": "Etel\u00e4-Korea"},
 			"zho": {"official": "\u5927\u97E9\u6C11\u56FD", "common": "\u97E9\u56FD"}
 		},
@@ -5950,8 +5950,8 @@
 			"nld": {"official": "Republiek Kosovo", "common":"Kosovo"},
 			"por": {"official": "Rep\u00fablica do Kosovo", "common": "Kosovo"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0441\u043e\u0432\u043e", "common": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0441\u043e\u0432\u043e"},
+			"slk": {"official": "Republika Kosovo", "common": "Kosovo"},
 			"spa": {"official": "Rep\u00fablica de Kosovo", "common": "Kosovo"},
-			"svk": {"official": "Republika Kosovo", "common": "Kosovo"},
 			"fin": {"official": "Kosovon tasavalta", "common": "Kosovo"},
 			"zho": {"official": "\u79D1\u7D22\u6C83\u5171\u548C\u56FD", "common": "\u79D1\u7D22\u6C83"}
 		},
@@ -5995,8 +5995,8 @@
 			"nld": {"official": "Staat Koeweit", "common": "Koeweit"},
 			"por": {"official": "Estado do Kuwait", "common": "Kuwait"},
 			"rus": {"official": "\u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u041a\u0443\u0432\u0435\u0439\u0442", "common": "\u041a\u0443\u0432\u0435\u0439\u0442"},
+			"slk": {"official": "Kuvajtsk\u00fd \u0161t\u00e1t", "common": "Kuvajt"},
 			"spa": {"official": "Estado de Kuwait", "common": "Kuwait"},
-			"svk": {"official": "Kuvajtsk\u00fd \u0161t\u00e1t", "common": "Kuvajt"},
 			"fin": {"official": "Kuwaitin valtio", "common": "Kuwait"},
 			"zho": {"official": "\u79D1\u5A01\u7279\u56FD", "common": "\u79D1\u5A01\u7279"}
 		},
@@ -6040,8 +6040,8 @@
 			"nld": {"official": "Lao Democratische Volksrepubliek", "common": "Laos"},
 			"por": {"official": "Laos, Rep\u00fablica Democr\u00e1tica", "common": "Laos"},
 			"rus": {"official": "\u041b\u0430\u043e\u0441\u0441\u043a\u0430\u044f \u041d\u0430\u0440\u043e\u0434\u043d\u043e-\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u041b\u0430\u043e\u0441"},
+			"slk": {"official": "Laosk\u00e1 \u013eudovodemokratick\u00e1 republika", "common": "Laos"},
 			"spa": {"official": "Rep\u00fablica Democr\u00e1tica Popular Lao", "common": "Laos"},
-			"svk": {"official": "Laosk\u00e1 \u013eudovodemokratick\u00e1 republika", "common": "Laos"},
 			"fin": {"official": "Laosin demokraattinen kansantasavalta", "common": "Laos"},
 			"zho": {"official": "\u8001\u631D\u4EBA\u6C11\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u8001\u631D"}
 		},
@@ -6090,8 +6090,8 @@
 			"nld": {"official": "Libanese Republiek", "common": "Libanon"},
 			"por": {"official": "Rep\u00fablica Libanesa", "common": "L\u00edbano"},
 			"rus": {"official": "\u041b\u0438\u0432\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u041b\u0438\u0432\u0430\u043d"},
+			"slk": {"official": "Libanonsk\u00e1 republika", "common": "Libanon"},
 			"spa": {"official": "Rep\u00fablica Libanesa", "common": "L\u00edbano"},
-			"svk": {"official": "Libanonsk\u00e1 republika", "common": "Libanon"},
 			"fin": {"official": "Libanonin tasavalta", "common": "Libanon"},
 			"zho": {"official": "\u9ECE\u5DF4\u5AE9\u5171\u548C\u56FD", "common": "\u9ECE\u5DF4\u5AE9"}
 		},
@@ -6135,8 +6135,8 @@
 			"nld": {"official": "Republiek Liberia", "common": "Liberia"},
 			"por": {"official": "Rep\u00fablica da Lib\u00e9ria", "common": "Lib\u00e9ria"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041b\u0438\u0431\u0435\u0440\u0438\u044f", "common": "\u041b\u0438\u0431\u0435\u0440\u0438\u044f"},
+			"slk": {"official": "Lib\u00e9rijsk\u00e1 republika", "common": "Lib\u00e9ria"},
 			"spa": {"official": "Rep\u00fablica de Liberia", "common": "Liberia"},
-			"svk": {"official": "Lib\u00e9rijsk\u00e1 republika", "common": "Lib\u00e9ria"},
 			"fin": {"official": "Liberian tasavalta", "common": "Liberia"},
 			"zho": {"official": "\u5229\u6BD4\u91CC\u4E9A\u5171\u548C\u56FD", "common": "\u5229\u6BD4\u91CC\u4E9A"}
 		},
@@ -6180,8 +6180,8 @@
 			"nld": {"official": "Staat van Libi\u00eb", "common": "Libi\u00eb"},
 			"por": {"official": "Estado da L\u00edbia", "common": "L\u00edbia"},
 			"rus": {"official": "\u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u041b\u0438\u0432\u0438\u0438", "common": "\u041b\u0438\u0432\u0438\u044f"},
+			"slk": {"official": "L\u00edbya", "common": "L\u00edbya"},
 			"spa": {"official": "Estado de Libia", "common": "Libia"},
-			"svk": {"official": "L\u00edbya", "common": "L\u00edbya"},
 			"fin": {"official": "Libyan valtio", "common": "Libya"},
 			"zho": {"official": "\u5229\u6BD4\u4E9A\u56FD", "common": "\u5229\u6BD4\u4E9A"}
 		},
@@ -6225,8 +6225,8 @@
 			"nld": {"official": "Saint Lucia", "common": "Saint Lucia"},
 			"por": {"official": "Santa L\u00facia", "common": "Santa L\u00facia"},
 			"rus": {"official": "\u0421\u0435\u043d\u0442-\u041b\u044e\u0441\u0438\u044f", "common": "\u0421\u0435\u043d\u0442-\u041b\u044e\u0441\u0438\u044f"},
+			"slk": {"official": "Sv\u00e4t\u00e1 Lucia", "common": "Sv\u00e4t\u00e1 Lucia"},
 			"spa": {"official": "Santa Luc\u00eda", "common": "Santa Luc\u00eda"},
-			"svk": {"official": "Sv\u00e4t\u00e1 Lucia", "common": "Sv\u00e4t\u00e1 Lucia"},
 			"fin": {"official": "Saint Lucia", "common": "Saint Lucia"},
 			"zho": {"official": "\u5723\u5362\u897F\u4E9A", "common": "\u5723\u5362\u897F\u4E9A"}
 		},
@@ -6270,8 +6270,8 @@
 			"nld": {"official": "Vorstendom Liechtenstein", "common": "Liechtenstein"},
 			"por": {"official": "Principado de Liechtenstein", "common": "Liechtenstein"},
 			"rus": {"official": "\u041a\u043d\u044f\u0436\u0435\u0441\u0442\u0432\u043e \u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0435\u0439\u043d", "common": "\u041b\u0438\u0445\u0442\u0435\u043d\u0448\u0442\u0435\u0439\u043d"},
+			"slk": {"official": "Lichten\u0161tajnsk\u00e9 knie\u017eatstvo", "common": "Lichten\u0161tajnsko"},
 			"spa": {"official": "Principado de Liechtenstein", "common": "Liechtenstein"},
-			"svk": {"official": "Lichten\u0161tajnsk\u00e9 knie\u017eatstvo", "common": "Lichten\u0161tajnsko"},
 			"fin": {"official": "Liechensteinin ruhtinaskunta", "common": "Liechenstein"},
 			"zho": {"official": "\u5217\u652F\u6566\u58EB\u767B\u516C\u56FD", "common": "\u5217\u652F\u6566\u58EB\u767B"}
 		},
@@ -6320,8 +6320,8 @@
 			"nld": {"official": "Democratische Socialistische Republiek Sri Lanka", "common": "Sri Lanka"},
 			"por": {"official": "Rep\u00fablica Democr\u00e1tica Socialista do Sri Lanka", "common": "Sri Lanka"},
 			"rus": {"official": "\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0421\u043e\u0446\u0438\u0430\u043b\u0438\u0441\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0428\u0440\u0438-\u041b\u0430\u043d\u043a\u0430", "common": "\u0428\u0440\u0438-\u041b\u0430\u043d\u043a\u0430"},
+			"slk": {"official": "Sr\u00edlansk\u00e1 demokratick\u00e1 socialistick\u00e1 republika", "common": "Sr\u00ed Lanka"},
 			"spa": {"official": "Rep\u00fablica Democr\u00e1tica Socialista de Sri Lanka", "common": "Sri Lanka"},
-			"svk": {"official": "Sr\u00edlansk\u00e1 demokratick\u00e1 socialistick\u00e1 republika", "common": "Sr\u00ed Lanka"},
 			"fin": {"official": "Sri Lankan demokraattinen sosialistinen tasavalta", "common": "Sri Lanka"},
 			"zho": {"official": "\u65AF\u91CC\u5170\u5361\u6C11\u4E3B\u793E\u4F1A\u4E3B\u4E49\u5171\u548C\u56FD", "common": "\u65AF\u91CC\u5170\u5361"}
 		},
@@ -6370,8 +6370,8 @@
 			"nld": {"official": "Koninkrijk Lesotho", "common": "Lesotho"},
 			"por": {"official": "Reino do Lesoto", "common": "Lesoto"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u041b\u0435\u0441\u043e\u0442\u043e", "common": "\u041b\u0435\u0441\u043e\u0442\u043e"},
+			"slk": {"official": "Lesothsk\u00e9 kr\u00e1\u013eovstvo", "common": "Lesotho"},
 			"spa": {"official": "Reino de Lesotho", "common": "Lesotho"},
-			"svk": {"official": "Lesothsk\u00e9 kr\u00e1\u013eovstvo", "common": "Lesotho"},
 			"fin": {"official": "Lesothon kuningaskunta", "common": "Lesotho"},
 			"zho": {"official": "\u83B1\u7D22\u6258\u738B\u56FD", "common": "\u83B1\u7D22\u6258"}
 		},
@@ -6415,8 +6415,8 @@
 			"nld": {"official": "Republiek Litouwen", "common": "Litouwen"},
 			"por": {"official": "Rep\u00fablica da Litu\u00e2nia", "common": "Litu\u00e2nia"},
 			"rus": {"official": "\u041b\u0438\u0442\u043e\u0432\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u041b\u0438\u0442\u0432\u0430"},
+			"slk": {"official": "Litovsk\u00e1 republika", "common": "Litva"},
 			"spa": {"official": "Rep\u00fablica de Lituania", "common": "Lituania"},
-			"svk": {"official": "Litovsk\u00e1 republika", "common": "Litva"},
 			"fin": {"official": "Liettuan tasavalta", "common": "Liettua"},
 			"zho": {"official": "\u7ACB\u9676\u5B9B\u5171\u548C\u56FD", "common": "\u7ACB\u9676\u5B9B"}
 		},
@@ -6470,8 +6470,8 @@
 			"nld": {"official": "Groothertogdom Luxemburg", "common": "Luxemburg"},
 			"por": {"official": "Gr\u00e3o-Ducado do Luxemburgo", "common": "Luxemburgo"},
 			"rus": {"official": "\u0412\u0435\u043b\u0438\u043a\u043e\u0435 \u0413\u0435\u0440\u0446\u043e\u0433\u0441\u0442\u0432\u043e \u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433", "common": "\u041b\u044e\u043a\u0441\u0435\u043c\u0431\u0443\u0440\u0433"},
+			"slk": {"official": "Luxembursk\u00e9 ve\u013ekovojvodstvo", "common": "Luxembursko"},
 			"spa": {"official": "Gran Ducado de Luxemburgo", "common": "Luxemburgo"},
-			"svk": {"official": "Luxembursk\u00e9 ve\u013ekovojvodstvo", "common": "Luxembursko"},
 			"fin": {"official": "Luxemburgin suurherttuakunta", "common": "Luxemburg"},
 			"zho": {"official": "\u5362\u68EE\u5821\u5927\u516C\u56FD", "common": "\u5362\u68EE\u5821"}
 		},
@@ -6515,8 +6515,8 @@
 			"nld": {"official": "Republiek Letland", "common": "Letland"},
 			"por": {"official": "Rep\u00fablica da Let\u00f3nia", "common": "Let\u00f3nia"},
 			"rus": {"official": "\u041b\u0430\u0442\u0432\u0438\u0439\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u041b\u0430\u0442\u0432\u0438\u044f"},
+			"slk": {"official": "Loty\u0161sk\u00e1 republika", "common": "Loty\u0161sko"},
 			"spa": {"official": "Rep\u00fablica de Letonia", "common": "Letonia"},
-			"svk": {"official": "Loty\u0161sk\u00e1 republika", "common": "Loty\u0161sko"},
 			"fin": {"official": "Latvian tasavalta", "common": "Latvia"},
 			"zho": {"official": "\u62C9\u8131\u7EF4\u4E9A\u5171\u548C\u56FD", "common": "\u62C9\u8131\u7EF4\u4E9A"}
 		},
@@ -6565,8 +6565,8 @@
 			"nld": {"official": "Speciale Administratieve Regio Macau van de Volksrepubliek China", "common": "Macao"},
 			"por": {"official": "Macau Regi\u00e3o Administrativa Especial da Rep\u00fablica Popular da China", "common": "Macau"},
 			"rus": {"official": "\u0421\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u044b\u0439 \u0430\u0434\u043c\u0438\u043d\u0438\u0441\u0442\u0440\u0430\u0442\u0438\u0432\u043d\u044b\u0439 \u0440\u0430\u0439\u043e\u043d \u041c\u0430\u043a\u0430\u043e \u041a\u0438\u0442\u0430\u0439\u0441\u043a\u043e\u0439 \u041d\u0430\u0440\u043e\u0434\u043d\u043e\u0439 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438 \u041a\u0438\u0442\u0430\u0439", "common": "\u041c\u0430\u043a\u0430\u043e"},
+			"slk": {"official": "Macao, \u0160peci\u00e0lna administrat\u00edvna oblas\u0166", "common": "Macao"},
 			"spa": {"official": "Macao, Regi\u00f3n Administrativa Especial de la Rep\u00fablica Popular China", "common": "Macao"},
-			"svk": {"official": "Macao, \u0160peci\u00e0lna administrat\u00edvna oblas\u0166", "common": "Macao"},
 			"fin": {"official": "Macaon Kiinan kansantasavallan erityishallintoalue", "common": "Macao"}
 		},
 		"latlng": [22.16666666, 113.55],
@@ -6609,8 +6609,8 @@
 			"nld": {"official": "Saint Martin", "common": "Saint-Martin"},
 			"por": {"official": "saint Martin", "common": "S\u00e3o Martinho"},
 			"rus": {"official": "\u0421\u0435\u043d-\u041c\u0430\u0440\u0442\u0435\u043d", "common": "\u0421\u0435\u043d-\u041c\u0430\u0440\u0442\u0435\u043d"},
+			"slk": {"official": "Saint-Martin", "common": "Saint-Martin"},
 			"spa": {"official": "Saint Martin", "common": "Saint Martin"},
-			"svk": {"official": "Saint-Martin", "common": "Saint-Martin"},
 			"fin": {"official": "Saint-Martin", "common": "Saint-Martin"},
 			"zho": {"official": "\u5723\u9A6C\u4E01", "common": "\u5723\u9A6C\u4E01"}
 		},
@@ -6659,8 +6659,8 @@
 			"nld": {"official": "Koninkrijk Marokko", "common": "Marokko"},
 			"por": {"official": "Reino de Marrocos", "common": "Marrocos"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u041c\u0430\u0440\u043e\u043a\u043a\u043e", "common": "\u041c\u0430\u0440\u043e\u043a\u043a\u043e"},
+			"slk": {"official": "Marock\u00e9 knie\u017eatstvo", "common": "Maroko"},
 			"spa": {"official": "Reino de Marruecos", "common": "Marruecos"},
-			"svk": {"official": "Marock\u00e9 knie\u017eatstvo", "common": "Maroko"},
 			"fin": {"official": "Marokon kuningaskunta", "common": "Marokko"},
 			"zho": {"official": "\u6469\u6D1B\u54E5\u738B\u56FD", "common": "\u6469\u6D1B\u54E5"}
 		},
@@ -6704,8 +6704,8 @@
 			"nld": {"official": "Vorstendom Monaco", "common": "Monaco"},
 			"por": {"official": "Principado do M\u00f3naco", "common": "M\u00f3naco"},
 			"rus": {"official": "\u041a\u043d\u044f\u0436\u0435\u0441\u0442\u0432\u043e \u041c\u043e\u043d\u0430\u043a\u043e", "common": "\u041c\u043e\u043d\u0430\u043a\u043e"},
+			"slk": {"official": "Monack\u00e9 knie\u017eatstvo", "common": "Monako"},
 			"spa": {"official": "Principado de M\u00f3naco", "common": "M\u00f3naco"},
-			"svk": {"official": "Monack\u00e9 knie\u017eatstvo", "common": "Monako"},
 			"fin": {"official": "Monacon ruhtinaskunta", "common": "Monaco"},
 			"zho": {"official": "\u6469\u7EB3\u54E5\u516C\u56FD", "common": "\u6469\u7EB3\u54E5"}
 		},
@@ -6749,8 +6749,8 @@
 			"nld": {"official": "Republiek Moldavi\u00eb", "common": "Moldavi\u00eb"},
 			"por": {"official": "Rep\u00fablica da Mold\u00e1via", "common": "Mold\u00e1via"},
 			"rus": {"official": "\u041c\u043e\u043b\u0434\u043e\u0432\u0430", "common": "\u041c\u043e\u043b\u0434\u0430\u0432\u0438\u044f"},
+			"slk": {"official": "Moldavsk\u00e1 republika", "common": "Moldavsko"},
 			"spa": {"official": "Rep\u00fablica de Moldova", "common": "Moldavia"},
-			"svk": {"official": "Moldavsk\u00e1 republika", "common": "Moldavsko"},
 			"fin": {"official": "Moldovan tasavalta", "common": "Moldova"},
 			"zho": {"official": "\u6469\u5C14\u591A\u74E6\u5171\u548C\u56FD", "common": "\u6469\u5C14\u591A\u74E6"}
 		},
@@ -6799,8 +6799,8 @@
 			"nld": {"official": "Republiek Madagaskar", "common": "Madagaskar"},
 			"por": {"official": "Rep\u00fablica de Madag\u00e1scar", "common": "Madag\u00e1scar"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u0434\u0430\u0433\u0430\u0441\u043a\u0430\u0440", "common": "\u041c\u0430\u0434\u0430\u0433\u0430\u0441\u043a\u0430\u0440"},
+			"slk": {"official": "Madagaskarsk\u00e1 republika", "common": "Madagaskar"},
 			"spa": {"official": "Rep\u00fablica de Madagascar", "common": "Madagascar"},
-			"svk": {"official": "Madagaskarsk\u00e1 republika", "common": "Madagaskar"},
 			"fin": {"official": "Madagaskarin tasavalta", "common": "Madagaskar"},
 			"zho": {"official": "\u9A6C\u8FBE\u52A0\u65AF\u52A0\u5171\u548C\u56FD", "common": "\u9A6C\u8FBE\u52A0\u65AF\u52A0"}
 		},
@@ -6843,8 +6843,8 @@
 			"jpn": {"official": "\u30e2\u30eb\u30c7\u30a3\u30d6\u5171\u548c\u56fd", "common": "\u30e2\u30eb\u30c7\u30a3\u30d6"},
 			"nld": {"official": "Republiek van de Malediven", "common": "Maldiven"},
 			"por": {"official": "Rep\u00fablica das Maldivas", "common": "Maldivas"},
+			"slk": {"official": "Rep\u00fablica de las Maldivas", "common": "Maldivas"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043b\u044c\u0434\u0438\u0432\u044b", "common": "\u041c\u0430\u043b\u044c\u0434\u0438\u0432\u044b"},
-			"spa": {"official": "Rep\u00fablica de las Maldivas", "common": "Maldivas"},
 			"svk": {"official": "Maldivsk\u00e1 republika", "common": "Maldivy"},
 			"fin": {"official": "Malediivien tasavalta", "common": "Malediivit"},
 			"zho": {"official": "\u9A6C\u5C14\u4EE3\u592B\u5171\u548C\u56FD", "common": "\u9A6C\u5C14\u4EE3\u592B"}
@@ -6889,8 +6889,8 @@
 			"nld": {"official": "Verenigde Mexicaanse Staten", "common": "Mexico"},
 			"por": {"official": "Estados Unidos Mexicanos", "common": "M\u00e9xico"},
 			"rus": {"official": "\u041c\u0435\u043a\u0441\u0438\u043a\u0430\u043d\u0441\u043a\u0438\u0445 \u0421\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u043d\u044b\u0445 \u0428\u0442\u0430\u0442\u043e\u0432", "common": "\u041c\u0435\u043a\u0441\u0438\u043a\u0430"},
+			"slk": {"official": "Spojen\u00e9 \u0161t\u00e1\u0161y mexick\u00e9", "common": "Mexiko"},
 			"spa": {"official": "Estados Unidos Mexicanos", "common": "M\u00e9xico"},
-			"svk": {"official": "Spojen\u00e9 \u0161t\u00e1\u0161y mexick\u00e9", "common": "Mexiko"},
 			"fin": {"official": "Meksikon yhdysvallat", "common": "Meksiko"},
 			"zho": {"official": "\u58A8\u897F\u54E5\u5408\u4F17\u56FD", "common": "\u58A8\u897F\u54E5"}
 		},
@@ -6939,8 +6939,8 @@
 			"nld": {"official": "Republiek van de Marshall-eilanden", "common": "Marshalleilanden"},
 			"por": {"official": "Rep\u00fablica das Ilhas Marshall", "common": "Ilhas Marshall"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u0440\u0448\u0430\u043b\u043b\u043e\u0432\u044b \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u041c\u0430\u0440\u0448\u0430\u043b\u043b\u043e\u0432\u044b \u041e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Republika Marshallov\u00fdch ostrovov", "common": "Marshallove ostrovy"},
 			"spa": {"official": "Rep\u00fablica de las Islas Marshall", "common": "Islas Marshall"},
-			"svk": {"official": "Republika Marshallov\u00fdch ostrovov", "common": "Marshallove ostrovy"},
 			"fin": {"official": "Marshallinsaarten tasavalta", "common": "Marshallinsaaret"},
 			"zho": {"official": "\u9A6C\u7ECD\u5C14\u7FA4\u5C9B\u5171\u548C\u56FD", "common": "\u9A6C\u7ECD\u5C14\u7FA4\u5C9B"}
 		},
@@ -6984,8 +6984,8 @@
 			"nld": {"official": "Republic of Macedonia", "common": "Macedoni\u00eb"},
 			"por": {"official": "Rep\u00fablica da Maced\u00f3nia", "common": "Maced\u00f3nia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f", "common": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"},
+			"slk": {"official": "Maced\u00f3nska republika", "common": "Maced\u00f3nsko"},
 			"spa": {"official": "Rep\u00fablica de Macedonia", "common": "Macedonia"},
-			"svk": {"official": "Maced\u00f3nska republika", "common": "Maced\u00f3nsko"},
 			"fin": {"official": "Makedonian tasavalta", "common": "Makedonia"},
 			"zho": {"official": "\u9A6C\u5176\u987F\u5171\u548C\u56FD", "common": "\u9A6C\u5176\u987F"}
 		},
@@ -7029,8 +7029,8 @@
 			"nld": {"official": "Republiek Mali", "common": "Mali"},
 			"por": {"official": "Rep\u00fablica do Mali", "common": "Mali"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043b\u0438", "common": "\u041c\u0430\u043b\u0438"},
+			"slk": {"official": "Malijsk\u00e1 republika", "common": "Mali"},
 			"spa": {"official": "Rep\u00fablica de Mal\u00ed", "common": "Mali"},
-			"svk": {"official": "Malijsk\u00e1 republika", "common": "Mali"},
 			"fin": {"official": "Malin tasavalta", "common": "Mali"},
 			"zho": {"official": "\u9A6C\u91CC\u5171\u548C\u56FD", "common": "\u9A6C\u91CC"}
 		},
@@ -7079,8 +7079,8 @@
 			"nld": {"official": "Republiek Malta", "common": "Malta"},
 			"por": {"official": "Rep\u00fablica de Malta", "common": "Malta"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043b\u044c\u0442\u0430", "common": "\u041c\u0430\u043b\u044c\u0442\u0430"},
+			"slk": {"official": "Maltsk\u00e1 republika", "common": "Malta"},
 			"spa": {"official": "Rep\u00fablica de Malta", "common": "Malta"},
-			"svk": {"official": "Maltsk\u00e1 republika", "common": "Malta"},
 			"fin": {"official": "Maltan tasavalta", "common": "Malta"},
 			"zho": {"official": "\u9A6C\u8033\u4ED6\u5171\u548C\u56FD", "common": "\u9A6C\u8033\u4ED6"}
 		},
@@ -7124,8 +7124,8 @@
 			"nld": {"official": "Republiek van de Unie van Myanmar", "common": "Myanmar"},
 			"por": {"official": "Rep\u00fablica da Uni\u00e3o de Myanmar", "common": "Myanmar"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u043e\u044e\u0437\u0430 \u041c\u044c\u044f\u043d\u043c\u0430", "common": "\u041c\u044c\u044f\u043d\u043c\u0430"},
+			"slk": {"official": "Mjanmarsk\u00e1 zv\u00e4zov\u00e1 republika", "common": "Mjanmarsko"},
 			"spa": {"official": "Rep\u00fablica de la Uni\u00f3n de Myanmar", "common": "Myanmar"},
-			"svk": {"official": "Mjanmarsk\u00e1 zv\u00e4zov\u00e1 republika", "common": "Mjanmarsko"},
 			"fin": {"official": "Myanmarin liiton tasavalta", "common": "Myanmar"},
 			"zho": {"official": "\u7F05\u7538\u8054\u90A6\u5171\u548C\u56FD", "common": "\u7F05\u7538"}
 		},
@@ -7169,8 +7169,8 @@
 			"nld": {"official": "Montenegro", "common": "Montenegro"},
 			"por": {"official": "Montenegro", "common": "Montenegro"},
 			"rus": {"official": "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f", "common": "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"},
+			"slk": {"official": "\u010cierna Hora", "common": "\u010cierna Hora"},
 			"spa": {"official": "Montenegro", "common": "Montenegro"},
-			"svk": {"official": "\u010cierna Hora", "common": "\u010cierna Hora"},
 			"fin": {"official": "Montenegro", "common": "Montenegro"},
 			"zho": {"official": "\u9ED1\u5C71", "common": "\u9ED1\u5C71"}
 		},
@@ -7214,8 +7214,8 @@
 			"nld": {"official": "Mongoli\u00eb", "common": "Mongoli\u00eb"},
 			"por": {"official": "Mong\u00f3lia", "common": "Mong\u00f3lia"},
 			"rus": {"official": "\u041c\u043e\u043d\u0433\u043e\u043b\u0438\u044f", "common": "\u041c\u043e\u043d\u0433\u043e\u043b\u0438\u044f"},
+			"slk": {"official": "Mongolsko", "common": "Mongolsko"},
 			"spa": {"official": "Mongolia", "common": "Mongolia"},
-			"svk": {"official": "Mongolsko", "common": "Mongolsko"},
 			"fin": {"official": "Mongolian tasavalta", "common": "Mongolia"},
 			"zho": {"official": "\u8499\u53E4", "common": "\u8499\u53E4"}
 		},
@@ -7269,8 +7269,8 @@
 			"nld": {"official": "Commonwealth van de Noordelijke Marianen", "common": "Noordelijke Marianeneilanden"},
 			"por": {"official": "Comunidade das Ilhas Marianas do Norte", "common": "Marianas Setentrionais"},
 			"rus": {"official": "\u0421\u043e\u0434\u0440\u0443\u0436\u0435\u0441\u0442\u0432\u043e \u0421\u0435\u0432\u0435\u0440\u043d\u044b\u0445 \u041c\u0430\u0440\u0438\u0430\u043d\u0441\u043a\u0438\u0445 \u043e\u0441\u0442\u0440\u043e\u0432\u043e\u0432", "common": "\u0421\u0435\u0432\u0435\u0440\u043d\u044b\u0435 \u041c\u0430\u0440\u0438\u0430\u043d\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Spolo\u010denstvo ostrovov Severn\u00e9 Mari\u00e1ny", "common": "Severn\u00e9 Mari\u00e1ny"},
 			"spa": {"official": "Mancomunidad de las Islas Marianas del Norte", "common": "Islas Marianas del Norte"},
-			"svk": {"official": "Spolo\u010denstvo ostrovov Severn\u00e9 Mari\u00e1ny", "common": "Severn\u00e9 Mari\u00e1ny"},
 			"fin": {"official": "Pohjois-Mariaanit", "common": "Pohjois-Mariaanit"},
 			"zho": {"official": "\u5317\u9A6C\u91CC\u4E9A\u7EB3\u7FA4\u5C9B", "common": "\u5317\u9A6C\u91CC\u4E9A\u7EB3\u7FA4\u5C9B"}
 		},
@@ -7314,8 +7314,8 @@
 			"nld": {"official": "Republiek Mozambique", "common": "Mozambique"},
 			"por": {"official": "Rep\u00fablica de Mo\u00e7ambique", "common": "Mo\u00e7ambique"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u043e\u0437\u0430\u043c\u0431\u0438\u043a", "common": "\u041c\u043e\u0437\u0430\u043c\u0431\u0438\u043a"},
+			"slk": {"official": "Mozambick\u00e1 republika", "common": "Mozambik"},
 			"spa": {"official": "Rep\u00fablica de Mozambique", "common": "Mozambique"},
-			"svk": {"official": "Mozambick\u00e1 republika", "common": "Mozambik"},
 			"fin": {"official": "Mosambikin tasavalta", "common": "Mosambik"},
 			"zho": {"official": "\u83AB\u6851\u6BD4\u514B\u5171\u548C\u56FD", "common": "\u83AB\u6851\u6BD4\u514B"}
 		},
@@ -7359,8 +7359,8 @@
 			"nld": {"official": "Islamitische Republiek Mauritani\u00eb", "common": "Mauritani\u00eb"},
 			"por": {"official": "Rep\u00fablica Isl\u00e2mica da Maurit\u00e2nia", "common": "Maurit\u00e2nia"},
 			"rus": {"official": "\u0418\u0441\u043b\u0430\u043c\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u0432\u0440\u0438\u0442\u0430\u043d\u0438\u044f", "common": "\u041c\u0430\u0432\u0440\u0438\u0442\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "Maurit\u00e1nska islamsk\u00e1 republika", "common": "Maurit\u00e1nia"},
 			"spa": {"official": "Rep\u00fablica Isl\u00e1mica de Mauritania", "common": "Mauritania"},
-			"svk": {"official": "Maurit\u00e1nska islamsk\u00e1 republika", "common": "Maurit\u00e1nia"},
 			"fin": {"official": "Mauritanian islamilainen tasavalta", "common": "Mauritania"},
 			"zho": {"official": "\u6BDB\u91CC\u5854\u5C3C\u4E9A\u4F0A\u65AF\u5170\u5171\u548C\u56FD", "common": "\u6BDB\u91CC\u5854\u5C3C\u4E9A"}
 		},
@@ -7404,8 +7404,8 @@
 			"nld": {"official": "Montserrat", "common": "Montserrat"},
 			"por": {"official": "Montserrat", "common": "Montserrat"},
 			"rus": {"official": "\u041c\u043e\u043d\u0442\u0441\u0435\u0440\u0440\u0430\u0442", "common": "\u041c\u043e\u043d\u0442\u0441\u0435\u0440\u0440\u0430\u0442"},
+			"slk": {"official": "Montserrat", "common": "Montserrat"},
 			"spa": {"official": "Montserrat", "common": "Montserrat"},
-			"svk": {"official": "Montserrat", "common": "Montserrat"},
 			"fin": {"official": "Montserrat", "common": "Montserrat"},
 			"zho": {"official": "\u8499\u7279\u585E\u62C9\u7279", "common": "\u8499\u7279\u585E\u62C9\u7279"}
 		},
@@ -7504,8 +7504,8 @@
 			"nld": {"official": "Republiek Mauritius", "common": "Mauritius"},
 			"por": {"official": "Rep\u00fablica das Maur\u00edcias", "common": "Maur\u00edcio"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u0432\u0440\u0438\u043a\u0438\u0439", "common": "\u041c\u0430\u0432\u0440\u0438\u043a\u0438\u0439"},
+			"slk": {"official": "Maur\u00edcijsk\u00e1 republika", "common": "Maur\u00edcius"},
 			"spa": {"official": "Rep\u00fablica de Mauricio", "common": "Mauricio"},
-			"svk": {"official": "Maur\u00edcijsk\u00e1 republika", "common": "Maur\u00edcius"},
 			"fin": {"official": "Mauritiuksen tasavalta", "common": "Mauritius"},
 			"zho": {"official": "\u6BDB\u91CC\u6C42\u65AF\u5171\u548C\u56FD", "common": "\u6BDB\u91CC\u6C42\u65AF"}
 		},
@@ -7554,8 +7554,8 @@
 			"nld": {"official": "Republiek Malawi", "common": "Malawi"},
 			"por": {"official": "Rep\u00fablica do Malawi", "common": "Malawi"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043b\u0430\u0432\u0438", "common": "\u041c\u0430\u043b\u0430\u0432\u0438"},
+			"slk": {"official": "Malawijsk\u00e1 republika", "common": "Malawi"},
 			"spa": {"official": "Rep\u00fablica de Malawi", "common": "Malawi"},
-			"svk": {"official": "Malawijsk\u00e1 republika", "common": "Malawi"},
 			"fin": {"official": "Malawin tasavalta", "common": "Malawi"},
 			"zho": {"official": "\u9A6C\u62C9\u7EF4\u5171\u548C\u56FD", "common": "\u9A6C\u62C9\u7EF4"}
 		},
@@ -7604,8 +7604,8 @@
 			"nld": {"official": "Maleisi\u00eb", "common": "Maleisi\u00eb"},
 			"por": {"official": "Mal\u00e1sia", "common": "Mal\u00e1sia"},
 			"rus": {"official": "\u041c\u0430\u043b\u0430\u0439\u0437\u0438\u044f", "common": "\u041c\u0430\u043b\u0430\u0439\u0437\u0438\u044f"},
+			"slk": {"official": "Malajzia", "common": "Malajzia"},
 			"spa": {"official": "Malasia", "common": "Malasia"},
-			"svk": {"official": "Malajzia", "common": "Malajzia"},
 			"fin": {"official": "Malesia", "common": "Malesia"},
 			"zho": {"official": "\u9A6C\u6765\u897F\u4E9A", "common": "\u9A6C\u6765\u897F\u4E9A"}
 		},
@@ -7649,8 +7649,8 @@
 			"nld": {"official": "Afdeling Mayotte", "common": "Mayotte"},
 			"por": {"official": "Departamento de Mayotte", "common": "Mayotte"},
 			"rus": {"official": "\u0414\u0435\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442 \u041c\u0430\u0439\u043e\u0442\u0442\u0430", "common": "\u041c\u0430\u0439\u043e\u0442\u0442\u0430"},
+			"slk": {"official": "Department Mayotte", "common": "Mayotte"},
 			"spa": {"official": "Departamento de Mayotte", "common": "Mayotte"},
-			"svk": {"official": "Department Mayotte", "common": "Mayotte"},
 			"fin": {"official": "Mayotte", "common": "Mayotte"},
 			"zho": {"official": "\u9A6C\u7EA6\u7279", "common": "\u9A6C\u7EA6\u7279"}
 		},
@@ -7734,8 +7734,8 @@
 			"nld": {"official": "Republiek Namibi\u00eb", "common": "Namibi\u00eb"},
 			"por": {"official": "Rep\u00fablica da Nam\u00edbia", "common": "Nam\u00edbia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041d\u0430\u043c\u0438\u0431\u0438\u044f", "common": "\u041d\u0430\u043c\u0438\u0431\u0438\u044f"},
+			"slk": {"official": "Nam\u00edbijsk\u00e1 republika", "common": "Nam\u00edbia"},
 			"spa": {"official": "Rep\u00fablica de Namibia", "common": "Namibia"},
-			"svk": {"official": "Nam\u00edbijsk\u00e1 republika", "common": "Nam\u00edbia"},
 			"fin": {"official": "Namibian tasavalta", "common": "Namibia"},
 			"zho": {"official": "\u7EB3\u7C73\u6BD4\u4E9A\u5171\u548C\u56FD", "common": "\u7EB3\u7C73\u6BD4\u4E9A"}
 		},
@@ -7779,8 +7779,8 @@
 			"nld": {"official": "nieuw -Caledoni\u00eb", "common": "Nieuw-Caledoni\u00eb"},
 			"por": {"official": "New Caledonia", "common": "Nova Caled\u00f3nia"},
 			"rus": {"official": "\u041d\u043e\u0432\u0430\u044f \u041a\u0430\u043b\u0435\u0434\u043e\u043d\u0438\u044f", "common": "\u041d\u043e\u0432\u0430\u044f \u041a\u0430\u043b\u0435\u0434\u043e\u043d\u0438\u044f"},
+			"slk": {"official": "Nov\u00e1 Kaled\u00f3nia", "common": "Nov\u00e1 Kaled\u00f3nia"},
 			"spa": {"official": "nueva Caledonia", "common": "Nueva Caledonia"},
-			"svk": {"official": "Nov\u00e1 Kaled\u00f3nia", "common": "Nov\u00e1 Kaled\u00f3nia"},
 			"fin": {"official": "Uusi-Kaledonia", "common": "Uusi-Kaledonia"},
 			"zho": {"official": "\u65B0\u5580\u91CC\u591A\u5C3C\u4E9A", "common": "\u65B0\u5580\u91CC\u591A\u5C3C\u4E9A"}
 		},
@@ -7824,8 +7824,8 @@
 			"nld": {"official": "Republiek Niger", "common": "Niger"},
 			"por": {"official": "Rep\u00fablica do N\u00edger", "common": "N\u00edger"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041d\u0438\u0433\u0435\u0440", "common": "\u041d\u0438\u0433\u0435\u0440"},
+			"slk": {"official": "Nig\u00e9rsk\u00e1 republika", "common": "Niger"},
 			"spa": {"official": "Rep\u00fablica de N\u00edger", "common": "N\u00edger"},
-			"svk": {"official": "Nig\u00e9rsk\u00e1 republika", "common": "Niger"},
 			"fin": {"official": "Nigerin tasavalta", "common": "Niger"},
 			"zho": {"official": "\u5C3C\u65E5\u5C14\u5171\u548C\u56FD", "common": "\u5C3C\u65E5\u5C14"}
 		},
@@ -7874,8 +7874,8 @@
 			"nld": {"official": "Grondgebied van Norfolk Island", "common": "Norfolkeiland"},
 			"por": {"official": "Territ\u00f3rio da Ilha Norfolk", "common": "Ilha Norfolk"},
 			"rus": {"official": "\u0422\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u044f \u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u041d\u043e\u0440\u0444\u043e\u043b\u043a", "common": "\u041d\u043e\u0440\u0444\u043e\u043b\u043a"},
+			"slk": {"official": "Terit\u00f3rium ostrova Norfolk", "common": "Norfolk"},
 			"spa": {"official": "Territorio de la Isla Norfolk", "common": "Isla de Norfolk"},
-			"svk": {"official": "Terit\u00f3rium ostrova Norfolk", "common": "Norfolk"},
 			"fin": {"official": "Norfolkinsaaren territorio", "common": "Norfolkinsaari"},
 			"zho": {"official": "\u8BFA\u798F\u514B\u5C9B", "common": "\u8BFA\u798F\u514B\u5C9B"}
 		},
@@ -7919,8 +7919,8 @@
 			"nld": {"official": "Federale Republiek Nigeria", "common": "Nigeria"},
 			"por": {"official": "Rep\u00fablica Federal da Nig\u00e9ria", "common": "Nig\u00e9ria"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041d\u0438\u0433\u0435\u0440\u0438\u044f", "common": "\u041d\u0438\u0433\u0435\u0440\u0438\u044f"},
+			"slk": {"official": "Nig\u00e9rijsk\u00e1 federat\u00edvna republika", "common": "Nig\u00e9ria"},
 			"spa": {"official": "Rep\u00fablica Federal de Nigeria", "common": "Nigeria"},
-			"svk": {"official": "Nig\u00e9rijsk\u00e1 federat\u00edvna republika", "common": "Nig\u00e9ria"},
 			"fin": {"official": "Nigerian liittotasavalta", "common": "Nigeria"},
 			"zho": {"official": "\u5C3C\u65E5\u5229\u4E9A\u8054\u90A6\u5171\u548C\u56FD", "common": "\u5C3C\u65E5\u5229\u4E9A"}
 		},
@@ -7964,8 +7964,8 @@
 			"nld": {"official": "Republiek Nicaragua", "common": "Nicaragua"},
 			"por": {"official": "Rep\u00fablica da Nicar\u00e1gua", "common": "Nicar\u00e1gua"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041d\u0438\u043a\u0430\u0440\u0430\u0433\u0443\u0430", "common": "\u041d\u0438\u043a\u0430\u0440\u0430\u0433\u0443\u0430"},
+			"slk": {"official": "Nikaragujsk\u00e1 republika", "common": "Nikaragua"},
 			"spa": {"official": "Rep\u00fablica de Nicaragua", "common": "Nicaragua"},
-			"svk": {"official": "Nikaragujsk\u00e1 republika", "common": "Nikaragua"},
 			"fin": {"official": "Nicaraguan tasavalta", "common": "Nicaragua"},
 			"zho": {"official": "\u5C3C\u52A0\u62C9\u74DC\u5171\u548C\u56FD", "common": "\u5C3C\u52A0\u62C9\u74DC"}
 		},
@@ -8014,8 +8014,8 @@
 			"nld": {"official": "Niue", "common": "Niue"},
 			"por": {"official": "Niue", "common": "Niue"},
 			"rus": {"official": "\u041d\u0438\u0443\u044d", "common": "\u041d\u0438\u0443\u044d"},
+			"slk": {"official": "Niue", "common": "Niue"},
 			"spa": {"official": "Niue", "common": "Niue"},
-			"svk": {"official": "Niue", "common": "Niue"},
 			"fin": {"official": "Niue", "common": "Niue"},
 			"zho": {"official": "\u7EBD\u57C3", "common": "\u7EBD\u57C3"}
 		},
@@ -8059,8 +8059,8 @@
 			"nld": {"official": "Nederland", "common": "Nederland"},
 			"por": {"official": "Holanda", "common": "Holanda"},
 			"rus": {"official": "\u041d\u0438\u0434\u0435\u0440\u043b\u0430\u043d\u0434\u044b", "common": "\u041d\u0438\u0434\u0435\u0440\u043b\u0430\u043d\u0434\u044b"},
+			"slk": {"official": "Holandsk\u00e9 kr\u00e1\u013eovstvo", "common": "Holansko"},
 			"spa": {"official": "Pa\u00edses Bajos", "common": "Pa\u00edses Bajos"},
-			"svk": {"official": "Holandsk\u00e9 kr\u00e1\u013eovstvo", "common": "Holansko"},
 			"fin": {"official": "Alankomaat", "common": "Alankomaat"},
 			"zho": {"official": "\u8377\u5170", "common": "\u8377\u5170"}
 		},
@@ -8114,8 +8114,8 @@
 			"nld": {"official": "Koninkrijk Noorwegen", "common": "Noorwegen"},
 			"por": {"official": "Reino da Noruega", "common": "Noruega"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u041d\u043e\u0440\u0432\u0435\u0433\u0438\u044f", "common": "\u041d\u043e\u0440\u0432\u0435\u0433\u0438\u044f"},
+			"slk": {"official": "N\u00f3rske kr\u00e1\u013eovstvo", "common": "N\u00f3rsko"},
 			"spa": {"official": "Reino de Noruega", "common": "Noruega"},
-			"svk": {"official": "N\u00f3rske kr\u00e1\u013eovstvo", "common": "N\u00f3rsko"},
 			"fin": {"official": "Norjan kuningaskunta", "common": "Norja"},
 			"zho": {"official": "\u632A\u5A01\u738B\u56FD", "common": "\u632A\u5A01"}
 		},
@@ -8159,8 +8159,8 @@
 			"nld": {"official": "Federale Democratische Republiek Nepal", "common": "Nepal"},
 			"por": {"official": "Rep\u00fablica Democr\u00e1tica Federal do Nepal", "common": "Nepal"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u0430\u044f \u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041d\u0435\u043f\u0430\u043b", "common": "\u041d\u0435\u043f\u0430\u043b"},
+			"slk": {"official": "Nep\u00e1lska federat\u00edvna demokratick\u00e1 republika", "common": "Nep\u00e1l"},
 			"spa": {"official": "Rep\u00fablica Democr\u00e1tica Federal de Nepal", "common": "Nepal"},
-			"svk": {"official": "Nep\u00e1lska federat\u00edvna demokratick\u00e1 republika", "common": "Nep\u00e1l"},
 			"fin": {"official": "Nepalin demokraattinen liittotasavalta", "common": "Nepal"},
 			"zho": {"official": "\u5C3C\u6CCA\u5C14\u8054\u90A6\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u5C3C\u6CCA\u5C14"}
 		},
@@ -8209,8 +8209,8 @@
 			"nld": {"official": "Republiek Nauru", "common": "Nauru"},
 			"por": {"official": "Rep\u00fablica de Nauru", "common": "Nauru"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041d\u0430\u0443\u0440\u0443", "common": "\u041d\u0430\u0443\u0440\u0443"},
+			"slk": {"official": "Naursk\u00e1 republika", "common": "Nauru"},
 			"spa": {"official": "Rep\u00fablica de Nauru", "common": "Nauru"},
-			"svk": {"official": "Naursk\u00e1 republika", "common": "Nauru"},
 			"fin": {"official": "Naurun tasavalta", "common": "Nauru"},
 			"zho": {"official": "\u7459\u9C81\u5171\u548C\u56FD", "common": "\u7459\u9C81"}
 		},
@@ -8264,8 +8264,8 @@
 			"nld": {"official": "Nieuw Zeeland", "common": "Nieuw-Zeeland"},
 			"por": {"official": "nova Zel\u00e2ndia", "common": "Nova Zel\u00e2ndia"},
 			"rus": {"official": "\u041d\u043e\u0432\u0430\u044f \u0417\u0435\u043b\u0430\u043d\u0434\u0438\u044f", "common": "\u041d\u043e\u0432\u0430\u044f \u0417\u0435\u043b\u0430\u043d\u0434\u0438\u044f"},
+			"slk": {"official": "Nov\u00fd Z\u00e9land", "common": "Nov\u00fd Z\u00e9land"},
 			"spa": {"official": "nueva Zelanda", "common": "Nueva Zelanda"},
-			"svk": {"official": "Nov\u00fd Z\u00e9land", "common": "Nov\u00fd Z\u00e9land"},
 			"fin": {"official": "Uusi-Seelanti", "common": "Uusi-Seelanti"},
 			"zho": {"official": "\u65B0\u897F\u5170", "common": "\u65B0\u897F\u5170"}
 		},
@@ -8309,8 +8309,8 @@
 			"nld": {"official": "Sultanaat van Oman", "common": "Oman"},
 			"por": {"official": "Sultanato de Om\u00e3", "common": "Om\u00e3"},
 			"rus": {"official": "\u0421\u0443\u043b\u0442\u0430\u043d\u0430\u0442 \u041e\u043c\u0430\u043d", "common": "\u041e\u043c\u0430\u043d"},
+			"slk": {"official": "Om\u00e1nsky sultan\u00e1t", "common": "Om\u00e1n"},
 			"spa": {"official": "Sultanato de Om\u00e1n", "common": "Om\u00e1n"},
-			"svk": {"official": "Om\u00e1nsky sultan\u00e1t", "common": "Om\u00e1n"},
 			"fin": {"official": "Omanin sulttaanikunta", "common": "Oman"},
 			"zho": {"official": "\u963F\u66FC\u82CF\u4E39\u56FD", "common": "\u963F\u66FC"}
 		},
@@ -8359,8 +8359,8 @@
 			"nld": {"official": "Islamitische Republiek Pakistan", "common": "Pakistan"},
 			"por": {"official": "Rep\u00fablica Isl\u00e2mica do Paquist\u00e3o", "common": "Paquist\u00e3o"},
 			"rus": {"official": "\u0418\u0441\u043b\u0430\u043c\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041f\u0430\u043a\u0438\u0441\u0442\u0430\u043d", "common": "\u041f\u0430\u043a\u0438\u0441\u0442\u0430\u043d"},
+			"slk": {"official": "Pakistansk\u00e1 islamsk\u00e1 republika", "common": "Pakistan"},
 			"spa": {"official": "Rep\u00fablica Isl\u00e1mica de Pakist\u00e1n", "common": "Pakist\u00e1n"},
-			"svk": {"official": "Pakistansk\u00e1 islamsk\u00e1 republika", "common": "Pakistan"},
 			"fin": {"official": "Pakistanin islamilainen tasavalta", "common": "Pakistan"},
 			"zho": {"official": "\u5DF4\u57FA\u65AF\u5766\u4F0A\u65AF\u5170\u5171\u548C\u56FD", "common": "\u5DF4\u57FA\u65AF\u5766"}
 		},
@@ -8404,8 +8404,8 @@
 			"nld": {"official": "Republiek Panama", "common": "Panama"},
 			"por": {"official": "Rep\u00fablica do Panam\u00e1", "common": "Panam\u00e1"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041f\u0430\u043d\u0430\u043c\u0430", "common": "\u041f\u0430\u043d\u0430\u043c\u0430"},
+			"slk": {"official": "Panamsk\u00e1 republika", "common": "Panama"},
 			"spa": {"official": "Rep\u00fablica de Panam\u00e1", "common": "Panam\u00e1"},
-			"svk": {"official": "Panamsk\u00e1 republika", "common": "Panama"},
 			"fin": {"official": "Panaman tasavalta", "common": "Panama"},
 			"zho": {"official": "\u5DF4\u62FF\u9A6C\u5171\u548C\u56FD", "common": "\u5DF4\u62FF\u9A6C"}
 		},
@@ -8449,8 +8449,8 @@
 			"nld": {"official": "Pitcairn groep eilanden", "common": "Pitcairneilanden"},
 			"por": {"official": "Pitcairn grupo de ilhas", "common": "Ilhas Pitcairn"},
 			"rus": {"official": "\u041f\u0438\u0442\u043a\u044d\u0440\u043d \u0433\u0440\u0443\u043f\u043f\u0430 \u043e\u0441\u0442\u0440\u043e\u0432\u043e\u0432", "common": "\u041e\u0441\u0442\u0440\u043e\u0432\u0430 \u041f\u0438\u0442\u043a\u044d\u0440\u043d"},
+			"slk": {"official": "Pitcairnove ostrovy", "common": "Pitcairnove ostrovy"},
 			"spa": {"official": "Grupo de Islas Pitcairn", "common": "Islas Pitcairn"},
-			"svk": {"official": "Pitcairnove ostrovy", "common": "Pitcairnove ostrovy"},
 			"fin": {"official": "Pitcairn", "common": "Pitcairn"},
 			"zho": {"official": "\u76AE\u7279\u51EF\u6069\u7FA4\u5C9B", "common": "\u76AE\u7279\u51EF\u6069\u7FA4\u5C9B"}
 		},
@@ -8504,8 +8504,8 @@
 			"nld": {"official": "Republiek Peru", "common": "Peru"},
 			"por": {"official": "Rep\u00fablica do Peru", "common": "Per\u00fa"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041f\u0435\u0440\u0443", "common": "\u041f\u0435\u0440\u0443"},
+			"slk": {"official": "Peru\u00e1nska republika", "common": "Peru"},
 			"spa": {"official": "Rep\u00fablica de Per\u00fa", "common": "Per\u00fa"},
-			"svk": {"official": "Peru\u00e1nska republika", "common": "Peru"},
 			"fin": {"official": "Perun tasavalta", "common": "Peru"},
 			"zho": {"official": "\u79D8\u9C81\u5171\u548C\u56FD", "common": "\u79D8\u9C81"}
 		},
@@ -8554,8 +8554,8 @@
 			"nld": {"official": "Republiek der Filipijnen", "common": "Filipijnen"},
 			"por": {"official": "Rep\u00fablica das Filipinas", "common": "Filipinas"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0424\u0438\u043b\u0438\u043f\u043f\u0438\u043d\u044b", "common": "\u0424\u0438\u043b\u0438\u043f\u043f\u0438\u043d\u044b"},
+			"slk": {"official": "Filip\u00ednska republika", "common": "Filip\u00edny"},
 			"spa": {"official": "Rep\u00fablica de las Filipinas", "common": "Filipinas"},
-			"svk": {"official": "Filip\u00ednska republika", "common": "Filip\u00edny"},
 			"fin": {"official": "Filippiinien tasavalta", "common": "Filippiinit"},
 			"zho": {"official": "\u83F2\u5F8B\u5BBE\u5171\u548C\u56FD", "common": "\u83F2\u5F8B\u5BBE"}
 		},
@@ -8604,8 +8604,8 @@
 			"nld": {"official": "Republiek van Palau", "common": "Palau"},
 			"por": {"official": "Rep\u00fablica de Palau", "common": "Palau"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041f\u0430\u043b\u0430\u0443", "common": "\u041f\u0430\u043b\u0430\u0443"},
+			"slk": {"official": "Palausk\u00e1 republika", "common": "Palau"},
 			"spa": {"official": "Rep\u00fablica de Palau", "common": "Palau"},
-			"svk": {"official": "Palausk\u00e1 republika", "common": "Palau"},
 			"fin": {"official": "Palaun tasavalta", "common": "Palau"},
 			"zho": {"official": "\u5E15\u52B3\u5171\u548C\u56FD", "common": "\u5E15\u52B3"}
 		},
@@ -8659,8 +8659,8 @@
 			"nld": {"official": "Onafhankelijke Staat Papoea -Nieuw-Guinea", "common": "Papoea-Nieuw-Guinea"},
 			"por": {"official": "Estado Independente da Papua Nova Guin\u00e9", "common": "Papua Nova Guin\u00e9"},
 			"rus": {"official": "\u041d\u0435\u0437\u0430\u0432\u0438\u0441\u0438\u043c\u043e\u0435 \u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u041f\u0430\u043f\u0443\u0430-\u041d\u043e\u0432\u043e\u0439 \u0413\u0432\u0438\u043d\u0435\u0438", "common": "\u041f\u0430\u043f\u0443\u0430 \u2014 \u041d\u043e\u0432\u0430\u044f \u0413\u0432\u0438\u043d\u0435\u044f"},
+			"slk": {"official": "Nez\u00e1visl\u00fd \u0161t\u00e1t Papua-Nov\u00e1 Guinea", "common": "Papua-Nov\u00e1 Guinea"},
 			"spa": {"official": "Estado Independiente de Pap\u00faa Nueva Guinea", "common": "Pap\u00faa Nueva Guinea"},
-			"svk": {"official": "Nez\u00e1visl\u00fd \u0161t\u00e1t Papua-Nov\u00e1 Guinea", "common": "Papua-Nov\u00e1 Guinea"},
 			"fin": {"official": "Papua-Uuden-Guinean Itsen\u00e4inen valtio", "common": "Papua-Uusi-Guinea"},
 			"zho": {"official": "\u5DF4\u5E03\u4E9A\u65B0\u51E0\u5185\u4E9A", "common": "\u5DF4\u5E03\u4E9A\u65B0\u51E0\u5185\u4E9A"}
 		},
@@ -8704,8 +8704,8 @@
 			"nld": {"official": "Republiek Polen", "common": "Polen"},
 			"por": {"official": "Rep\u00fablica da Pol\u00f3nia", "common": "Pol\u00f3nia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041f\u043e\u043b\u044c\u0448\u0430", "common": "\u041f\u043e\u043b\u044c\u0448\u0430"},
+			"slk": {"official": "Po\u013esk\u00e1 republika", "common": "Po\u013esko"},
 			"spa": {"official": "Rep\u00fablica de Polonia", "common": "Polonia"},
-			"svk": {"official": "Po\u013esk\u00e1 republika", "common": "Po\u013esko"},
 			"fin": {"official": "Puolan tasavalta", "common": "Puola"},
 			"zho": {"official": "\u6CE2\u5170\u5171\u548C\u56FD", "common": "\u6CE2\u5170"}
 		},
@@ -8754,8 +8754,8 @@
 			"nld": {"official": "Gemenebest van Puerto Rico", "common": "Puerto Rico"},
 			"por": {"official": "Commonwealth of Puerto Rico", "common": "Porto Rico"},
 			"rus": {"official": "\u0421\u043e\u0434\u0440\u0443\u0436\u0435\u0441\u0442\u0432\u043e \u041f\u0443\u044d\u0440\u0442\u043e-\u0420\u0438\u043a\u043e", "common": "\u041f\u0443\u044d\u0440\u0442\u043e-\u0420\u0438\u043a\u043e"},
+			"slk": {"official": "Portorick\u00e9 spolo\u010denstvo", "common": "Portoriko"},
 			"spa": {"official": "Asociado de Puerto Rico", "common": "Puerto Rico"},
-			"svk": {"official": "Portorick\u00e9 spolo\u010denstvo", "common": "Portoriko"},
 			"fin": {"official": "Puerto Rico", "common": "Puerto Rico"},
 			"zho": {"official": "\u6CE2\u591A\u9ECE\u5404\u8054\u90A6", "common": "\u6CE2\u591A\u9ECE\u5404"}
 		},
@@ -8799,8 +8799,8 @@
 			"nld": {"official": "Democratische Volksrepubliek Korea", "common": "Noord-Korea"},
 			"por": {"official": "Rep\u00fablica Popular Democr\u00e1tica da Coreia", "common": "Coreia do Norte"},
 			"rus": {"official": "\u041a\u043e\u0440\u0435\u0439\u0441\u043a\u0430\u044f \u041d\u0430\u0440\u043e\u0434\u043d\u043e-\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041a\u043e\u0440\u0435\u044f", "common": "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041a\u043e\u0440\u0435\u044f"},
+			"slk": {"official": "K\u00f3rejsk\u00e1 \u013eudovodemokratick\u00e1 republika", "common": "K\u00f3rejsk\u00e1 \u013eudovodemokratick\u00e1 republika (K\u013dR, Severn\u00e1 K\u00f3rea)"},
 			"spa": {"official": "Rep\u00fablica Popular Democr\u00e1tica de Corea", "common": "Corea del Norte"},
-			"svk": {"official": "K\u00f3rejsk\u00e1 \u013eudovodemokratick\u00e1 republika", "common": "K\u00f3rejsk\u00e1 \u013eudovodemokratick\u00e1 republika (K\u013dR, Severn\u00e1 K\u00f3rea)"},
 			"fin": {"official": "Korean demokraattinen kansantasavalta", "common": "Pohjois-Korea"},
 			"zho": {"official": "\u671D\u9C9C\u4EBA\u6C11\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u671D\u9C9C"}
 		},
@@ -8844,8 +8844,8 @@
 			"nld": {"official": "Portugese Republiek", "common": "Portugal"},
 			"por": {"official": "Rep\u00fablica portugu\u00eas", "common": "Portugal"},
 			"rus": {"official": "\u041f\u043e\u0440\u0442\u0443\u0433\u0430\u043b\u044c\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u041f\u043e\u0440\u0442\u0443\u0433\u0430\u043b\u0438\u044f"},
+			"slk": {"official": "Portugalsk\u00e1 republika", "common": "Portugalsko"},
 			"spa": {"official": "Rep\u00fablica Portuguesa", "common": "Portugal"},
-			"svk": {"official": "Portugalsk\u00e1 republika", "common": "Portugalsko"},
 			"fin": {"official": "Portugalin tasavalta", "common": "Portugali"},
 			"zho": {"official": "\u8461\u8404\u7259\u5171\u548C\u56FD", "common": "\u8461\u8404\u7259"}
 		},
@@ -8894,8 +8894,8 @@
 			"nld": {"official": "Republiek Paraguay", "common": "Paraguay"},
 			"por": {"official": "Rep\u00fablica do Paraguai", "common": "Paraguai"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041f\u0430\u0440\u0430\u0433\u0432\u0430\u0439", "common": "\u041f\u0430\u0440\u0430\u0433\u0432\u0430\u0439"},
+			"slk": {"official": "Paraguajsk\u00e1 republika", "common": "Paraguaj"},
 			"spa": {"official": "Rep\u00fablica de Paraguay", "common": "Paraguay"},
-			"svk": {"official": "Paraguajsk\u00e1 republika", "common": "Paraguaj"},
 			"fin": {"official": "Paraguayn tasavalta", "common": "Paraguay"},
 			"zho": {"official": "\u5DF4\u62C9\u572D\u5171\u548C\u56FD", "common": "\u5DF4\u62C9\u572D"}
 		},
@@ -8939,8 +8939,8 @@
 			"nld": {"official": "Staat Palestina", "common": "Palestijnse gebieden"},
 			"por": {"official": "Estado da Palestina", "common": "Palestina"},
 			"rus": {"official": "\u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u041f\u0430\u043b\u0435\u0441\u0442\u0438\u043d\u0430", "common": "\u041f\u0430\u043b\u0435\u0441\u0442\u0438\u043d\u0430"},
+			"slk": {"official": "Palest\u00ednsky \u0161t\u00e1t", "common": "Palest\u00edna"},
 			"spa": {"official": "Estado de Palestina", "common": "Palestina"},
-			"svk": {"official": "Palest\u00ednsky \u0161t\u00e1t", "common": "Palest\u00edna"},
 			"fin": {"official": "Palestiinan valtio", "common": "Palestiina"},
 			"zho": {"official": "\u5DF4\u52D2\u65AF\u5766\u56FD", "common": "\u5DF4\u52D2\u65AF\u5766"}
 		},
@@ -8984,8 +8984,8 @@
 			"nld": {"official": "Frans-Polynesi\u00eb", "common": "Frans-Polynesi\u00eb"},
 			"por": {"official": "Polin\u00e9sia Francesa", "common": "Polin\u00e9sia Francesa"},
 			"rus": {"official": "\u0424\u0440\u0430\u043d\u0446\u0443\u0437\u0441\u043a\u0430\u044f \u041f\u043e\u043b\u0438\u043d\u0435\u0437\u0438\u044f", "common": "\u0424\u0440\u0430\u043d\u0446\u0443\u0437\u0441\u043a\u0430\u044f \u041f\u043e\u043b\u0438\u043d\u0435\u0437\u0438\u044f"},
+			"slk": {"official": "Franc\u00fazska Polyn\u00e9zia", "common": "Franc\u00fazska Polyn\u00e9zia"},
 			"spa": {"official": "Polinesia franc\u00e9s", "common": "Polinesia Francesa"},
-			"svk": {"official": "Franc\u00fazska Polyn\u00e9zia", "common": "Franc\u00fazska Polyn\u00e9zia"},
 			"fin": {"official": "Ranskan Polynesia", "common": "Ranskan Polynesia"},
 			"zho": {"official": "\u6CD5\u5C5E\u6CE2\u5229\u5C3C\u897F\u4E9A", "common": "\u6CD5\u5C5E\u6CE2\u5229\u5C3C\u897F\u4E9A"}
 		},
@@ -9029,8 +9029,8 @@
 			"nld": {"official": "Staat Qatar", "common": "Qatar"},
 			"por": {"official": "Estado do Qatar", "common": "Catar"},
 			"rus": {"official": "\u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u041a\u0430\u0442\u0430\u0440", "common": "\u041a\u0430\u0442\u0430\u0440"},
+			"slk": {"official": "Katarsk\u00fd \u0161t\u00e1t", "common": "Katar"},
 			"spa": {"official": "Estado de Qatar", "common": "Catar"},
-			"svk": {"official": "Katarsk\u00fd \u0161t\u00e1t", "common": "Katar"},
 			"fin": {"official": "Qatarin valtio", "common": "Qatar"},
 			"zho": {"official": "\u5361\u5854\u5C14\u56FD", "common": "\u5361\u5854\u5C14"}
 		},
@@ -9074,8 +9074,8 @@
 			"nld": {"official": "R\u00e9union", "common": "R\u00e9union"},
 			"por": {"official": "Ilha da Reuni\u00e3o", "common": "Reuni\u00e3o"},
 			"rus": {"official": "\u0420\u0435\u044e\u043d\u044c\u043e\u043d", "common": "\u0420\u0435\u044e\u043d\u044c\u043e\u043d"},
+			"slk": {"official": "R\u00e9unionsk\u00fd z\u00e1morsk\u00fd departm\u00e1n", "common": "R\u00e9union"},
 			"spa": {"official": "Isla de la Reuni\u00f3n", "common": "Reuni\u00f3n"},
-			"svk": {"official": "R\u00e9unionsk\u00fd z\u00e1morsk\u00fd departm\u00e1n", "common": "R\u00e9union"},
 			"fin": {"official": "R\u00e9union", "common": "R\u00e9union"},
 			"zho": {"official": "\u7559\u5C3C\u65FA\u5C9B", "common": "\u7559\u5C3C\u65FA\u5C9B"}
 		},
@@ -9119,8 +9119,8 @@
 			"nld": {"official": "Roemeni\u00eb", "common": "Roemeni\u00eb"},
 			"por": {"official": "Rom\u00eania", "common": "Rom\u00e9nia"},
 			"rus": {"official": "\u0420\u0443\u043c\u044b\u043d\u0438\u044f", "common": "\u0420\u0443\u043c\u044b\u043d\u0438\u044f"},
+			"slk": {"official": "Rumunsko", "common": "Rumunsko"},
 			"spa": {"official": "Rumania", "common": "Rumania"},
-			"svk": {"official": "Rumunsko", "common": "Rumunsko"},
 			"fin": {"official": "Romania", "common": "Romania"},
 			"zho": {"official": "\u7F57\u9A6C\u5C3C\u4E9A", "common": "\u7F57\u9A6C\u5C3C\u4E9A"}
 		},
@@ -9164,8 +9164,8 @@
 			"nld": {"official": "Russische Federatie", "common": "Rusland"},
 			"por": {"official": "Federa\u00e7\u00e3o Russa", "common": "R\u00fassia"},
 			"rus": {"official": "\u0420\u043e\u0441\u0441\u0438\u044f \u0424\u0435\u0434\u0435\u0440\u0430\u0446\u0438\u044f", "common": "\u0420\u043e\u0441\u0441\u0438\u044f"},
+			"slk": {"official": "Rusk\u00e1 feder\u00e1cia", "common": "Rusko"},
 			"spa": {"official": "Federaci\u00f3n de Rusia", "common": "Rusia"},
-			"svk": {"official": "Rusk\u00e1 feder\u00e1cia", "common": "Rusko"},
 			"fin": {"official": "Ven\u00e4j\u00e4n federaatio", "common": "Ven\u00e4j\u00e4"},
 			"zho": {"official": "\u4FC4\u7F57\u65AF\u8054\u90A6", "common": "\u4FC4\u7F57\u65AF"}
 		},
@@ -9219,8 +9219,8 @@
 			"nld": {"official": "Republiek Rwanda", "common": "Rwanda"},
 			"por": {"official": "Rep\u00fablica do Ruanda", "common": "Ruanda"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0420\u0443\u0430\u043d\u0434\u0430", "common": "\u0420\u0443\u0430\u043d\u0434\u0430"},
+			"slk": {"official": "Rwandsk\u00e1 republika", "common": "Rwanda"},
 			"spa": {"official": "Rep\u00fablica de Rwanda", "common": "Ruanda"},
-			"svk": {"official": "Rwandsk\u00e1 republika", "common": "Rwanda"},
 			"fin": {"official": "Ruandan tasavalta", "common": "Ruanda"},
 			"zho": {"official": "\u5362\u65FA\u8FBE\u5171\u548C\u56FD", "common": "\u5362\u65FA\u8FBE"}
 		},
@@ -9264,8 +9264,8 @@
 			"nld": {"official": "Koninkrijk van Saoedi-Arabi\u00eb", "common": "Saoedi-Arabi\u00eb"},
 			"por": {"official": "Reino da Ar\u00e1bia Saudita", "common": "Ar\u00e1bia Saudita"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0421\u0430\u0443\u0434\u043e\u0432\u0441\u043a\u0430\u044f \u0410\u0440\u0430\u0432\u0438\u044f", "common": "\u0421\u0430\u0443\u0434\u043e\u0432\u0441\u043a\u0430\u044f \u0410\u0440\u0430\u0432\u0438\u044f"},
+			"slk": {"official": "Saudskoarabsk\u00e9 kr\u00e1\u013eovstvo", "common": "Saudsk\u00e1 Ar\u00e1bia"},
 			"spa": {"official": "Reino de Arabia Saudita", "common": "Arabia Saud\u00ed"},
-			"svk": {"official": "Saudskoarabsk\u00e9 kr\u00e1\u013eovstvo", "common": "Saudsk\u00e1 Ar\u00e1bia"},
 			"fin": {"official": "Saudi-Arabian kuningaskunta", "common": "Saudi-Arabia"},
 			"zho": {"official": "\u6C99\u7279\u963F\u62C9\u4F2F\u738B\u56FD", "common": "\u6C99\u7279\u963F\u62C9\u4F2F"}
 		},
@@ -9314,8 +9314,8 @@
 			"nld": {"official": "Republiek Soedan", "common": "Soedan"},
 			"por": {"official": "Rep\u00fablica do Sud\u00e3o", "common": "Sud\u00e3o"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0443\u0434\u0430\u043d", "common": "\u0421\u0443\u0434\u0430\u043d"},
+			"slk": {"official": "Sud\u00e1nska republika", "common": "Sud\u00e1n"},
 			"spa": {"official": "Rep\u00fablica de Sud\u00e1n", "common": "Sud\u00e1n"},
-			"svk": {"official": "Sud\u00e1nska republika", "common": "Sud\u00e1n"},
 			"fin": {"official": "Sudanin tasavalta", "common": "Sudan"},
 			"zho": {"official": "\u82CF\u4E39\u5171\u548C\u56FD", "common": "\u82CF\u4E39"}
 		},
@@ -9359,8 +9359,8 @@
 			"nld": {"official": "Republiek Senegal", "common": "Senegal"},
 			"por": {"official": "Rep\u00fablica do Senegal", "common": "Senegal"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0435\u043d\u0435\u0433\u0430\u043b", "common": "\u0421\u0435\u043d\u0435\u0433\u0430\u043b"},
+			"slk": {"official": "Senegalsk\u00e1 republika", "common": "Senegal"},
 			"spa": {"official": "Rep\u00fablica de Senegal", "common": "Senegal"},
-			"svk": {"official": "Senegalsk\u00e1 republika", "common": "Senegal"},
 			"fin": {"official": "Senegalin tasavalta", "common": "Senegal"},
 			"zho": {"official": "\u585E\u5185\u52A0\u5C14\u5171\u548C\u56FD", "common": "\u585E\u5185\u52A0\u5C14"}
 		},
@@ -9419,8 +9419,8 @@
 			"nld": {"official": "Republiek Singapore", "common": "Singapore"},
 			"por": {"official": "Rep\u00fablica de Singapura", "common": "Singapura"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0438\u043d\u0433\u0430\u043f\u0443\u0440", "common": "\u0421\u0438\u043d\u0433\u0430\u043f\u0443\u0440"},
+			"slk": {"official": "Singapursk\u00e1 republika", "common": "Singapur"},
 			"spa": {"official": "Rep\u00fablica de Singapur", "common": "Singapur"},
-			"svk": {"official": "Singapursk\u00e1 republika", "common": "Singapur"},
 			"fin": {"official": "Singaporen tasavalta", "common": "Singapore"}
 		},
 		"latlng": [1.36666666, 103.8],
@@ -9463,8 +9463,8 @@
 			"nld": {"official": "Zuid-Georgi\u00eb en de Zuidelijke Sandwich-eilanden", "common": "Zuid-Georgia en Zuidelijke Sandwicheilanden"},
 			"por": {"official": "Ge\u00f3rgia do Sul e Sandwich do Sul", "common": "Ilhas Ge\u00f3rgia do Sul e Sandwich do Sul"},
 			"rus": {"official": "\u042e\u0436\u043d\u0430\u044f \u0413\u0435\u043e\u0440\u0433\u0438\u044f \u0438 \u042e\u0436\u043d\u044b\u0435 \u0421\u0430\u043d\u0434\u0432\u0438\u0447\u0435\u0432\u044b \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u042e\u0436\u043d\u0430\u044f \u0413\u0435\u043e\u0440\u0433\u0438\u044f \u0438 \u042e\u0436\u043d\u044b\u0435 \u0421\u0430\u043d\u0434\u0432\u0438\u0447\u0435\u0432\u044b \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Ju\u017en\u00e1 Georgia a Ju\u017en\u00e9 Sandwichove ostrovy", "common": "Ju\u017en\u00e1 Georgia a Ju\u017en\u00e9 Sandwichove ostrovy"},
 			"spa": {"official": "Georgia del Sur y las Islas Sandwich del Sur", "common": "Islas Georgias del Sur y Sandwich del Sur"},
-			"svk": {"official": "Ju\u017en\u00e1 Georgia a Ju\u017en\u00e9 Sandwichove ostrovy", "common": "Ju\u017en\u00e1 Georgia a Ju\u017en\u00e9 Sandwichove ostrovy"},
 			"fin": {"official": "Etel\u00e4-Georgia ja Etel\u00e4iset Sandwichsaaret", "common": "Etel\u00e4-Georgia ja Etel\u00e4iset Sandwichsaaret"},
 			"zho": {"official": "\u5357\u4E54\u6CBB\u4E9A\u5C9B\u548C\u5357\u6851\u5A01\u5947\u7FA4\u5C9B", "common": "\u5357\u4E54\u6CBB\u4E9A"}
 		},
@@ -9508,8 +9508,8 @@
 			"nld": {"official": "Svalbard og Jan Mayen", "common": "Svalbard en Jan Mayen"},
 			"por": {"official": "Svalbard og Jan Mayen", "common": "Ilhas Svalbard e Jan Mayen"},
 			"rus": {"official": "\u0421\u0432\u0430\u043b\u044c\u0431\u0430\u0440\u0434\u0430 \u043e\u0433 \u042f\u043d-\u041c\u0430\u0439\u0435\u043d", "common": "\u0428\u043f\u0438\u0446\u0431\u0435\u0440\u0433\u0435\u043d \u0438 \u042f\u043d-\u041c\u0430\u0439\u0435\u043d"},
+			"slk": {"official": "Svalbard a Jan Mayen", "common": "Svalbard a Jan Mayen"},
 			"spa": {"official": "Svalbard og Jan Mayen", "common": "Islas Svalbard y Jan Mayen"},
-			"svk": {"official": "Svalbard a Jan Mayen", "common": "Svalbard a Jan Mayen"},
 			"fin": {"official": "Huippuvuoret", "common": "Huippuvuoret"},
 			"zho": {"official": "\u65AF\u74E6\u5C14\u5DF4\u7279", "common": "\u65AF\u74E6\u5C14\u5DF4\u7279"}
 		},
@@ -9553,8 +9553,8 @@
 			"nld": {"official": "Solomon eilanden", "common": "Salomonseilanden"},
 			"por": {"official": "Ilhas Salom\u00e3o", "common": "Ilhas Salom\u00e3o"},
 			"rus": {"official": "\u0421\u043e\u043b\u043e\u043c\u043e\u043d\u043e\u0432\u044b \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0421\u043e\u043b\u043e\u043c\u043e\u043d\u043e\u0432\u044b \u041e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Salomonove ostrovy", "common": "Salomonove ostrovy"},
 			"spa": {"official": "islas Salom\u00f3n", "common": "Islas Salom\u00f3n"},
-			"svk": {"official": "Salomonove ostrovy", "common": "Salomonove ostrovy"},
 			"fin": {"official": "Salomonsaaret", "common": "Salomonsaaret"},
 			"zho": {"official": "\u6240\u7F57\u95E8\u7FA4\u5C9B", "common": "\u6240\u7F57\u95E8\u7FA4\u5C9B"}
 		},
@@ -9598,8 +9598,8 @@
 			"nld": {"official": "Republiek Sierra Leone", "common": "Sierra Leone"},
 			"por": {"official": "Rep\u00fablica da Serra Leoa", "common": "Serra Leoa"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u044c\u0435\u0440\u0440\u0430-\u041b\u0435\u043e\u043d\u0435", "common": "\u0421\u044c\u0435\u0440\u0440\u0430-\u041b\u0435\u043e\u043d\u0435"},
+			"slk": {"official": "Sierraleonsk\u00e1 republika", "common": "Sierra Leone"},
 			"spa": {"official": "Rep\u00fablica de Sierra Leona", "common": "Sierra Leone"},
-			"svk": {"official": "Sierraleonsk\u00e1 republika", "common": "Sierra Leone"},
 			"fin": {"official": "Sierra Leonen tasavalta", "common": "Sierra Leone"},
 			"zho": {"official": "\u585E\u62C9\u5229\u6602\u5171\u548C\u56FD", "common": "\u585E\u62C9\u5229\u6602"}
 		},
@@ -9644,8 +9644,8 @@
 			"nld": {"official": "Republiek El Salvador", "common": "El Salvador"},
 			"por": {"official": "Rep\u00fablica de El Salvador", "common": "El Salvador"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u042d\u043b\u044c-\u0421\u0430\u043b\u044c\u0432\u0430\u0434\u043e\u0440", "common": "\u0421\u0430\u043b\u044c\u0432\u0430\u0434\u043e\u0440"},
+			"slk": {"official": "Salv\u00e1dorsk\u00e1 republika", "common": "Salv\u00e1dor"},
 			"spa": {"official": "Rep\u00fablica de El Salvador", "common": "El Salvador"},
-			"svk": {"official": "Salv\u00e1dorsk\u00e1 republika", "common": "Salv\u00e1dor"},
 			"fin": {"official": "El Salvadorin tasavalta", "common": "El Salvador"},
 			"zho": {"official": "\u8428\u5C14\u74E6\u591A\u5171\u548C\u56FD", "common": "\u8428\u5C14\u74E6\u591A"}
 		},
@@ -9689,8 +9689,8 @@
 			"nld": {"official": "Meest Serene Republiek San Marino", "common": "San Marino"},
 			"por": {"official": "Seren\u00edssima Rep\u00fablica de San Marino", "common": "San Marino"},
 			"rus": {"official": "\u0411\u043e\u043b\u044c\u0448\u0438\u043d\u0441\u0442\u0432\u043e Serene \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0430\u043d-\u041c\u0430\u0440\u0438\u043d\u043e", "common": "\u0421\u0430\u043d-\u041c\u0430\u0440\u0438\u043d\u043e"},
+			"slk": {"official": "Sanmar\u00ednska republika", "common": "San Mar\u00edno"},
 			"spa": {"official": "Seren\u00edsima Rep\u00fablica de San Marino", "common": "San Marino"},
-			"svk": {"official": "Sanmar\u00ednska republika", "common": "San Mar\u00edno"},
 			"fin": {"official": "San Marinon seesteinen tasavalta", "common": "San Marino"},
 			"zho": {"official": "\u5723\u9A6C\u529B\u8BFA\u5171\u548C\u56FD", "common": "\u5723\u9A6C\u529B\u8BFA"}
 		},
@@ -9739,8 +9739,8 @@
 			"nld": {"official": "Federale Republiek Somali\u00eb", "common": "Somali\u00eb"},
 			"por": {"official": "Rep\u00fablica Federal da Som\u00e1lia", "common": "Som\u00e1lia"},
 			"rus": {"official": "\u0424\u0435\u0434\u0435\u0440\u0430\u0442\u0438\u0432\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u043e\u043c\u0430\u043b\u0438", "common": "\u0421\u043e\u043c\u0430\u043b\u0438"},
+			"slk": {"official": "Som\u00e1lska federat\u00edvna republika", "common": "Som\u00e1lsko"},
 			"spa": {"official": "Rep\u00fablica Federal de Somalia", "common": "Somalia"},
-			"svk": {"official": "Som\u00e1lska federat\u00edvna republika", "common": "Som\u00e1lsko"},
 			"fin": {"official": "Somalian liittotasavalta", "common": "Somalia"},
 			"zho": {"official": "\u7D22\u9A6C\u91CC\u5171\u548C\u56FD", "common": "\u7D22\u9A6C\u91CC"}
 		},
@@ -9784,8 +9784,8 @@
 			"nld": {"official": "Saint-Pierre en Miquelon", "common": "Saint Pierre en Miquelon"},
 			"por": {"official": "Saint Pierre e Miquelon", "common": "Saint-Pierre e Miquelon"},
 			"rus": {"official": "\u0421\u0435\u043d-\u041f\u044c\u0435\u0440 \u0438 \u041c\u0438\u043a\u0435\u043b\u043e\u043d", "common": "\u0421\u0435\u043d-\u041f\u044c\u0435\u0440 \u0438 \u041c\u0438\u043a\u0435\u043b\u043e\u043d"},
+			"slk": {"official": "Ostrovy Saint Pierre a Miquelon", "common": "Saint Pierre a Miquelon"},
 			"spa": {"official": "San Pedro y Miquel\u00f3n", "common": "San Pedro y Miquel\u00f3n"},
-			"svk": {"official": "Ostrovy Saint Pierre a Miquelon", "common": "Saint Pierre a Miquelon"},
 			"fin": {"official": "Saint-Pierre ja Miquelon", "common": "Saint-Pierre ja Miquelon"},
 			"zho": {"official": "\u5723\u76AE\u57C3\u5C14\u548C\u5BC6\u514B\u9686", "common": "\u5723\u76AE\u57C3\u5C14\u548C\u5BC6\u514B\u9686"}
 		},
@@ -9829,8 +9829,8 @@
 			"nld": {"official": "Republiek Servi\u00eb", "common": "Servi\u00eb"},
 			"por": {"official": "Rep\u00fablica da S\u00e9rvia", "common": "S\u00e9rvia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0435\u0440\u0431\u0438\u044f", "common": "\u0421\u0435\u0440\u0431\u0438\u044f"},
+			"slk": {"official": "Srbsk\u00e1 republika", "common": "Srbsko"},
 			"spa": {"official": "Rep\u00fablica de Serbia", "common": "Serbia"},
-			"svk": {"official": "Srbsk\u00e1 republika", "common": "Srbsko"},
 			"fin": {"official": "Serbian tasavalta", "common": "Serbia"},
 			"zho": {"official": "\u585E\u5C14\u7EF4\u4E9A\u5171\u548C\u56FD", "common": "\u585E\u5C14\u7EF4\u4E9A"}
 		},
@@ -9874,8 +9874,8 @@
 			"nld": {"official": "Republiek Zuid-Soedan", "common": "Zuid-Soedan"},
 			"por": {"official": "Rep\u00fablica do Sud\u00e3o do Sul", "common": "Sud\u00e3o do Sul"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u042e\u0436\u043d\u044b\u0439 \u0421\u0443\u0434\u0430\u043d", "common": "\u042e\u0436\u043d\u044b\u0439 \u0421\u0443\u0434\u0430\u043d"},
+			"slk": {"official": "Juhosud\u00e1nska republika", "common": "Ju\u017en\u00fd Sud\u00e1n"},
 			"spa": {"official": "Rep\u00fablica de Sud\u00e1n del Sur", "common": "Sud\u00e1n del Sur"},
-			"svk": {"official": "Juhosud\u00e1nska republika", "common": "Ju\u017en\u00fd Sud\u00e1n"},
 			"fin": {"official": "Etel\u00e4-Sudanin tasavalta", "common": "Etel\u00e4-Sudan"},
 			"zho": {"official": "\u5357\u82CF\u4E39\u5171\u548C\u56FD", "common": "\u5357\u82CF\u4E39"}
 		},
@@ -9918,8 +9918,8 @@
 			"jpn": {"official": "\u30b5\u30f3\u30c8\u30e1\u00b7\u30d7\u30ea\u30f3\u30b7\u30da\u6c11\u4e3b\u5171\u548c\u56fd", "common": "\u30b5\u30f3\u30c8\u30e1\u30fb\u30d7\u30ea\u30f3\u30b7\u30da"},
 			"nld": {"official": "Democratische Republiek Sao Tom\u00e9 en Principe", "common": "Sao Tom\u00e9 en Principe"},
 			"por": {"official": "Rep\u00fablica Democr\u00e1tica de S\u00e3o Tom\u00e9 e Pr\u00edncipe", "common": "S\u00e3o Tom\u00e9 e Pr\u00edncipe"},
+			"slk": {"official": "Rep\u00fablica Democr\u00e1tica de Santo Tom\u00e9 y Pr\u00edncipe", "common": "Santo Tom\u00e9 y Pr\u00edncipe"},
 			"rus": {"official": "\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0430\u043d-\u0422\u043e\u043c\u0435 \u0438 \u041f\u0440\u0438\u043d\u0441\u0438\u043f\u0438", "common": "\u0421\u0430\u043d-\u0422\u043e\u043c\u0435 \u0438 \u041f\u0440\u0438\u043d\u0441\u0438\u043f\u0438"},
-			"spa": {"official": "Rep\u00fablica Democr\u00e1tica de Santo Tom\u00e9 y Pr\u00edncipe", "common": "Santo Tom\u00e9 y Pr\u00edncipe"},
 			"svk": {"official": "Demokratick\u00e1 republika Sv\u00e4t\u00e9ho Tom\u00e1\u0161a A princovho ostrova", "common": "Sv\u00e4t\u00fd Tom\u00e1\u0161 a Princov ostrov"},
 			"fin": {"official": "S\u00e3o Tom\u00e9 ja Pr\u00edncipen demokraattinen tasavalta", "common": "S\u00e3o T\u00e9me ja Pr\u00edncipe"},
 			"zho": {"official": "\u5723\u591A\u7F8E\u548C\u666E\u6797\u897F\u6BD4\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u5723\u591A\u7F8E\u548C\u666E\u6797\u897F\u6BD4"}
@@ -9964,8 +9964,8 @@
 			"nld": {"official": "Republiek Suriname", "common": "Suriname"},
 			"por": {"official": "Rep\u00fablica do Suriname", "common": "Suriname"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0443\u0440\u0438\u043d\u0430\u043c", "common": "\u0421\u0443\u0440\u0438\u043d\u0430\u043c"},
+			"slk": {"official": "Surinamsk\u00e1 republika", "common": "Surinam"},
 			"spa": {"official": "Rep\u00fablica de Suriname", "common": "Surinam"},
-			"svk": {"official": "Surinamsk\u00e1 republika", "common": "Surinam"},
 			"fin": {"official": "Surinamen tasavalta", "common": "Suriname"},
 			"zho": {"official": "\u82CF\u91CC\u5357\u5171\u548C\u56FD", "common": "\u82CF\u91CC\u5357"}
 		},
@@ -10009,8 +10009,8 @@
 			"nld": {"official": "Slowaakse Republiek", "common": "Slowakije"},
 			"por": {"official": "Rep\u00fablica Eslovaca", "common": "Eslov\u00e1quia"},
 			"rus": {"official": "\u0421\u043b\u043e\u0432\u0430\u0446\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0421\u043b\u043e\u0432\u0430\u043a\u0438\u044f"},
+			"slk": {"official": "Slovensk\u00e1 republika", "common": "Slovensko"},
 			"spa": {"official": "Rep\u00fablica Eslovaca", "common": "Rep\u00fablica Eslovaca"},
-			"svk": {"official": "Slovensk\u00e1 republika", "common": "Slovensko"},
 			"fin": {"official": "Slovakian tasavalta", "common": "Slovakia"},
 			"zho": {"official": "\u65AF\u6D1B\u4F10\u514B\u5171\u548C\u56FD", "common": "\u65AF\u6D1B\u4F10\u514B"}
 		},
@@ -10054,8 +10054,8 @@
 			"nld": {"official": "Republiek Sloveni\u00eb", "common": "Sloveni\u00eb"},
 			"por": {"official": "Rep\u00fablica da Eslov\u00e9nia", "common": "Eslov\u00e9nia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u043b\u043e\u0432\u0435\u043d\u0438\u044f", "common": "\u0421\u043b\u043e\u0432\u0435\u043d\u0438\u044f"},
+			"slk": {"official": "Slovinsk\u00e1 republika", "common": "Slovinsko"},
 			"spa": {"official": "Rep\u00fablica de Eslovenia", "common": "Eslovenia"},
-			"svk": {"official": "Slovinsk\u00e1 republika", "common": "Slovinsko"},
 			"fin": {"official": "Slovenian tasavalta", "common": "Slovenia"},
 			"zho": {"official": "\u65AF\u6D1B\u6587\u5C3C\u4E9A\u5171\u548C\u56FD", "common": "\u65AF\u6D1B\u6587\u5C3C\u4E9A"}
 		},
@@ -10099,8 +10099,8 @@
 			"nld": {"official": "Koninkrijk Zweden", "common": "Zweden"},
 			"por": {"official": "Reino da Su\u00e9cia", "common": "Su\u00e9cia"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0428\u0432\u0435\u0446\u0438\u044f", "common": "\u0428\u0432\u0435\u0446\u0438\u044f"},
+			"slk": {"official": "\u0160v\u00e9dske kr\u00e1\u013eovstvo", "common": "\u0160v\u00e9dsko"},
 			"spa": {"official": "Reino de Suecia", "common": "Suecia"},
-			"svk": {"official": "\u0160v\u00e9dske kr\u00e1\u013eovstvo", "common": "\u0160v\u00e9dsko"},
 			"fin": {"official": "Ruotsin kuningaskunta", "common": "Ruotsi"},
 			"zho": {"official": "\u745E\u5178\u738B\u56FD", "common": "\u745E\u5178"}
 		},
@@ -10149,8 +10149,8 @@
 			"nld": {"official": "Koninkrijk Swaziland", "common": "Swaziland"},
 			"por": {"official": "Reino da Suazil\u00e2ndia", "common": "Suazil\u00e2ndia"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0421\u0432\u0430\u0437\u0438\u043b\u0435\u043d\u0434", "common": "\u0421\u0432\u0430\u0437\u0438\u043b\u0435\u043d\u0434"},
+			"slk": {"official": "Svazijsk\u00e9 kr\u00e1\u013eovstvo", "common": "Svazijsko"},
 			"spa": {"official": "Reino de Swazilandia", "common": "Suazilandia"},
-			"svk": {"official": "Svazijsk\u00e9 kr\u00e1\u013eovstvo", "common": "Svazijsko"},
 			"fin": {"official": "Swazimaan kuningaskunta", "common": "Swazimaa"},
 			"zho": {"official": "\u65AF\u5A01\u58EB\u5170\u738B\u56FD", "common": "\u65AF\u5A01\u58EB\u5170"}
 		},
@@ -10203,8 +10203,8 @@
 			"nld": {"official": "Sint Maarten", "common": "Sint Maarten"},
 			"por": {"official": "Sint Maarten", "common": "S\u00e3o Martinho"},
 			"rus": {"official": "\u0421\u0438\u043d\u0442-\u041c\u0430\u0430\u0440\u0442\u0435\u043d", "common": "\u0421\u0438\u043d\u0442-\u041c\u0430\u0440\u0442\u0435\u043d"},
+			"slk": {"official": "Sint Maarten", "common": "Sint Maarten"},
 			"spa": {"official": "Sint Maarten", "common": "Sint Maarten"},
-			"svk": {"official": "Sint Maarten", "common": "Sint Maarten"},
 			"fin": {"official": "Sint Maarten", "common": "Sint Maarten"},
 			"zho": {"official": "\u5723\u9A6C\u4E01\u5C9B", "common": "\u5723\u9A6C\u4E01\u5C9B"}
 		},
@@ -10258,8 +10258,8 @@
 			"nld": {"official": "Republiek der Seychellen", "common": "Seychellen"},
 			"por": {"official": "Rep\u00fablica das Seychelles", "common": "Seicheles"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0435\u0439\u0448\u0435\u043b\u044c\u0441\u043a\u0438\u0435 \u041e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0421\u0435\u0439\u0448\u0435\u043b\u044c\u0441\u043a\u0438\u0435 \u041e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Seychelsk\u00e1 republika", "common": "Seychely"},
 			"spa": {"official": "Rep\u00fablica de las Seychelles", "common": "Seychelles"},
-			"svk": {"official": "Seychelsk\u00e1 republika", "common": "Seychely"},
 			"fin": {"official": "Seychellien tasavalta", "common": "Seychellit"},
 			"zho": {"official": "\u585E\u820C\u5C14\u5171\u548C\u56FD", "common": "\u585E\u820C\u5C14"}
 		},
@@ -10303,8 +10303,8 @@
 			"nld": {"official": "Syrische Arabische Republiek", "common": "Syri\u00eb"},
 			"por": {"official": "Rep\u00fablica \u00c1rabe S\u00edria", "common": "S\u00edria"},
 			"rus": {"official": "\u0421\u0438\u0440\u0438\u0439\u0441\u043a\u0430\u044f \u0410\u0440\u0430\u0431\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0421\u0438\u0440\u0438\u044f"},
+			"slk": {"official": "S\u00fdrska arabsk\u00e1 republika", "common": "S\u00fdria"},
 			"spa": {"official": "Rep\u00fablica \u00c1rabe Siria", "common": "Siria"},
-			"svk": {"official": "S\u00fdrska arabsk\u00e1 republika", "common": "S\u00fdria"},
 			"fin": {"official": "Syyrian arabitasavalta", "common": "Syyria"},
 			"zho": {"official": "\u53D9\u5229\u4E9A\u963F\u62C9\u4F2F\u5171\u548C\u56FD", "common": "\u53D9\u5229\u4E9A"}
 		},
@@ -10348,8 +10348,8 @@
 			"nld": {"official": "Turks-en Caicoseilanden", "common": "Turks-en Caicoseilanden"},
 			"por": {"official": "Ilhas Turks e Caicos", "common": "Ilhas Turks e Caicos"},
 			"rus": {"official": "\u0422\u0435\u0440\u043a\u0441 \u0438 \u041a\u0430\u0439\u043a\u043e\u0441 \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0422\u0435\u0440\u043a\u0441 \u0438 \u041a\u0430\u0439\u043a\u043e\u0441"},
+			"slk": {"official": "Ostrovy Turks a Caicos", "common": "Turks a Caicos"},
 			"spa": {"official": "Islas Turcas y Caicos", "common": "Islas Turks y Caicos"},
-			"svk": {"official": "Ostrovy Turks a Caicos", "common": "Turks a Caicos"},
 			"fin": {"official": "Turks-ja Caicossaaret", "common": "Turks-ja Caicossaaret"},
 			"zho": {"official": "\u7279\u514B\u65AF\u548C\u51EF\u79D1\u65AF\u7FA4\u5C9B", "common": "\u7279\u514B\u65AF\u548C\u51EF\u79D1\u65AF\u7FA4\u5C9B"}
 		},
@@ -10399,8 +10399,8 @@
 			"nld": {"official": "Republiek Tsjaad", "common": "Tsjaad"},
 			"por": {"official": "Rep\u00fablica do Chade", "common": "Chade"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0427\u0430\u0434", "common": "\u0427\u0430\u0434"},
+			"slk": {"official": "\u010cadsk\u00e1 republika", "common": "\u010cad"},
 			"spa": {"official": "Rep\u00fablica de Chad", "common": "Chad"},
-			"svk": {"official": "\u010cadsk\u00e1 republika", "common": "\u010cad"},
 			"fin": {"official": "T\u0161adin tasavalta", "common": "T\u0161ad"},
 			"zho": {"official": "\u4E4D\u5F97\u5171\u548C\u56FD", "common": "\u4E4D\u5F97"}
 		},
@@ -10444,8 +10444,8 @@
 			"nld": {"official": "Republiek Togo", "common": "Togo"},
 			"por": {"official": "Rep\u00fablica do Togo", "common": "Togo"},
 			"rus": {"official": "\u0422\u043e\u0433\u043e \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0422\u043e\u0433\u043e"},
+			"slk": {"official": "Togsk\u00e1 republika", "common": "Togo"},
 			"spa": {"official": "Rep\u00fablica de Togo", "common": "Togo"},
-			"svk": {"official": "Togsk\u00e1 republika", "common": "Togo"},
 			"fin": {"official": "Togon tasavalta", "common": "Togo"},
 			"zho": {"official": "\u591A\u54E5\u5171\u548C\u56FD", "common": "\u591A\u54E5"}
 		},
@@ -10489,8 +10489,8 @@
 			"nld": {"official": "Koninkrijk Thailand", "common": "Thailand"},
 			"por": {"official": "Reino da Tail\u00e2ndia", "common": "Tail\u00e2ndia"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0422\u0430\u0438\u043b\u0430\u043d\u0434", "common": "\u0422\u0430\u0438\u043b\u0430\u043d\u0434"},
+			"slk": {"official": "Thajsk\u00e9 kr\u00e1\u013eovstvo", "common": "Thajsko"},
 			"spa": {"official": "Reino de Tailandia", "common": "Tailandia"},
-			"svk": {"official": "Thajsk\u00e9 kr\u00e1\u013eovstvo", "common": "Thajsko"},
 			"fin": {"official": "Thaimaan kuningaskunta", "common": "Thaimaa"},
 			"zho": {"official": "\u6CF0\u738B\u56FD", "common": "\u6CF0\u56FD"}
 		},
@@ -10539,8 +10539,8 @@
 			"nld": {"official": "Tadzjikistan", "common": "Tadzjikistan"},
 			"por": {"official": "Rep\u00fablica do Tajiquist\u00e3o", "common": "Tajiquist\u00e3o"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0422\u0430\u0434\u0436\u0438\u043a\u0438\u0441\u0442\u0430\u043d", "common": "\u0422\u0430\u0434\u0436\u0438\u043a\u0438\u0441\u0442\u0430\u043d"},
+			"slk": {"official": "Ta\u01c6ick\u00e1 republika", "common": "Ta\u01c6ikistan"},
 			"spa": {"official": "Rep\u00fablica de Tayikist\u00e1n", "common": "Tayikist\u00e1n"},
-			"svk": {"official": "Ta\u01c6ick\u00e1 republika", "common": "Ta\u01c6ikistan"},
 			"fin": {"official": "Tad\u017eikistanin tasavalta", "common": "Tad\u017eikistan"},
 			"zho": {"official": "\u5854\u5409\u514B\u65AF\u5766\u5171\u548C\u56FD", "common": "\u5854\u5409\u514B\u65AF\u5766"}
 		},
@@ -10594,8 +10594,8 @@
 			"nld": {"official": "Tokelau", "common": "Tokelau"},
 			"por": {"official": "Tokelau", "common": "Tokelau"},
 			"rus": {"official": "\u0422\u043e\u043a\u0435\u043b\u0430\u0443", "common": "\u0422\u043e\u043a\u0435\u043b\u0430\u0443"},
+			"slk": {"official": "Tokelausk\u00e9 ostrovy", "common": "Tokelau"},
 			"spa": {"official": "Tokelau", "common": "Islas Tokelau"},
-			"svk": {"official": "Tokelausk\u00e9 ostrovy", "common": "Tokelau"},
 			"fin": {"official": "Tokelau", "common": "Tokelau"},
 			"zho": {"official": "\u6258\u514B\u52B3", "common": "\u6258\u514B\u52B3"}
 		},
@@ -10644,8 +10644,8 @@
 			"nld": {"official": "Turkmenistan", "common": "Turkmenistan"},
 			"por": {"official": "Turcomenist\u00e3o", "common": "Turquemenist\u00e3o"},
 			"rus": {"official": "\u0422\u0443\u0440\u043a\u043c\u0435\u043d\u0438\u0441\u0442\u0430\u043d", "common": "\u0422\u0443\u0440\u043a\u043c\u0435\u043d\u0438\u044f"},
+			"slk": {"official": "Turkm\u00e9nsko", "common": "Turkm\u00e9nsko"},
 			"spa": {"official": "Turkmenist\u00e1n", "common": "Turkmenist\u00e1n"},
-			"svk": {"official": "Turkm\u00e9nsko", "common": "Turkm\u00e9nsko"},
 			"fin": {"official": "Turkmenistan", "common": "Turkmenistan"},
 			"zho": {"official": "\u571F\u5E93\u66FC\u65AF\u5766", "common": "\u571F\u5E93\u66FC\u65AF\u5766"}
 		},
@@ -10694,8 +10694,8 @@
 			"nld": {"official": "Democratische Republiek Oost-Timor", "common": "Oost-Timor"},
 			"por": {"official": "Rep\u00fablica Democr\u00e1tica de Timor-Leste", "common": "Timor-Leste"},
 			"rus": {"official": "\u0414\u0435\u043c\u043e\u043a\u0440\u0430\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0422\u0438\u043c\u043e\u0440 -\u041b\u0435\u0448\u0442\u0438", "common": "\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u044b\u0439 \u0422\u0438\u043c\u043e\u0440"},
+			"slk": {"official": "V\u00fdchodotimorsk\u00e1 demokratick\u00e1 republika", "common": "V\u00fdchodn\u00fd Timor"},
 			"spa": {"official": "Rep\u00fablica Democr\u00e1tica de Timor-Leste", "common": "Timor Oriental"},
-			"svk": {"official": "V\u00fdchodotimorsk\u00e1 demokratick\u00e1 republika", "common": "V\u00fdchodn\u00fd Timor"},
 			"fin": {"official": "It\u00e4-Timorin demokraattinen tasavalta", "common": "It\u00e4-Timor"},
 			"zho": {"official": "\u4E1C\u5E1D\u6C76\u6C11\u4E3B\u5171\u548C\u56FD", "common": "\u4E1C\u5E1D\u6C76"}
 		},
@@ -10744,8 +10744,8 @@
 			"nld": {"official": "Koninkrijk Tonga", "common": "Tonga"},
 			"por": {"official": "Reino de Tonga", "common": "Tonga"},
 			"rus": {"official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0422\u043e\u043d\u0433\u0430", "common": "\u0422\u043e\u043d\u0433\u0430"},
+			"slk": {"official": "Tongsk\u00e9 kr\u00e1\u013eovstvo", "common": "Tonga"},
 			"spa": {"official": "Reino de Tonga", "common": "Tonga"},
-			"svk": {"official": "Tongsk\u00e9 kr\u00e1\u013eovstvo", "common": "Tonga"},
 			"fin": {"official": "Tongan kuningaskunta", "common": "Tonga"},
 			"zho": {"official": "\u6C64\u52A0\u738B\u56FD", "common": "\u6C64\u52A0"}
 		},
@@ -10789,8 +10789,8 @@
 			"nld": {"official": "Republiek Trinidad en Tobago", "common": "Trinidad en Tobago"},
 			"por": {"official": "Rep\u00fablica de Trinidad e Tobago", "common": "Trinidade e Tobago"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0422\u0440\u0438\u043d\u0438\u0434\u0430\u0434 \u0438 \u0422\u043e\u0431\u0430\u0433\u043e", "common": "\u0422\u0440\u0438\u043d\u0438\u0434\u0430\u0434 \u0438 \u0422\u043e\u0431\u0430\u0433\u043e"},
+			"slk": {"official": "Republika Trinidad a Tobaga", "common": "Trinidad a Tobago"},
 			"spa": {"official": "Rep\u00fablica de Trinidad y Tobago", "common": "Trinidad y Tobago"},
-			"svk": {"official": "Republika Trinidad a Tobaga", "common": "Trinidad a Tobago"},
 			"fin": {"official": "Trinidadin ja Tobagon tasavalta", "common": "Trinidad ja Tobago"},
 			"zho": {"official": "\u7279\u7ACB\u5C3C\u8FBE\u548C\u591A\u5DF4\u54E5\u5171\u548C\u56FD", "common": "\u7279\u7ACB\u5C3C\u8FBE\u548C\u591A\u5DF4\u54E5"}
 		},
@@ -10834,8 +10834,8 @@
 			"nld": {"official": "Republiek Tunesi\u00eb", "common": "Tunesi\u00eb"},
 			"por": {"official": "Rep\u00fablica da Tun\u00edsia", "common": "Tun\u00edsia"},
 			"rus": {"official": "\u0422\u0443\u043d\u0438\u0441\u0441\u043a\u043e\u0439 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438", "common": "\u0422\u0443\u043d\u0438\u0441"},
+			"slk": {"official": "Tunisk\u00e1 republika", "common": "Tunisko"},
 			"spa": {"official": "Rep\u00fablica de T\u00fanez", "common": "T\u00fanez"},
-			"svk": {"official": "Tunisk\u00e1 republika", "common": "Tunisko"},
 			"fin": {"official": "Tunisian tasavalta", "common": "Tunisia"},
 			"zho": {"official": "\u7A81\u5C3C\u65AF\u5171\u548C\u56FD", "common": "\u7A81\u5C3C\u65AF"}
 		},
@@ -10879,8 +10879,8 @@
 			"nld": {"official": "Republiek Turkije", "common": "Turkije"},
 			"por": {"official": "Rep\u00fablica da Turquia", "common": "Turquia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0422\u0443\u0440\u0446\u0438\u0438", "common": "\u0422\u0443\u0440\u0446\u0438\u044f"},
+			"slk": {"official": "Tureck\u00e1 republika", "common": "Turecko"},
 			"spa": {"official": "Rep\u00fablica de Turqu\u00eda", "common": "Turqu\u00eda"},
-			"svk": {"official": "Tureck\u00e1 republika", "common": "Turecko"},
 			"fin": {"official": "Turkin tasavalta", "common": "Turkki"},
 			"zho": {"official": "\u571F\u8033\u5176\u5171\u548C\u56FD", "common": "\u571F\u8033\u5176"}
 		},
@@ -10929,8 +10929,8 @@
 			"nld": {"official": "Tuvalu", "common": "Tuvalu"},
 			"por": {"official": "Tuvalu", "common": "Tuvalu"},
 			"rus": {"official": "\u0422\u0443\u0432\u0430\u043b\u0443", "common": "\u0422\u0443\u0432\u0430\u043b\u0443"},
+			"slk": {"official": "Tuvalu", "common": "Tuvalu"},
 			"spa": {"official": "Tuvalu", "common": "Tuvalu"},
-			"svk": {"official": "Tuvalu", "common": "Tuvalu"},
 			"fin": {"official": "Tuvalu", "common": "Tuvalu"},
 			"zho": {"official": "\u56FE\u74E6\u5362", "common": "\u56FE\u74E6\u5362"}
 		},
@@ -10974,8 +10974,8 @@
 			"nld": {"official": "Republiek China (Taiwan)", "common": "Taiwan"},
 			"por": {"official": "Rep\u00fablica da China", "common": "Ilha Formosa"},
 			"rus": {"official": "\u041a\u0438\u0442\u0430\u0439\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0422\u0430\u0439\u0432\u0430\u043d\u044c"},
+			"slk": {"official": "\u010c\u00ednska republika", "common": "Taiwan"},
 			"spa": {"official": "Rep\u00fablica de China en Taiw\u00e1n", "common": "Taiw\u00e1n"},
-			"svk": {"official": "\u010c\u00ednska republika", "common": "Taiwan"},
 			"fin": {"official": "Kiinan tasavalta", "common": "Taiwan"}
 		},
 		"latlng": [23.5, 121],
@@ -11023,8 +11023,8 @@
 			"nld": {"official": "Verenigde Republiek Tanzania", "common": "Tanzania"},
 			"por": {"official": "Rep\u00fablica Unida da Tanz\u00e2nia", "common": "Tanz\u00e2nia"},
 			"rus": {"official": "\u041e\u0431\u044a\u0435\u0434\u0438\u043d\u0435\u043d\u043d\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0422\u0430\u043d\u0437\u0430\u043d\u0438\u044f", "common": "\u0422\u0430\u043d\u0437\u0430\u043d\u0438\u044f"},
+			"slk": {"official": "Tanz\u00e1nijsk\u00e1 zjednoten\u00e1 republika", "common": "Tanz\u00e1nia"},
 			"spa": {"official": "Rep\u00fablica Unida de Tanzania", "common": "Tanzania"},
-			"svk": {"official": "Tanz\u00e1nijsk\u00e1 zjednoten\u00e1 republika", "common": "Tanz\u00e1nia"},
 			"fin": {"official": "Tansanian yhdistynyt tasavalta", "common": "Tansania"},
 			"zho": {"official": "\u5766\u6851\u5C3C\u4E9A\u8054\u5408\u5171\u548C\u56FD", "common": "\u5766\u6851\u5C3C\u4E9A"}
 		},
@@ -11073,8 +11073,8 @@
 			"nld": {"official": "Republiek Uganda", "common": "Oeganda"},
 			"por": {"official": "Rep\u00fablica do Uganda", "common": "Uganda"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0423\u0433\u0430\u043d\u0434\u0430", "common": "\u0423\u0433\u0430\u043d\u0434\u0430"},
+			"slk": {"official": "Ugandsk\u00e1 republika", "common": "Uganda"},
 			"spa": {"official": "Rep\u00fablica de Uganda", "common": "Uganda"},
-			"svk": {"official": "Ugandsk\u00e1 republika", "common": "Uganda"},
 			"fin": {"official": "Ugandan tasavalta", "common": "Uganda"},
 			"zho": {"official": "\u4E4C\u5E72\u8FBE\u5171\u548C\u56FD", "common": "\u4E4C\u5E72\u8FBE"}
 		},
@@ -11123,8 +11123,8 @@
 			"nld": {"official": "Oekra\u00efne", "common": "Oekra\u00efne"},
 			"por": {"official": "Ucr\u00e2nia", "common": "Ucr\u00e2nia"},
 			"rus": {"official": "\u0423\u043a\u0440\u0430\u0438\u043d\u0430", "common": "\u0423\u043a\u0440\u0430\u0438\u043d\u0430"},
+			"slk": {"official": "Ukrajina", "common": "Ukrajina"},
 			"spa": {"official": "Ucrania", "common": "Ucrania"},
-			"svk": {"official": "Ukrajina", "common": "Ukrajina"},
 			"fin": {"official": "Ukraina", "common": "Ukraina"},
 			"zho": {"official": "\u4E4C\u514B\u5170", "common": "\u4E4C\u514B\u5170"}
 		},
@@ -11168,8 +11168,8 @@
 			"nld": {"official": "Kleine afgelegen eilanden van de Verenigde Staten", "common": "Kleine afgelegen eilanden van de Verenigde Staten"},
 			"por": {"official": "Estados Unidos Ilhas Menores Distantes", "common": "Ilhas Menores Distantes dos Estados Unidos"},
 			"rus": {"official": "\u0412\u043d\u0435\u0448\u043d\u0438\u0435 \u043c\u0430\u043b\u044b\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u0421\u0428\u0410", "common": "\u0412\u043d\u0435\u0448\u043d\u0438\u0435 \u043c\u0430\u043b\u044b\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u0421\u0428\u0410"},
+			"slk": {"official": "Men\u0161ie od\u013eahl\u00e9 ostrovy Spjoen\u00fdch \u0161t\u00e1tov", "common": "Men\u0161ie od\u013eahl\u00e9 ostrovy USA"},
 			"spa": {"official": "Estados Unidos Islas menores alejadas de", "common": "Islas Ultramarinas Menores de Estados Unidos"},
-			"svk": {"official": "Men\u0161ie od\u013eahl\u00e9 ostrovy Spjoen\u00fdch \u0161t\u00e1tov", "common": "Men\u0161ie od\u013eahl\u00e9 ostrovy USA"},
 			"fin": {"official": "Yhdysvaltain asumattomat saaret", "common": "Yhdysvaltain asumattomat saaret"},
 			"zho": {"official": "\u7F8E\u56FD\u672C\u571F\u5916\u5C0F\u5C9B\u5C7F", "common": "\u7F8E\u56FD\u672C\u571F\u5916\u5C0F\u5C9B\u5C7F"}
 		},
@@ -11213,8 +11213,8 @@
 			"nld": {"official": "Oosterse Republiek Uruguay", "common": "Uruguay"},
 			"por": {"official": "Rep\u00fablica Oriental do Uruguai", "common": "Uruguai"},
 			"rus": {"official": "\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u043e\u0439 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438 \u0423\u0440\u0443\u0433\u0432\u0430\u0439", "common": "\u0423\u0440\u0443\u0433\u0432\u0430\u0439"},
+			"slk": {"official": "Uruguajsk\u00e1 v\u00fdchodn\u00e1 republika", "common": "Uruguaj"},
 			"spa": {"official": "Rep\u00fablica Oriental del Uruguay", "common": "Uruguay"},
-			"svk": {"official": "Uruguajsk\u00e1 v\u00fdchodn\u00e1 republika", "common": "Uruguaj"},
 			"fin": {"official": "Uruguayn it\u00e4inen tasavalta", "common": "Uruguay"},
 			"zho": {"official": "\u4E4C\u62C9\u572D\u4E1C\u5CB8\u5171\u548C\u56FD", "common": "\u4E4C\u62C9\u572D"}
 		},
@@ -11258,8 +11258,8 @@
 			"nld": {"official": "Verenigde Staten van Amerika", "common": "Verenigde Staten"},
 			"por": {"official": "Estados Unidos da Am\u00e9rica", "common": "Estados Unidos"},
 			"rus": {"official": "\u0421\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u043d\u044b\u0435 \u0428\u0442\u0430\u0442\u044b \u0410\u043c\u0435\u0440\u0438\u043a\u0438", "common": "\u0421\u043e\u0435\u0434\u0438\u043d\u0451\u043d\u043d\u044b\u0435 \u0428\u0442\u0430\u0442\u044b \u0410\u043c\u0435\u0440\u0438\u043a\u0438"},
+			"slk": {"official": "Spojen\u00e9 \u0161t\u00e1ty Americk\u00e9", "common": "Spojen\u00e9 \u0161t\u00e1ty americk\u00e9"},
 			"spa": {"official": "Estados Unidos de Am\u00e9rica", "common": "Estados Unidos"},
-			"svk": {"official": "Spojen\u00e9 \u0161t\u00e1ty Americk\u00e9", "common": "Spojen\u00e9 \u0161t\u00e1ty americk\u00e9"},
 			"fin": {"official": "Amerikan yhdysvallat", "common": "Yhdysvallat"},
 			"zho": {"official": "\u7F8E\u5229\u575A\u5408\u4F17\u56FD", "common": "\u7F8E\u56FD"}
 		},
@@ -11308,8 +11308,8 @@
 			"nld": {"official": "Republiek Oezbekistan", "common": "Oezbekistan"},
 			"por": {"official": "Rep\u00fablica do Usbequist\u00e3o", "common": "Uzbequist\u00e3o"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0423\u0437\u0431\u0435\u043a\u0438\u0441\u0442\u0430\u043d", "common": "\u0423\u0437\u0431\u0435\u043a\u0438\u0441\u0442\u0430\u043d"},
+			"slk": {"official": "Uzbeck\u00e1 republika", "common": "Uzbekistan"},
 			"spa": {"official": "Rep\u00fablica de Uzbekist\u00e1n", "common": "Uzbekist\u00e1n"},
-			"svk": {"official": "Uzbeck\u00e1 republika", "common": "Uzbekistan"},
 			"fin": {"official": "Uzbekistanin tasavalta", "common": "Uzbekistan"},
 			"zho": {"official": "\u4E4C\u5179\u522B\u514B\u65AF\u5766\u5171\u548C\u56FD", "common": "\u4E4C\u5179\u522B\u514B\u65AF\u5766"}
 		},
@@ -11358,8 +11358,8 @@
 			"nld": {"official": "Vaticaanstad", "common": "Vaticaanstad"},
 			"por": {"official": "Cidade do Vaticano", "common": "Cidade do Vaticano"},
 			"rus": {"official": "\u0413\u043e\u0440\u043e\u0434-\u0433\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u0412\u0430\u0442\u0438\u043a\u0430\u043d", "common": "\u0412\u0430\u0442\u0438\u043a\u0430\u043d"},
+			"slk": {"official": "Sv\u00e4t\u00e1 stolica (Vatik\u00e1nsky mestsk\u00fd \u0161t\u00e1t", "common": "Vatik\u00e1n"},
 			"spa": {"official": "Ciudad del Vaticano", "common": "Ciudad del Vaticano"},
-			"svk": {"official": "Sv\u00e4t\u00e1 stolica (Vatik\u00e1nsky mestsk\u00fd \u0161t\u00e1t", "common": "Vatik\u00e1n"},
 			"fin": {"official": "Vatikaanin kaupunkivaltio", "common": "Vatikaani"},
 			"zho": {"official": "\u68B5\u8482\u5188\u57CE\u56FD", "common": "\u68B5\u8482\u5188"}
 		},
@@ -11403,8 +11403,8 @@
 			"nld": {"official": "Saint Vincent en de Grenadines", "common": "Saint Vincent en de Grenadines"},
 			"por": {"official": "S\u00e3o Vicente e Granadinas", "common": "S\u00e3o Vincente e Granadinas"},
 			"rus": {"official": "\u0421\u0435\u043d\u0442-\u0412\u0438\u043d\u0441\u0435\u043d\u0442 \u0438 \u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d\u044b", "common": "\u0421\u0435\u043d\u0442-\u0412\u0438\u043d\u0441\u0435\u043d\u0442 \u0438 \u0413\u0440\u0435\u043d\u0430\u0434\u0438\u043d\u044b"},
+			"slk": {"official": "Sv\u00e4t\u00fd Vincent a Grenad\u00edny", "common": "Sv\u00e4t\u00fd Vincent a Grenad\u00edny"},
 			"spa": {"official": "San Vicente y las Granadinas", "common": "San Vicente y Granadinas"},
-			"svk": {"official": "Sv\u00e4t\u00fd Vincent a Grenad\u00edny", "common": "Sv\u00e4t\u00fd Vincent a Grenad\u00edny"},
 			"fin": {"official": "Saint Vincent ja Grenadiinit", "common": "Saint Vincent ja Grenadiinit"},
 			"zho": {"official": "\u5723\u6587\u68EE\u7279\u548C\u683C\u6797\u7EB3\u4E01\u65AF", "common": "\u5723\u6587\u68EE\u7279\u548C\u683C\u6797\u7EB3\u4E01\u65AF"}
 		},
@@ -11448,8 +11448,8 @@
 			"nld": {"official": "Bolivariaanse Republiek Venezuela", "common": "Venezuela"},
 			"por": {"official": "Rep\u00fablica Bolivariana da Venezuela", "common": "Venezuela"},
 			"rus": {"official": "\u0411\u043e\u043b\u0438\u0432\u0430\u0440\u0438\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0412\u0435\u043d\u0435\u0441\u0443\u044d\u043b\u0430", "common": "\u0412\u0435\u043d\u0435\u0441\u0443\u044d\u043b\u0430"},
+			"slk": {"official": "Venezuelsk\u00e1 bol\u00edvarovsk\u00e1 republika", "common": "Venezuela"},
 			"spa": {"official": "Rep\u00fablica Bolivariana de Venezuela", "common": "Venezuela"},
-			"svk": {"official": "Venezuelsk\u00e1 bol\u00edvarovsk\u00e1 republika", "common": "Venezuela"},
 			"fin": {"official": "Venezuelan bolivariaainen tasavalta", "common": "Venezuela"},
 			"zho": {"official": "\u59D4\u5185\u745E\u62C9\u73BB\u5229\u74E6\u5C14\u5171\u548C\u56FD", "common": "\u59D4\u5185\u745E\u62C9"}
 		},
@@ -11493,8 +11493,8 @@
 			"nld": {"official": "Maagdeneilanden", "common": "Britse Maagdeneilanden"},
 			"por": {"official": "Ilhas Virgens", "common": "Ilhas Virgens"},
 			"rus": {"official": "\u0412\u0438\u0440\u0433\u0438\u043d\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0411\u0440\u0438\u0442\u0430\u043d\u0441\u043a\u0438\u0435 \u0412\u0438\u0440\u0433\u0438\u043d\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Panensk\u00e9 ostrovy", "common": "Panensk\u00e9 ostrovy"},
 			"spa": {"official": "Islas V\u00edrgenes", "common": "Islas V\u00edrgenes del Reino Unido"},
-			"svk": {"official": "Panensk\u00e9 ostrovy", "common": "Panensk\u00e9 ostrovy"},
 			"fin": {"official": "Brittil\u00e4iset Neitsytsaaret", "common": "Neitsytsaaret"},
 			"zho": {"official": "\u82F1\u5C5E\u7EF4\u5C14\u4EAC\u7FA4\u5C9B", "common": "\u82F1\u5C5E\u7EF4\u5C14\u4EAC\u7FA4\u5C9B"}
 		},
@@ -11538,8 +11538,8 @@
 			"nld": {"official": "Maagdeneilanden van de Verenigde Staten", "common": "Amerikaanse Maagdeneilanden"},
 			"por": {"official": "Ilhas Virgens dos Estados Unidos", "common": "Ilhas Virgens dos Estados Unidos"},
 			"rus": {"official": "\u0412\u0438\u0440\u0433\u0438\u043d\u0441\u043a\u0438\u0435 \u043e\u0441\u0442\u0440\u043e\u0432\u0430 \u0421\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u043d\u044b\u0445 \u0428\u0442\u0430\u0442\u043e\u0432", "common": "\u0412\u0438\u0440\u0433\u0438\u043d\u0441\u043a\u0438\u0435 \u041e\u0441\u0442\u0440\u043e\u0432\u0430"},
+			"slk": {"official": "Americk\u00e9 Panensk\u00e9 ostrovy", "common": "Americk\u00e9 Panensk\u00e9 ostrovy"},
 			"spa": {"official": "Islas V\u00edrgenes de los Estados Unidos", "common": "Islas V\u00edrgenes de los Estados Unidos"},
-			"svk": {"official": "Americk\u00e9 Panensk\u00e9 ostrovy", "common": "Americk\u00e9 Panensk\u00e9 ostrovy"},
 			"fin": {"official": "Yhdysvaltain Neitsytsaaret", "common": "Neitsytsaaret"},
 			"zho": {"official": "\u7F8E\u5C5E\u7EF4\u5C14\u4EAC\u7FA4\u5C9B", "common": "\u7F8E\u5C5E\u7EF4\u5C14\u4EAC\u7FA4\u5C9B"}
 		},
@@ -11583,8 +11583,8 @@
 			"nld": {"official": "Socialistische Republiek Vietnam", "common": "Vietnam"},
 			"por": {"official": "Rep\u00fablica Socialista do Vietname", "common": "Vietname"},
 			"rus": {"official": "\u0421\u043e\u0446\u0438\u0430\u043b\u0438\u0441\u0442\u0438\u0447\u0435\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0412\u044c\u0435\u0442\u043d\u0430\u043c", "common": "\u0412\u044c\u0435\u0442\u043d\u0430\u043c"},
+			"slk": {"official": "Vietnamsk\u00e1 socialistick\u00e1 republika", "common": "Vietnam"},
 			"spa": {"official": "Rep\u00fablica Socialista de Vietnam", "common": "Vietnam"},
-			"svk": {"official": "Vietnamsk\u00e1 socialistick\u00e1 republika", "common": "Vietnam"},
 			"fin": {"official": "Vietnamin sosialistinen tasavalta", "common": "Vietnam"},
 			"zho": {"official": "\u8D8A\u5357\u793E\u4F1A\u4E3B\u4E49\u5171\u548C\u56FD", "common": "\u8D8A\u5357"}
 		},
@@ -11638,8 +11638,8 @@
 			"nld": {"official": "Republiek Vanuatu", "common": "Vanuatu"},
 			"por": {"official": "Rep\u00fablica de Vanuatu", "common": "Vanuatu"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0412\u0430\u043d\u0443\u0430\u0442\u0443", "common": "\u0412\u0430\u043d\u0443\u0430\u0442\u0443"},
+			"slk": {"official": "Vanuatsk\u00e1 republika", "common": "Vanuatu"},
 			"spa": {"official": "Rep\u00fablica de Vanuatu", "common": "Vanuatu"},
-			"svk": {"official": "Vanuatsk\u00e1 republika", "common": "Vanuatu"},
 			"fin": {"official": "Vanuatun tasavalta", "common": "Vanuatu"},
 			"zho": {"official": "\u74E6\u52AA\u963F\u56FE\u5171\u548C\u56FD", "common": "\u74E6\u52AA\u963F\u56FE"}
 		},
@@ -11683,8 +11683,8 @@
 			"nld": {"official": "Grondgebied van de Wallis en Futuna", "common": "Wallis en Futuna"},
 			"por": {"official": "Territ\u00f3rio das Ilhas Wallis e Futuna", "common": "Wallis e Futuna"},
 			"rus": {"official": "\u0422\u0435\u0440\u0440\u0438\u0442\u043e\u0440\u0438\u044f \u0423\u043e\u043b\u043b\u0438\u0441 \u0438 \u0424\u0443\u0442\u0443\u043d\u0430 \u043e\u0441\u0442\u0440\u043e\u0432\u0430", "common": "\u0423\u043e\u043b\u043b\u0438\u0441 \u0438 \u0424\u0443\u0442\u0443\u043d\u0430"},
+			"slk": {"official": "Terit\u00f3rium ostrovov Wallis a Futuna", "common": "Wallis a Futuna"},
 			"spa": {"official": "Territorio de las Islas Wallis y Futuna", "common": "Wallis y Futuna"},
-			"svk": {"official": "Terit\u00f3rium ostrovov Wallis a Futuna", "common": "Wallis a Futuna"},
 			"fin": {"official": "Wallisin ja Futunan yhteis\u00f6", "common": "Wallis ja Futuna"},
 			"zho": {"official": "\u74E6\u5229\u65AF\u548C\u5BCC\u56FE\u7EB3\u7FA4\u5C9B", "common": "\u74E6\u5229\u65AF\u548C\u5BCC\u56FE\u7EB3\u7FA4\u5C9B"}
 		},
@@ -11733,8 +11733,8 @@
 			"nld": {"official": "Onafhankelijke Staat Samoa", "common": "Samoa"},
 			"por": {"official": "Estado Independente de Samoa", "common": "Samoa"},
 			"rus": {"official": "\u041d\u0435\u0437\u0430\u0432\u0438\u0441\u0438\u043c\u043e\u0435 \u0413\u043e\u0441\u0443\u0434\u0430\u0440\u0441\u0442\u0432\u043e \u0421\u0430\u043c\u043e\u0430", "common": "\u0421\u0430\u043c\u043e\u0430"},
+			"slk": {"official": "Nez\u00e1visl\u00fd \u0161t\u00e1tSamoa", "common": "Samoa"},
 			"spa": {"official": "Estado Independiente de Samoa", "common": "Samoa"},
-			"svk": {"official": "Nez\u00e1visl\u00fd \u0161t\u00e1tSamoa", "common": "Samoa"},
 			"fin": {"official": "Samoan itsen\u00e4inen valtio", "common": "Samoa"},
 			"zho": {"official": "\u8428\u6469\u4E9A\u72EC\u7ACB\u56FD", "common": "\u8428\u6469\u4E9A"}
 		},
@@ -11778,8 +11778,8 @@
 			"nld": {"official": "Republiek Jemen", "common": "Jemen"},
 			"por": {"official": "Rep\u00fablica do I\u00eamen", "common": "I\u00e9men"},
 			"rus": {"official": "\u0419\u0435\u043c\u0435\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0419\u0435\u043c\u0435\u043d"},
+			"slk": {"official": "Jemensk\u00e1 republika", "common": "Jemen"},
 			"spa": {"official": "Rep\u00fablica de Yemen", "common": "Yemen"},
-			"svk": {"official": "Jemensk\u00e1 republika", "common": "Jemen"},
 			"fin": {"official": "Jemenin tasavalta", "common": "Jemen"},
 			"zho": {"official": "\u4E5F\u95E8\u5171\u548C\u56FD", "common": "\u4E5F\u95E8"}
 		},
@@ -11873,8 +11873,8 @@
 			"nld": {"official": "Zuid -Afrika", "common": "Zuid-Afrika"},
 			"por": {"official": "Rep\u00fablica da \u00c1frica do Sul", "common": "\u00c1frica do Sul"},
 			"rus": {"official": "\u042e\u0436\u043d\u043e-\u0410\u0444\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u042e\u0436\u043d\u043e-\u0410\u0444\u0440\u0438\u043a\u0430\u043d\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"},
+			"slk": {"official": "Juhoafrick\u00e1 republika", "common": "Juhoafrick\u00e1 republika"},
 			"spa": {"official": "Rep\u00fablica de Sud\u00e1frica", "common": "Rep\u00fablica de Sud\u00e1frica"},
-			"svk": {"official": "Juhoafrick\u00e1 republika", "common": "Juhoafrick\u00e1 republika"},
 			"fin": {"official": "Etel\u00e4-Afrikan tasavalta", "common": "Etel\u00e4-Afrikka"},
 			"zho": {"official": "\u5357\u975E\u5171\u548C\u56FD", "common": "\u5357\u975E"}
 		},
@@ -11918,8 +11918,8 @@
 			"nld": {"official": "Republiek Zambia", "common": "Zambia"},
 			"por": {"official": "Rep\u00fablica da Z\u00e2mbia", "common": "Z\u00e2mbia"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0417\u0430\u043c\u0431\u0438\u044f", "common": "\u0417\u0430\u043c\u0431\u0438\u044f"},
+			"slk": {"official": "Zambijsk\u00e1 republika", "common": "Zambia"},
 			"spa": {"official": "Rep\u00fablica de Zambia", "common": "Zambia"},
-			"svk": {"official": "Zambijsk\u00e1 republika", "common": "Zambia"},
 			"fin": {"official": "Sambian tasavalta", "common": "Sambia"},
 			"zho": {"official": "\u8D5E\u6BD4\u4E9A\u5171\u548C\u56FD", "common": "\u8D5E\u6BD4\u4E9A"}
 		},
@@ -12033,8 +12033,8 @@
 			"nld": {"official": "Republiek Zimbabwe", "common": "Zimbabwe"},
 			"por": {"official": "Rep\u00fablica do Zimbabwe", "common": "Zimbabwe"},
 			"rus": {"official": "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0417\u0438\u043c\u0431\u0430\u0431\u0432\u0435", "common": "\u0417\u0438\u043c\u0431\u0430\u0431\u0432\u0435"},
+			"slk": {"official": "Zimbabwianska republika", "common": "Zimbabwe"},
 			"spa": {"official": "Rep\u00fablica de Zimbabue", "common": "Zimbabue"},
-			"svk": {"official": "Zimbabwianska republika", "common": "Zimbabwe"},
 			"fin": {"official": "Zimbabwen tasavalta", "common": "Zimbabwe"},
 			"zho": {"official": "\u6D25\u5DF4\u5E03\u97E6\u5171\u548C\u56FD", "common": "\u6D25\u5DF4\u5E03\u97E6"}
 		},

--- a/countries.json
+++ b/countries.json
@@ -2785,16 +2785,16 @@
 	},
 	{
 		"name": {
-			"common": "Czech Republic",
+			"common": "Czechia",
 			"official": "Czech Republic",
 			"native": {
 				"ces": {
 					"official": "\u010desk\u00e1 republika",
-					"common": "\u010cesk\u00e1 republika"
+					"common": "\u010cesko"
 				},
 				"slk": {
 					"official": "\u010cesk\u00e1 republika",
-					"common": "\u010cesk\u00e1 republika"
+					"common": "\u010cesko"
 				}
 			}
 		},
@@ -2815,15 +2815,15 @@
 		},
 		"translations": {
 			"cym": {"official": "Czech Republic", "common": "Y Weriniaeth Tsiec"},
-			"deu": {"official": "Tschechische Republik", "common": "Tschechische Republik"},
-			"fra": {"official": "R\u00e9publique tch\u00e8que", "common": "R\u00e9publique tch\u00e8que"},
+			"deu": {"official": "Tschechische Republik", "common": "Tschechien"},
+			"fra": {"official": "R\u00e9publique tch\u00e8que", "common": "Tch\u00e9quie"},
 			"hrv": {"official": "\u010ce\u0161ka", "common": "\u010ce\u0161ka"},
-			"ita": {"official": "Repubblica Ceca", "common": "Repubblica Ceca"},
+			"ita": {"official": "Repubblica Ceca", "common": "Cechia"},
 			"jpn": {"official": "\u30c1\u30a7\u30b3\u5171\u548c\u56fd", "common": "\u30c1\u30a7\u30b3"},
 			"nld": {"official": "Tsjechische Republiek", "common": "Tsjechi\u00eb"},
-			"por": {"official": "Rep\u00fablica Checa", "common": "Rep\u00fablica Checa"},
+			"por": {"official": "Rep\u00fablica Checa", "common": "Tcheca"},
 			"rus": {"official": "\u0427\u0435\u0448\u0441\u043a\u0430\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430", "common": "\u0427\u0435\u0445\u0438\u044f"},
-			"spa": {"official": "Rep\u00fablica Checa", "common": "Rep\u00fablica Checa"},
+			"spa": {"official": "Rep\u00fablica Checa", "common": "Chequia"},
 			"svk": {"official": "\u010cesk\u00e1 republika", "common": "\u010cesko"},
 			"fin": {"official": "T\u0161ekin tasavalta", "common": "T\u0161ekki"},
 			"zho": {"official": "\u6377\u514B\u5171\u548C\u56FD", "common": "\u6377\u514B"}


### PR DESCRIPTION
**Czechia** [was approved](http://www.mzv.cz/jnp/cz/udalosti_a_media/tiskove_zpravy/x_2016_05_02_vlada_schvalila_czechia.html) as the official English short name. For other languages were also _created_ short names (e.g., French, Arabian, Chinese).

It has been already published in the [United Nations](http://unterm.un.org/UNTERM/Display/Record/UNHQ/NA/4275087d-4018-4082-899d-95f37efeda65) name databases and in the official [ISO 3166](https://www.iso.org/obp/ui/#iso:code:3166:CZ) country codes list. It's recommended (by the government) to use short name.

I know that Czechia is not commonly used, however Czech Republic had no official short name before. 