### PR TITLE
Official German name for Nepal

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -9431,7 +9431,7 @@
 		"languages": {"nep": "Nepali"},
 		"translations": {
 			"ces": {"official": "Federativn\u00ed demokratick\u00e1 republika Nep\u00e1l", "common": "Nep\u00e1l"},
-			"deu": {"official": "Demokratischen Bundesrepublik Nepal", "common": "Nepal"},
+			"deu": {"official": "Demokratische Bundesrepublik Nepal", "common": "Nepal"},
 			"fra": {"official": "R\u00e9publique du N\u00e9pal", "common": "N\u00e9pal"},
 			"hrv": {"official": "Savezna Demokratska Republika Nepal", "common": "Nepal"},
 			"ita": {"official": "Repubblica federale democratica del Nepal", "common": "Nepal"},


### PR DESCRIPTION
The official German name for Nepal (Demokratische Bundesrepublik Nepal) contained a superfluous letter.