### PR TITLE
Fix invalid "translations" objects.

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -5420,7 +5420,7 @@
 			"spa": {"official": "Hong Kong Regi\u00f3n Administrativa Especial de la Rep\u00fablica Popular China", "common": "Hong Kong"},
 			"fin": {"official": "Hong Kongin erityishallintoalue", "common": "Hongkong"},
 			"est": {"official": "Hongkongi erihalduspiirkond", "common": "Hongkong"},
-			"pol": {"official": "Specjalny Region Administracyjny Chi\u0144skiej Republiki Ludowej Hongkong", "common": "Hongkong"}, "common": "Hong Kong",
+			"pol": {"official": "Specjalny Region Administracyjny Chi\u0144skiej Republiki Ludowej Hongkong", "common": "Hongkong"},
 			"urd": {"official": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 \u06a9\u0627 \u062e\u0635\u0648\u0635\u06cc \u0627\u0646\u062a\u0638\u0627\u0645\u06cc \u0639\u0644\u0627\u0642\u06c1", "common": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af"},
 			"kor": {"official": "\uc911\ud654\uc778\ubbfc\uacf5\ud654\uad6d \ud64d\ucf69 \ud2b9\ubcc4\ud589\uc815\uad6c", "common": "\ud64d\ucf69"}
 
@@ -6741,7 +6741,7 @@
 			"fin": {"official": "Kiribatin tasavalta", "common": "Kiribati"},
 			"est": {"official": "Kiribati Vabariik", "common": "Kiribati"},
 			"zho": {"official": "\u57FA\u91CC\u5DF4\u65AF\u5171\u548C\u56FD", "common": "\u57FA\u91CC\u5DF4\u65AF"},
-			"pol": {"official": "Republika Kiribati", "common": "Kiribati"}, "common": "Kiribati",
+			"pol": {"official": "Republika Kiribati", "common": "Kiribati"},
 			"urd": {"official": "\u0633\u0644\u0637\u0646\u062a \u0622\u0632\u0627\u062f \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc", "common": "\u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc"},
 			"kor": {"official": "\ud0a4\ub9ac\ubc14\uc2dc \uacf5\ud654\uad6d", "common": "\ud0a4\ub9ac\ubc14\uc2dc"}
 


### PR DESCRIPTION
The "translations" objects for "Hong Kong" and "Kiribati" are apparently corrupt. 
Please see the diff. 