### PR TITLE
Fix cli info format

### DIFF
--- a/src/MLD/Console/Command/ExportCommand.php
+++ b/src/MLD/Console/Command/ExportCommand.php
@@ -120,7 +120,8 @@ class ExportCommand extends Command
                 ->save($c['output_file']);
         }
 
-        $output->writeln('Converted data for <info>' . count($countries) . '</info> countries into <info>' . count($this->converters) . '</info> formats.');
+        $count = count($formats);
+        $output->writeln('Converted data for <info>' . count($countries) . '</info> countries into <info>' . $count . '</info> ' . ($count == 1 ? 'format.' : 'formats.'));
     }
 
     /**


### PR DESCRIPTION
Currently the convert script always displays the total number of formats
it is able to export to, no matter how many of which have actually been
selected:
```
Converted data for 250 countries into 5 formats.
```
This is now fixed. Calling the convert script with, say, `-f csv` it now
displays `[...] into 1 format.`