### PR TITLE
Fix Vatican City demonym

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -12377,7 +12377,7 @@
 			"zho": {"official": "\u68B5\u8482\u5188\u57CE\u56FD", "common": "\u68B5\u8482\u5188"}
 		},
 		"latlng": [41.9, 12.45],
-		"demonym": "Italian",
+		"demonym": "Vatican",
 		"landlocked": true,
 		"borders": ["ITA"],
 		"area": 0.44,


### PR DESCRIPTION
currently the Vatican City demonym is Italian, I think should be set to Vatican, as described in Wikipedia: [List_of_adjectival_and_demonymic_forms_for_countries_and_nations](https://en.wikipedia.org/wiki/List_of_adjectival_and_demonymic_forms_for_countries_and_nations)