### PR TITLE
Add lat/lng data for United States Minor Outlying Islands/UM

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -11406,7 +11406,7 @@
 			"est": {"official": "\u00DChendriikide v\u00E4ikesed hajasaared", "common": "\u00DChendriikide hajasaared"},
 			"zho": {"official": "\u7F8E\u56FD\u672C\u571F\u5916\u5C0F\u5C9B\u5C7F", "common": "\u7F8E\u56FD\u672C\u571F\u5916\u5C0F\u5C9B\u5C7F"}
 		},
-		"latlng": [],
+		"latlng": [19.3, 166.633333],
 		"demonym": "American",
 		"landlocked": false,
 		"borders": [],


### PR DESCRIPTION
 centered on Wake Island, UM's largest territory.

sources: 
- [List of territories in UM](https://en.wikipedia.org/wiki/United_States_Minor_Outlying_Islands#Islands)
- [Coordinates of Wake Island](https://tools.wmflabs.org/geohack/geohack.php?pagename=United_States_Minor_Outlying_Islands&params=19_18_N_166_38_E_type:isle_region:US-UM&title=Wake+Island)