### PR TITLE
Republik Südafrika -> Südafrika

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -13165,7 +13165,7 @@
 		},
 		"translations": {
 			"ces": {"official": "Jihoafrick\u00e1 republika", "common": "Jihoafrick\u00e1 republika"},
-			"deu": {"official": "Republik S\u00fcdafrika", "common": "Republik S\u00fcdafrika"},
+			"deu": {"official": "Republik S\u00fcdafrika", "common": "S\u00fcdafrika"},
 			"fra": {"official": "R\u00e9publique d'Afrique du Sud", "common": "Afrique du Sud"},
 			"hrv": {"official": "Ju\u017enoafri\u010dka Republika", "common": "Ju\u017enoafri\u010dka Republika"},
 			"ita": {"official": "Repubblica del Sud Africa", "common": "Sud Africa"},


### PR DESCRIPTION
the German (shorter) common name is "Südafrika" instead of "Republik Südafrika"
see https://de.wikipedia.org/wiki/S%C3%BCdafrika