### PR TITLE
Fix Macau demonym

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -7188,7 +7188,7 @@
 			"est": {"official": "Macau erihalduspiirkond", "common": "Macau"}
 		},
 		"latlng": [22.16666666, 113.55],
-		"demonym": "Chinese",
+		"demonym": "Macanese",
 		"landlocked": false,
 		"borders": ["CHN"],
 		"area": 30,


### PR DESCRIPTION
currently the Macau demonym is Chinese, I think should be set to Macanese, as described in Wikipedia: 
[Macau](https://en.wikipedia.org/wiki/Macau)