### PR TITLE
Add translated demonyms in French.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ in JSON, CSV and XML. Each line contains the country:
  		- key: official - official name translation
  		- key: common - common name translation
  - latitude and longitude (`latlng`)
- - name of residents (`demonym`)
+ - name of residents in english (`demonym`)
+ - `demonyms` - name of residents, translated & genderized
+    - key: three-letter ISO 639-3 language code
+	- value: genderized demonym object
+		- key: `f` (female) or `m` (male)
+		- value: genderized demonym translation
  - landlocked status (`landlocked`)
  - land borders (`borders`)
  - land area in km² (`area`)
@@ -106,6 +111,16 @@ GeoJSON outlines and flags in SVG format.
 	},
 	"latlng": [47.33333333, 13.33333333],
 	"demonym": "Austrian",
+	"demonyms": {
+		"fra": {
+			"f": "Autrichienne",
+			"m": "Autrichien"
+		},
+		"spa": {
+			"f": "Austriaco",
+			"m": "Austriaca"
+		}
+	},
 	"landlocked": true,
 	"borders": ["CZE", "DEU", "HUN", "ITA", "LIE", "SVK", "SVN", "CHE"],
 	"area": 83871,
@@ -214,7 +229,7 @@ Please refer to [CONTRIBUTING](https://github.com/mledoze/countries/blob/master/
 ## To do
  - add the type of the country (country, sovereign state, public body, territory, etc.)
  - add missing translations
- - pull in data automatically from CLDR at build time (idea from @Munter, see #108) 
+ - pull in data automatically from CLDR at build time (idea from @Munter, see #108)
 
 ## Sources
 https://www.currency-iso.org/ for currency codes.

--- a/countries.json
+++ b/countries.json
@@ -24470,8 +24470,8 @@
         "flag": "\ud83c\uddf3\ud83c\uddff",
         "demonyms": {
             "fra": {
-                "f": "Neo-zelandaise",
-                "m": "Neo-zelandais"
+                "f": "Neo-Z\u00e9landaise",
+                "m": "Neo-Z\u00e9landais"
             }
         }
     },
@@ -25604,8 +25604,8 @@
         "flag": "\ud83c\uddf5\ud83c\uddec",
         "demonyms": {
             "fra": {
-                "f": "Papouane-neoguineenne",
-                "m": "Papouane-neoguineen"
+                "f": "Papouasienne",
+                "m": "Papouasien"
             }
         }
     },
@@ -34085,8 +34085,8 @@
         "flag": "\ud83c\uddfb\ud83c\udde8",
         "demonyms": {
             "fra": {
-                "f": "Saint-Vincentaise-et-Grenadine",
-                "m": "Saint-Vincentaise-et-Grenadin"
+                "f": "Vincentaise",
+                "m": "Vincentais"
             }
         }
     },

--- a/countries.json
+++ b/countries.json
@@ -278,7 +278,13 @@
             "CHN"
         ],
         "area": 652230,
-        "flag": "\ud83c\udde6\ud83c\uddeb"
+        "flag": "\ud83c\udde6\ud83c\uddeb",
+        "demonyms": {
+            "fra": {
+                "f": "Afghane",
+                "m": "Afghan"
+            }
+        }
     },
     {
         "name": {
@@ -399,8 +405,8 @@
                 "common": "\uc559\uace8\ub77c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0646\u06af\u0648\u0644\u0627",
-              "common": "\u0622\u0646\u06af\u0648\u0644\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0646\u06af\u0648\u0644\u0627",
+                "common": "\u0622\u0646\u06af\u0648\u0644\u0627"
             }
         },
         "latlng": [
@@ -416,7 +422,13 @@
             "NAM"
         ],
         "area": 1246700,
-        "flag": "\ud83c\udde6\ud83c\uddf4"
+        "flag": "\ud83c\udde6\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Angolaise",
+                "m": "Angolais"
+            }
+        }
     },
     {
         "name": {
@@ -531,8 +543,8 @@
                 "common": "\uc575\uadc8\ub77c"
             },
             "per": {
-              "official": "\u0622\u0646\u06af\u0648\u06cc\u0644\u0627",
-              "common": "\u0622\u0646\u06af\u0648\u06cc\u0644\u0627"
+                "official": "\u0622\u0646\u06af\u0648\u06cc\u0644\u0627",
+                "common": "\u0622\u0646\u06af\u0648\u06cc\u0644\u0627"
             }
         },
         "latlng": [
@@ -661,8 +673,8 @@
                 "common": "\uc62c\ub780\ub4dc \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0627\u0644\u0646\u062f",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u0627\u0644\u0646\u062f"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0627\u0644\u0646\u062f",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0627\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -795,8 +807,8 @@
                 "common": "\uc54c\ubc14\ub2c8\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0644\u0628\u0627\u0646\u06cc",
-              "common": "\u0622\u0644\u0628\u0627\u0646\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0644\u0628\u0627\u0646\u06cc",
+                "common": "\u0622\u0644\u0628\u0627\u0646\u06cc"
             }
         },
         "latlng": [
@@ -812,7 +824,13 @@
             "UNK"
         ],
         "area": 28748,
-        "flag": "\ud83c\udde6\ud83c\uddf1"
+        "flag": "\ud83c\udde6\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "Albanaise",
+                "m": "Albanais"
+            }
+        }
     },
     {
         "name": {
@@ -933,8 +951,8 @@
                 "common": "\uc548\ub3c4\ub77c"
             },
             "per": {
-              "official": "\u0634\u0627\u0647\u0632\u0627\u062f\u0647\u200c\u0646\u0634\u06cc\u0646 \u0622\u0646\u062f\u0648\u0631\u0627",
-              "common": "\u0622\u0646\u062f\u0648\u0631\u0627"
+                "official": "\u0634\u0627\u0647\u0632\u0627\u062f\u0647\u200c\u0646\u0634\u06cc\u0646 \u0622\u0646\u062f\u0648\u0631\u0627",
+                "common": "\u0622\u0646\u062f\u0648\u0631\u0627"
             }
         },
         "latlng": [
@@ -948,7 +966,13 @@
             "ESP"
         ],
         "area": 468,
-        "flag": "\ud83c\udde6\ud83c\udde9"
+        "flag": "\ud83c\udde6\ud83c\udde9",
+        "demonyms": {
+            "fra": {
+                "f": "Andorrane",
+                "m": "Andorran"
+            }
+        }
     },
     {
         "name": {
@@ -1066,8 +1090,8 @@
                 "common": "\uc544\ub78d\uc5d0\ubbf8\ub9ac\ud2b8"
             },
             "per": {
-              "official": "\u0627\u0645\u0627\u0631\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0639\u0631\u0628\u06cc",
-              "common": "\u0627\u0645\u0627\u0631\u0627\u062a"
+                "official": "\u0627\u0645\u0627\u0631\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0639\u0631\u0628\u06cc",
+                "common": "\u0627\u0645\u0627\u0631\u0627\u062a"
             }
         },
         "latlng": [
@@ -1081,7 +1105,13 @@
             "SAU"
         ],
         "area": 83600,
-        "flag": "\ud83c\udde6\ud83c\uddea"
+        "flag": "\ud83c\udde6\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Emirienne",
+                "m": "Emirien"
+            }
+        }
     },
     {
         "name": {
@@ -1207,8 +1237,8 @@
                 "common": "\uc544\ub974\ud5e8\ud2f0\ub098"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0631\u0698\u0627\u0646\u062a\u06cc\u0646",
-              "common": "\u0622\u0631\u0698\u0627\u0646\u062a\u06cc\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0631\u0698\u0627\u0646\u062a\u06cc\u0646",
+                "common": "\u0622\u0631\u0698\u0627\u0646\u062a\u06cc\u0646"
             }
         },
         "latlng": [
@@ -1225,7 +1255,13 @@
             "URY"
         ],
         "area": 2780400,
-        "flag": "\ud83c\udde6\ud83c\uddf7"
+        "flag": "\ud83c\udde6\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Argentine",
+                "m": "Argentin"
+            }
+        }
     },
     {
         "name": {
@@ -1347,8 +1383,8 @@
                 "common": "\uc544\ub974\uba54\ub2c8\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0631\u0645\u0646\u0633\u062a\u0627\u0646",
-              "common": "\u0627\u0631\u0645\u0646\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0631\u0645\u0646\u0633\u062a\u0627\u0646",
+                "common": "\u0627\u0631\u0645\u0646\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -1364,7 +1400,13 @@
             "TUR"
         ],
         "area": 29743,
-        "flag": "\ud83c\udde6\ud83c\uddf2"
+        "flag": "\ud83c\udde6\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Arm\u00e9nienne",
+                "m": "Arm\u00e9nien"
+            }
+        }
     },
     {
         "name": {
@@ -1487,8 +1529,8 @@
                 "common": "\uc544\uba54\ub9ac\uce78\uc0ac\ubaa8\uc544"
             },
             "per": {
-              "official": "\u0633\u0627\u0645\u0648\u0622\u06cc \u0622\u0645\u0631\u06cc\u06a9\u0627",
-              "common": "\u0633\u0627\u0645\u0648\u0622\u06cc \u0622\u0645\u0631\u06cc\u06a9\u0627"
+                "official": "\u0633\u0627\u0645\u0648\u0622\u06cc \u0622\u0645\u0631\u06cc\u06a9\u0627",
+                "common": "\u0633\u0627\u0645\u0648\u0622\u06cc \u0622\u0645\u0631\u06cc\u06a9\u0627"
             }
         },
         "latlng": [
@@ -1604,8 +1646,8 @@
                 "common": "\ub0a8\uadf9"
             },
             "per": {
-              "official": "\u062c\u0646\u0648\u0628\u06af\u0627\u0646",
-              "common": "\u062c\u0646\u0648\u0628\u06af\u0627\u0646"
+                "official": "\u062c\u0646\u0648\u0628\u06af\u0627\u0646",
+                "common": "\u062c\u0646\u0648\u0628\u06af\u0627\u0646"
             }
         },
         "latlng": [
@@ -1732,8 +1774,8 @@
                 "common": "\ud504\ub791\uc2a4\ub839 \ub0a8\ubd80\uc640 \ub0a8\uadf9 \uc9c0\uc5ed"
             },
             "per": {
-              "official": "\u0633\u0631\u0632\u0645\u06cc\u0646\u200c\u0647\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u062c\u0646\u0648\u0628\u06af\u0627\u0646\u06cc \u0641\u0631\u0627\u0646\u0633\u0647",
-              "common": "\u0633\u0631\u0632\u0645\u06cc\u0646\u200c\u0647\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u062c\u0646\u0648\u0628\u06af\u0627\u0646\u06cc \u0641\u0631\u0627\u0646\u0633\u0647"
+                "official": "\u0633\u0631\u0632\u0645\u06cc\u0646\u200c\u0647\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u062c\u0646\u0648\u0628\u06af\u0627\u0646\u06cc \u0641\u0631\u0627\u0646\u0633\u0647",
+                "common": "\u0633\u0631\u0632\u0645\u06cc\u0646\u200c\u0647\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u062c\u0646\u0648\u0628\u06af\u0627\u0646\u06cc \u0641\u0631\u0627\u0646\u0633\u0647"
             }
         },
         "latlng": [
@@ -1863,8 +1905,8 @@
                 "common": "\uc564\ud2f0\uac00 \ubc14\ubd80\ub2e4"
             },
             "per": {
-              "official": "\u0622\u0646\u062a\u06cc\u06af\u0648\u0627 \u0648 \u0628\u0627\u0631\u0628\u0648\u062f\u0627",
-              "common": "\u0622\u0646\u062a\u06cc\u06af\u0648\u0627 \u0648 \u0628\u0627\u0631\u0628\u0648\u062f\u0627"
+                "official": "\u0622\u0646\u062a\u06cc\u06af\u0648\u0627 \u0648 \u0628\u0627\u0631\u0628\u0648\u062f\u0627",
+                "common": "\u0622\u0646\u062a\u06cc\u06af\u0648\u0627 \u0648 \u0628\u0627\u0631\u0628\u0648\u062f\u0627"
             }
         },
         "latlng": [
@@ -1875,7 +1917,13 @@
         "landlocked": false,
         "borders": [],
         "area": 442,
-        "flag": "\ud83c\udde6\ud83c\uddec"
+        "flag": "\ud83c\udde6\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Antiguaise et barbudienne",
+                "m": "Antiguaise et barbudien"
+            }
+        }
     },
     {
         "name": {
@@ -1994,8 +2042,8 @@
                 "common": "\ud638\uc8fc"
             },
             "per": {
-              "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u0627\u0633\u062a\u0631\u0627\u0644\u06cc\u0627",
-              "common": "\u0627\u0633\u062a\u0631\u0627\u0644\u06cc\u0627"
+                "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u0627\u0633\u062a\u0631\u0627\u0644\u06cc\u0627",
+                "common": "\u0627\u0633\u062a\u0631\u0627\u0644\u06cc\u0627"
             }
         },
         "latlng": [
@@ -2006,7 +2054,13 @@
         "landlocked": false,
         "borders": [],
         "area": 7692024,
-        "flag": "\ud83c\udde6\ud83c\uddfa"
+        "flag": "\ud83c\udde6\ud83c\uddfa",
+        "demonyms": {
+            "fra": {
+                "f": "Australienne",
+                "m": "Australien"
+            }
+        }
     },
     {
         "name": {
@@ -2127,8 +2181,8 @@
                 "common": "\uc624\uc2a4\ud2b8\ub9ac\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u062a\u0631\u06cc\u0634",
-              "common": "\u0627\u062a\u0631\u06cc\u0634"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u062a\u0631\u06cc\u0634",
+                "common": "\u0627\u062a\u0631\u06cc\u0634"
             }
         },
         "latlng": [
@@ -2148,7 +2202,13 @@
             "CHE"
         ],
         "area": 83871,
-        "flag": "\ud83c\udde6\ud83c\uddf9"
+        "flag": "\ud83c\udde6\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Autrichienne",
+                "m": "Autrichien"
+            }
+        }
     },
     {
         "name": {
@@ -2274,8 +2334,8 @@
                 "common": "\uc544\uc81c\ub974\ubc14\uc774\uc794"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0630\u0631\u0628\u0627\u06cc\u062c\u0627\u0646",
-              "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0630\u0631\u0628\u0627\u06cc\u062c\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0630\u0631\u0628\u0627\u06cc\u062c\u0627\u0646",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0630\u0631\u0628\u0627\u06cc\u062c\u0627\u0646"
             }
         },
         "latlng": [
@@ -2292,7 +2352,13 @@
             "TUR"
         ],
         "area": 86600,
-        "flag": "\ud83c\udde6\ud83c\uddff"
+        "flag": "\ud83c\udde6\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Azerba\u00efdjanaise",
+                "m": "Azerba\u00efdjanais"
+            }
+        }
     },
     {
         "name": {
@@ -2419,8 +2485,8 @@
                 "common": "\ubd80\ub8ec\ub514"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u0631\u0648\u0646\u062f\u06cc",
-              "common": "\u0628\u0648\u0631\u0648\u0646\u062f\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u0631\u0648\u0646\u062f\u06cc",
+                "common": "\u0628\u0648\u0631\u0648\u0646\u062f\u06cc"
             }
         },
         "latlng": [
@@ -2435,7 +2501,13 @@
             "TZA"
         ],
         "area": 27834,
-        "flag": "\ud83c\udde7\ud83c\uddee"
+        "flag": "\ud83c\udde7\ud83c\uddee",
+        "demonyms": {
+            "fra": {
+                "f": "Burundaise",
+                "m": "Burundais"
+            }
+        }
     },
     {
         "name": {
@@ -2572,8 +2644,8 @@
                 "common": "\ubca8\uae30\uc5d0"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0628\u0644\u0698\u06cc\u06a9",
-              "common": "\u0628\u0644\u0698\u06cc\u06a9"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0628\u0644\u0698\u06cc\u06a9",
+                "common": "\u0628\u0644\u0698\u06cc\u06a9"
             }
         },
         "latlng": [
@@ -2589,7 +2661,13 @@
             "NLD"
         ],
         "area": 30528,
-        "flag": "\ud83c\udde7\ud83c\uddea"
+        "flag": "\ud83c\udde7\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Belge",
+                "m": "Belge"
+            }
+        }
     },
     {
         "name": {
@@ -2710,8 +2788,8 @@
                 "common": "\ubca0\ub0c9"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0646\u06cc\u0646",
-              "common": "\u0628\u0646\u06cc\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0646\u06cc\u0646",
+                "common": "\u0628\u0646\u06cc\u0646"
             }
         },
         "latlng": [
@@ -2727,7 +2805,13 @@
             "TGO"
         ],
         "area": 112622,
-        "flag": "\ud83c\udde7\ud83c\uddef"
+        "flag": "\ud83c\udde7\ud83c\uddef",
+        "demonyms": {
+            "fra": {
+                "f": "B\u00e9ninoise",
+                "m": "B\u00e9ninois"
+            }
+        }
     },
     {
         "name": {
@@ -2846,8 +2930,8 @@
                 "common": "\ubd80\ub974\ud0a4\ub098\ud30c\uc18c"
             },
             "per": {
-              "official": "\u0628\u0648\u0631\u06a9\u06cc\u0646\u0627\u0641\u0627\u0633\u0648",
-              "common": "\u0628\u0648\u0631\u06a9\u06cc\u0646\u0627\u0641\u0627\u0633\u0648"
+                "official": "\u0628\u0648\u0631\u06a9\u06cc\u0646\u0627\u0641\u0627\u0633\u0648",
+                "common": "\u0628\u0648\u0631\u06a9\u06cc\u0646\u0627\u0641\u0627\u0633\u0648"
             }
         },
         "latlng": [
@@ -2865,7 +2949,13 @@
             "TGO"
         ],
         "area": 272967,
-        "flag": "\ud83c\udde7\ud83c\uddeb"
+        "flag": "\ud83c\udde7\ud83c\uddeb",
+        "demonyms": {
+            "fra": {
+                "f": "Burkinab\u00e9e",
+                "m": "Burkinab\u00e9"
+            }
+        }
     },
     {
         "name": {
@@ -2986,8 +3076,8 @@
                 "common": "\ubc29\uae00\ub77c\ub370\uc2dc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062e\u0644\u0642 \u0628\u0646\u06af\u0644\u0627\u062f\u0634",
-              "common": "\u0628\u0646\u06af\u0644\u0627\u062f\u0634"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062e\u0644\u0642 \u0628\u0646\u06af\u0644\u0627\u062f\u0634",
+                "common": "\u0628\u0646\u06af\u0644\u0627\u062f\u0634"
             }
         },
         "latlng": [
@@ -3001,7 +3091,13 @@
             "IND"
         ],
         "area": 147570,
-        "flag": "\ud83c\udde7\ud83c\udde9"
+        "flag": "\ud83c\udde7\ud83c\udde9",
+        "demonyms": {
+            "fra": {
+                "f": "Bangladaise",
+                "m": "Bangladais"
+            }
+        }
     },
     {
         "name": {
@@ -3122,8 +3218,8 @@
                 "common": "\ubd88\uac00\ub9ac\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0644\u063a\u0627\u0631\u0633\u062a\u0627\u0646",
-              "common": "\u0628\u0644\u063a\u0627\u0631\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0644\u063a\u0627\u0631\u0633\u062a\u0627\u0646",
+                "common": "\u0628\u0644\u063a\u0627\u0631\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -3140,7 +3236,13 @@
             "TUR"
         ],
         "area": 110879,
-        "flag": "\ud83c\udde7\ud83c\uddec"
+        "flag": "\ud83c\udde7\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Bulgare",
+                "m": "Bulgare"
+            }
+        }
     },
     {
         "name": {
@@ -3261,8 +3363,8 @@
                 "common": "\ubc14\ub808\uc778"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0628\u062d\u0631\u06cc\u0646",
-              "common": "\u0628\u062d\u0631\u06cc\u0646"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0628\u062d\u0631\u06cc\u0646",
+                "common": "\u0628\u062d\u0631\u06cc\u0646"
             }
         },
         "latlng": [
@@ -3273,7 +3375,13 @@
         "landlocked": false,
         "borders": [],
         "area": 765,
-        "flag": "\ud83c\udde7\ud83c\udded"
+        "flag": "\ud83c\udde7\ud83c\udded",
+        "demonyms": {
+            "fra": {
+                "f": "Bahre\u00efnienne",
+                "m": "Bahre\u00efnien"
+            }
+        }
     },
     {
         "name": {
@@ -3397,8 +3505,8 @@
                 "common": "\ubc14\ud558\ub9c8"
             },
             "per": {
-              "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u0628\u0627\u0647\u0627\u0645\u0627",
-              "common": "\u0628\u0627\u0647\u0627\u0645\u0627"
+                "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u0628\u0627\u0647\u0627\u0645\u0627",
+                "common": "\u0628\u0627\u0647\u0627\u0645\u0627"
             }
         },
         "latlng": [
@@ -3409,7 +3517,13 @@
         "landlocked": false,
         "borders": [],
         "area": 13943,
-        "flag": "\ud83c\udde7\ud83c\uddf8"
+        "flag": "\ud83c\udde7\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Bahamienne",
+                "m": "Bahamien"
+            }
+        }
     },
     {
         "name": {
@@ -3540,8 +3654,8 @@
                 "common": "\ubcf4\uc2a4\ub2c8\uc544 \ud5e4\ub974\uccb4\uace0\ube44\ub098"
             },
             "per": {
-              "official": "\u0628\u0648\u0633\u0646\u06cc \u0648 \u0647\u0631\u0632\u06af\u0648\u06cc\u0646",
-              "common": "\u0628\u0648\u0633\u0646\u06cc \u0648 \u0647\u0631\u0632\u06af\u0648\u06cc\u0646"
+                "official": "\u0628\u0648\u0633\u0646\u06cc \u0648 \u0647\u0631\u0632\u06af\u0648\u06cc\u0646",
+                "common": "\u0628\u0648\u0633\u0646\u06cc \u0648 \u0647\u0631\u0632\u06af\u0648\u06cc\u0646"
             }
         },
         "latlng": [
@@ -3556,7 +3670,13 @@
             "SRB"
         ],
         "area": 51209,
-        "flag": "\ud83c\udde7\ud83c\udde6"
+        "flag": "\ud83c\udde7\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Bosnienne",
+                "m": "Bosnien"
+            }
+        }
     },
     {
         "name": {
@@ -3674,8 +3794,8 @@
                 "common": "\uc0dd\ubc14\ub974\ud154\ub808\ubbf8"
             },
             "per": {
-              "official": "\u0633\u0646 \u0628\u0627\u0631\u062a\u0644\u0645\u06cc",
-              "common": "\u0633\u0646 \u0628\u0627\u0631\u062a\u0644\u0645\u06cc"
+                "official": "\u0633\u0646 \u0628\u0627\u0631\u062a\u0644\u0645\u06cc",
+                "common": "\u0633\u0646 \u0628\u0627\u0631\u062a\u0644\u0645\u06cc"
             }
         },
         "latlng": [
@@ -3808,8 +3928,8 @@
                 "common": "\uc138\uc778\ud2b8\ud5ec\ub808\ub098"
             },
             "per": {
-              "official": "\u0633\u0646\u062a \u0647\u0644\u0646",
-              "common": "\u0633\u0646\u062a \u0647\u0644\u0646"
+                "official": "\u0633\u0646\u062a \u0647\u0644\u0646",
+                "common": "\u0633\u0646\u062a \u0647\u0644\u0646"
             }
         },
         "latlng": [
@@ -3948,8 +4068,8 @@
                 "common": "\ubca8\ub77c\ub8e8\uc2a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0644\u0627\u0631\u0648\u0633",
-              "common": "\u0628\u0644\u0627\u0631\u0648\u0633"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0644\u0627\u0631\u0648\u0633",
+                "common": "\u0628\u0644\u0627\u0631\u0648\u0633"
             }
         },
         "latlng": [
@@ -3966,7 +4086,13 @@
             "UKR"
         ],
         "area": 207600,
-        "flag": "\ud83c\udde7\ud83c\uddfe"
+        "flag": "\ud83c\udde7\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Bi\u00e9lorusse",
+                "m": "Bi\u00e9lorusse"
+            }
+        }
     },
     {
         "name": {
@@ -4095,8 +4221,8 @@
                 "common": "\ubca8\ub9ac\uc988"
             },
             "per": {
-              "official": "\u0628\u0644\u06cc\u0632",
-              "common": "\u0628\u0644\u06cc\u0632"
+                "official": "\u0628\u0644\u06cc\u0632",
+                "common": "\u0628\u0644\u06cc\u0632"
             }
         },
         "latlng": [
@@ -4110,7 +4236,13 @@
             "MEX"
         ],
         "area": 22966,
-        "flag": "\ud83c\udde7\ud83c\uddff"
+        "flag": "\ud83c\udde7\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "B\u00e9lizienne",
+                "m": "B\u00e9lizien"
+            }
+        }
     },
     {
         "name": {
@@ -4232,8 +4364,8 @@
                 "common": "\ubc84\ubba4\ub2e4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0628\u0631\u0645\u0648\u062f\u0627",
-              "common": "\u0628\u0631\u0645\u0648\u062f\u0627"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0628\u0631\u0645\u0648\u062f\u0627",
+                "common": "\u0628\u0631\u0645\u0648\u062f\u0627"
             }
         },
         "latlng": [
@@ -4386,8 +4518,8 @@
                 "common": "\ubcfc\ub9ac\ube44\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u0644\u06cc\u0648\u06cc",
-              "common": "\u0628\u0648\u0644\u06cc\u0648\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u0644\u06cc\u0648\u06cc",
+                "common": "\u0628\u0648\u0644\u06cc\u0648\u06cc"
             }
         },
         "latlng": [
@@ -4404,7 +4536,13 @@
             "PER"
         ],
         "area": 1098581,
-        "flag": "\ud83c\udde7\ud83c\uddf4"
+        "flag": "\ud83c\udde7\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Bolivienne",
+                "m": "Bolivien"
+            }
+        }
     },
     {
         "name": {
@@ -4524,8 +4662,8 @@
                 "common": "\uce74\ub9ac\ube0c \ub124\ub35c\ub780\ub4dc"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0627\u0631\u0627\u0626\u06cc\u0628 \u0647\u0644\u0646\u062f",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0627\u0631\u0627\u0626\u06cc\u0628 \u0647\u0644\u0646\u062f"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0627\u0631\u0627\u0626\u06cc\u0628 \u0647\u0644\u0646\u062f",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0627\u0631\u0627\u0626\u06cc\u0628 \u0647\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -4658,8 +4796,8 @@
                 "common": "\ube0c\ub77c\uc9c8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u062a\u06cc\u0648 \u0628\u0631\u0632\u06cc\u0644",
-              "common": "\u0628\u0631\u0632\u06cc\u0644"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u062a\u06cc\u0648 \u0628\u0631\u0632\u06cc\u0644",
+                "common": "\u0628\u0631\u0632\u06cc\u0644"
             }
         },
         "latlng": [
@@ -4681,7 +4819,13 @@
             "VEN"
         ],
         "area": 8515767,
-        "flag": "\ud83c\udde7\ud83c\uddf7"
+        "flag": "\ud83c\udde7\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Br\u00e9silienne",
+                "m": "Br\u00e9silien"
+            }
+        }
     },
     {
         "name": {
@@ -4800,8 +4944,8 @@
                 "common": "\ubc14\ubca0\uc774\ub3c4\uc2a4"
             },
             "per": {
-              "official": "\u0628\u0627\u0631\u0628\u0627\u062f\u0648\u0633",
-              "common": "\u0628\u0627\u0631\u0628\u0627\u062f\u0648\u0633"
+                "official": "\u0628\u0627\u0631\u0628\u0627\u062f\u0648\u0633",
+                "common": "\u0628\u0627\u0631\u0628\u0627\u062f\u0648\u0633"
             }
         },
         "latlng": [
@@ -4812,7 +4956,13 @@
         "landlocked": false,
         "borders": [],
         "area": 430,
-        "flag": "\ud83c\udde7\ud83c\udde7"
+        "flag": "\ud83c\udde7\ud83c\udde7",
+        "demonyms": {
+            "fra": {
+                "f": "Barbadienne",
+                "m": "Barbadien"
+            }
+        }
     },
     {
         "name": {
@@ -4938,8 +5088,8 @@
                 "common": "\ube0c\ub8e8\ub098\uc774"
             },
             "per": {
-              "official": "\u0628\u0631\u0648\u0646\u0626\u06cc \u0633\u0631\u0627\u06cc \u0635\u0644\u062d",
-              "common": "\u0628\u0631\u0648\u0646\u0626\u06cc"
+                "official": "\u0628\u0631\u0648\u0646\u0626\u06cc \u0633\u0631\u0627\u06cc \u0635\u0644\u062d",
+                "common": "\u0628\u0631\u0648\u0646\u0626\u06cc"
             }
         },
         "latlng": [
@@ -4952,7 +5102,13 @@
             "MYS"
         ],
         "area": 5765,
-        "flag": "\ud83c\udde7\ud83c\uddf3"
+        "flag": "\ud83c\udde7\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Brun\u00e9ienne",
+                "m": "Brun\u00e9ien"
+            }
+        }
     },
     {
         "name": {
@@ -5076,8 +5232,8 @@
                 "common": "\ubd80\ud0c4"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0628\u0648\u062a\u0627\u0646",
-              "common": "\u0628\u0648\u062a\u0627\u0646"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0628\u0648\u062a\u0627\u0646",
+                "common": "\u0628\u0648\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -5091,7 +5247,13 @@
             "IND"
         ],
         "area": 38394,
-        "flag": "\ud83c\udde7\ud83c\uddf9"
+        "flag": "\ud83c\udde7\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Bhoutanaise",
+                "m": "Bhoutanais"
+            }
+        }
     },
     {
         "name": {
@@ -5203,8 +5365,8 @@
                 "common": "\ubd80\ubca0 \uc12c"
             },
             "per": {
-              "official": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0628\u0648\u0648\u0647",
-              "common": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0628\u0648\u0648\u0647"
+                "official": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0628\u0648\u0648\u0647",
+                "common": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0628\u0648\u0648\u0647"
             }
         },
         "latlng": [
@@ -5337,8 +5499,8 @@
                 "common": "\ubcf4\uce20\uc640\ub098"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627",
-              "common": "\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627",
+                "common": "\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627"
             }
         },
         "latlng": [
@@ -5354,7 +5516,13 @@
             "ZWE"
         ],
         "area": 582000,
-        "flag": "\ud83c\udde7\ud83c\uddfc"
+        "flag": "\ud83c\udde7\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Botswanaise",
+                "m": "Botswanais"
+            }
+        }
     },
     {
         "name": {
@@ -5480,8 +5648,8 @@
                 "common": "\uc911\uc559\uc544\ud504\ub9ac\uce74 \uacf5\ud654\uad6d"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u0645\u0631\u06a9\u0632\u06cc",
-              "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u0645\u0631\u06a9\u0632\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u0645\u0631\u06a9\u0632\u06cc",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u0645\u0631\u06a9\u0632\u06cc"
             }
         },
         "latlng": [
@@ -5499,7 +5667,13 @@
             "SDN"
         ],
         "area": 622984,
-        "flag": "\ud83c\udde8\ud83c\uddeb"
+        "flag": "\ud83c\udde8\ud83c\uddeb",
+        "demonyms": {
+            "fra": {
+                "f": "Centrafricaine",
+                "m": "Centrafricain"
+            }
+        }
     },
     {
         "name": {
@@ -5623,8 +5797,8 @@
                 "common": "\uce90\ub098\ub2e4"
             },
             "per": {
-              "official": "\u06a9\u0627\u0646\u0627\u062f\u0627",
-              "common": "\u06a9\u0627\u0646\u0627\u062f\u0627"
+                "official": "\u06a9\u0627\u0646\u0627\u062f\u0627",
+                "common": "\u06a9\u0627\u0646\u0627\u062f\u0627"
             }
         },
         "latlng": [
@@ -5637,7 +5811,13 @@
             "USA"
         ],
         "area": 9984670,
-        "flag": "\ud83c\udde8\ud83c\udde6"
+        "flag": "\ud83c\udde8\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Canadienne",
+                "m": "Canadien"
+            }
+        }
     },
     {
         "name": {
@@ -5758,8 +5938,8 @@
                 "common": "\ucf54\ucf54\uc2a4 \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9\u0648\u0633",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9\u0648\u0633"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9\u0648\u0633",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9\u0648\u0633"
             }
         },
         "latlng": [
@@ -5905,8 +6085,8 @@
                 "common": "\uc2a4\uc704\uc2a4"
             },
             "per": {
-              "official": "\u06a9\u0646\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0633\u0648\u0626\u06cc\u0633",
-              "common": "\u0633\u0648\u0626\u06cc\u0633"
+                "official": "\u06a9\u0646\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0633\u0648\u0626\u06cc\u0633",
+                "common": "\u0633\u0648\u0626\u06cc\u0633"
             }
         },
         "latlng": [
@@ -5923,7 +6103,13 @@
             "DEU"
         ],
         "area": 41284,
-        "flag": "\ud83c\udde8\ud83c\udded"
+        "flag": "\ud83c\udde8\ud83c\udded",
+        "demonyms": {
+            "fra": {
+                "f": "Suisse",
+                "m": "Suisse"
+            }
+        }
     },
     {
         "name": {
@@ -6044,8 +6230,8 @@
                 "common": "\uce60\ub808"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0634\u06cc\u0644\u06cc",
-              "common": "\u0634\u06cc\u0644\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0634\u06cc\u0644\u06cc",
+                "common": "\u0634\u06cc\u0644\u06cc"
             }
         },
         "latlng": [
@@ -6060,7 +6246,13 @@
             "PER"
         ],
         "area": 756102,
-        "flag": "\ud83c\udde8\ud83c\uddf1"
+        "flag": "\ud83c\udde8\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "Chilienne",
+                "m": "Chilien"
+            }
+        }
     },
     {
         "name": {
@@ -6185,8 +6377,8 @@
                 "common": "\uc911\uad6d"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062e\u0644\u0642 \u0686\u06cc\u0646",
-              "common": "\u0686\u06cc\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062e\u0644\u0642 \u0686\u06cc\u0646",
+                "common": "\u0686\u06cc\u0646"
             }
         },
         "latlng": [
@@ -6214,7 +6406,13 @@
             "VNM"
         ],
         "area": 9706961,
-        "flag": "\ud83c\udde8\ud83c\uddf3"
+        "flag": "\ud83c\udde8\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Chinoise",
+                "m": "Chinois"
+            }
+        }
     },
     {
         "name": {
@@ -6333,8 +6531,8 @@
                 "common": "\ucf54\ud2b8\ub514\ubd80\uc544\ub974"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0627\u062d\u0644 \u0639\u0627\u062c",
-              "common": "\u0633\u0627\u062d\u0644 \u0639\u0627\u062c"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0627\u062d\u0644 \u0639\u0627\u062c",
+                "common": "\u0633\u0627\u062d\u0644 \u0639\u0627\u062c"
             }
         },
         "latlng": [
@@ -6351,7 +6549,13 @@
             "MLI"
         ],
         "area": 322463,
-        "flag": "\ud83c\udde8\ud83c\uddee"
+        "flag": "\ud83c\udde8\ud83c\uddee",
+        "demonyms": {
+            "fra": {
+                "f": "Ivoirienne",
+                "m": "Ivoirien"
+            }
+        }
     },
     {
         "name": {
@@ -6477,8 +6681,8 @@
                 "common": "\uce74\uba54\ub8ec"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0627\u0645\u0650\u0631\u0648\u0646",
-              "common": "\u06a9\u0627\u0645\u0650\u0631\u0648\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0627\u0645\u0650\u0631\u0648\u0646",
+                "common": "\u06a9\u0627\u0645\u0650\u0631\u0648\u0646"
             }
         },
         "latlng": [
@@ -6496,7 +6700,13 @@
             "NGA"
         ],
         "area": 475442,
-        "flag": "\ud83c\udde8\ud83c\uddf2"
+        "flag": "\ud83c\udde8\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Camerounaise",
+                "m": "Camerounais"
+            }
+        }
     },
     {
         "name": {
@@ -6639,8 +6849,8 @@
                 "common": "\ucf69\uace0 \ubbfc\uc8fc \uacf5\ud654\uad6d"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u06a9\u0646\u06af\u0648",
-              "common": "\u06a9\u0646\u06af\u0648 \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u06a9\u0646\u06af\u0648",
+                "common": "\u06a9\u0646\u06af\u0648 \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9"
             }
         },
         "latlng": [
@@ -6792,8 +7002,8 @@
                 "common": "\ucf69\uace0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0631\u0627\u0632\u0627\u0648\u06cc\u0644 \u06a9\u064f\u0646\u06af\u0648",
-              "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u064f\u0646\u06af\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0631\u0627\u0632\u0627\u0648\u06cc\u0644 \u06a9\u064f\u0646\u06af\u0648",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u064f\u0646\u06af\u0648"
             }
         },
         "latlng": [
@@ -6810,7 +7020,13 @@
             "GAB"
         ],
         "area": 342000,
-        "flag": "\ud83c\udde8\ud83c\uddec"
+        "flag": "\ud83c\udde8\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Congolaise",
+                "m": "Congolais"
+            }
+        }
     },
     {
         "name": {
@@ -6939,8 +7155,8 @@
                 "common": "\ucfe1 \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u06a9"
             }
         },
         "latlng": [
@@ -7072,8 +7288,8 @@
                 "common": "\ucf5c\ub86c\ube44\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0644\u0645\u0628\u06cc\u0627",
-              "common": "\u06a9\u0644\u0645\u0628\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0644\u0645\u0628\u06cc\u0627",
+                "common": "\u06a9\u0644\u0645\u0628\u06cc\u0627"
             }
         },
         "latlng": [
@@ -7090,7 +7306,13 @@
             "VEN"
         ],
         "area": 1141748,
-        "flag": "\ud83c\udde8\ud83c\uddf4"
+        "flag": "\ud83c\udde8\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Colombienne",
+                "m": "Colombien"
+            }
+        }
     },
     {
         "name": {
@@ -7223,8 +7445,8 @@
                 "common": "\ucf54\ubaa8\ub85c"
             },
             "per": {
-              "official": "\u0645\u062c\u0645\u0639\u200c\u0627\u0644\u062c\u0632\u0627\u06cc\u0631 \u0642\u0645\u0631",
-              "common": "\u0627\u062a\u062d\u0627\u062f \u0642\u064f\u0645\u064f\u0631"
+                "official": "\u0645\u062c\u0645\u0639\u200c\u0627\u0644\u062c\u0632\u0627\u06cc\u0631 \u0642\u0645\u0631",
+                "common": "\u0627\u062a\u062d\u0627\u062f \u0642\u064f\u0645\u064f\u0631"
             }
         },
         "latlng": [
@@ -7235,7 +7457,13 @@
         "landlocked": false,
         "borders": [],
         "area": 1862,
-        "flag": "\ud83c\uddf0\ud83c\uddf2"
+        "flag": "\ud83c\uddf0\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Comorienne",
+                "m": "Comorien"
+            }
+        }
     },
     {
         "name": {
@@ -7356,8 +7584,8 @@
                 "common": "\uce74\ubcf4\ubca0\ub974\ub370"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0628\u0648 \u0648\u0631\u062f",
-              "common": "\u062f\u0645\u0627\u063a\u0647\u0654 \u0633\u0628\u0632"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0628\u0648 \u0648\u0631\u062f",
+                "common": "\u062f\u0645\u0627\u063a\u0647\u0654 \u0633\u0628\u0632"
             }
         },
         "latlng": [
@@ -7368,7 +7596,13 @@
         "landlocked": false,
         "borders": [],
         "area": 4033,
-        "flag": "\ud83c\udde8\ud83c\uddfb"
+        "flag": "\ud83c\udde8\ud83c\uddfb",
+        "demonyms": {
+            "fra": {
+                "f": "Cap-verdienne",
+                "m": "Cap-verdien"
+            }
+        }
     },
     {
         "name": {
@@ -7489,8 +7723,8 @@
                 "common": "\ucf54\uc2a4\ud0c0\ub9ac\uce74"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0627\u0633\u062a\u0627\u0631\u06cc\u06a9\u0627",
-              "common": "\u06a9\u0627\u0633\u062a\u0627\u0631\u06cc\u06a9\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0627\u0633\u062a\u0627\u0631\u06cc\u06a9\u0627",
+                "common": "\u06a9\u0627\u0633\u062a\u0627\u0631\u06cc\u06a9\u0627"
             }
         },
         "latlng": [
@@ -7504,7 +7738,13 @@
             "PAN"
         ],
         "area": 51100,
-        "flag": "\ud83c\udde8\ud83c\uddf7"
+        "flag": "\ud83c\udde8\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Costaricaine",
+                "m": "Costaricain"
+            }
+        }
     },
     {
         "name": {
@@ -7629,8 +7869,8 @@
                 "common": "\ucfe0\ubc14"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0648\u0628\u0627",
-              "common": "\u06a9\u0648\u0628\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0648\u0628\u0627",
+                "common": "\u06a9\u0648\u0628\u0627"
             }
         },
         "latlng": [
@@ -7641,7 +7881,13 @@
         "landlocked": false,
         "borders": [],
         "area": 109884,
-        "flag": "\ud83c\udde8\ud83c\uddfa"
+        "flag": "\ud83c\udde8\ud83c\uddfa",
+        "demonyms": {
+            "fra": {
+                "f": "Cubaine",
+                "m": "Cubain"
+            }
+        }
     },
     {
         "name": {
@@ -7763,8 +8009,8 @@
                 "common": "\ud034\ub77c\uc18c"
             },
             "per": {
-              "official": "\u06a9\u0648\u0631\u0627\u0633\u0627\u0626\u0648",
-              "common": "\u06a9\u0648\u0631\u0627\u0633\u0627\u0626\u0648"
+                "official": "\u06a9\u0648\u0631\u0627\u0633\u0627\u0626\u0648",
+                "common": "\u06a9\u0648\u0631\u0627\u0633\u0627\u0626\u0648"
             }
         },
         "latlng": [
@@ -7775,7 +8021,13 @@
         "landlocked": false,
         "borders": [],
         "area": 444,
-        "flag": "\ud83c\udde8\ud83c\uddfc"
+        "flag": "\ud83c\udde8\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Curacienne",
+                "m": "Curacien"
+            }
+        }
     },
     {
         "name": {
@@ -7895,8 +8147,8 @@
                 "common": "\ud06c\ub9ac\uc2a4\ub9c8\uc2a4 \uc12c"
             },
             "per": {
-              "official": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u06a9\u0631\u06cc\u0633\u0645\u0633",
-              "common": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u06a9\u0631\u06cc\u0633\u0645\u0633"
+                "official": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u06a9\u0631\u06cc\u0633\u0645\u0633",
+                "common": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u06a9\u0631\u06cc\u0633\u0645\u0633"
             }
         },
         "latlng": [
@@ -8026,8 +8278,8 @@
                 "common": "\ucf00\uc774\ub9e8 \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u06cc\u0645\u0646",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u06cc\u0645\u0646"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u06cc\u0645\u0646",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u06cc\u0645\u0646"
             }
         },
         "latlng": [
@@ -8167,8 +8419,8 @@
                 "common": "\ud0a4\ud504\ub85c\uc2a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0642\u0628\u0631\u0633",
-              "common": "\u0642\u0650\u0628\u0631\u0650\u0633"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0642\u0628\u0631\u0633",
+                "common": "\u0642\u0650\u0628\u0631\u0650\u0633"
             }
         },
         "latlng": [
@@ -8179,7 +8431,13 @@
         "landlocked": false,
         "borders": [],
         "area": 9251,
-        "flag": "\ud83c\udde8\ud83c\uddfe"
+        "flag": "\ud83c\udde8\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Chypriote",
+                "m": "Chypriote"
+            }
+        }
     },
     {
         "name": {
@@ -8305,8 +8563,8 @@
                 "common": "\uccb4\ucf54"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u06a9",
-              "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u06a9"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u06a9",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u06a9"
             }
         },
         "latlng": [
@@ -8322,7 +8580,13 @@
             "SVK"
         ],
         "area": 78865,
-        "flag": "\ud83c\udde8\ud83c\uddff"
+        "flag": "\ud83c\udde8\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Tch\u00e8que",
+                "m": "Tch\u00e8que"
+            }
+        }
     },
     {
         "name": {
@@ -8439,8 +8703,8 @@
                 "common": "\ub3c5\uc77c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u0622\u0644\u0645\u0627\u0646",
-              "common": "\u0622\u0644\u0645\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u0622\u0644\u0645\u0627\u0646",
+                "common": "\u0622\u0644\u0645\u0627\u0646"
             }
         },
         "latlng": [
@@ -8461,7 +8725,13 @@
             "CHE"
         ],
         "area": 357114,
-        "flag": "\ud83c\udde9\ud83c\uddea"
+        "flag": "\ud83c\udde9\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Allemande",
+                "m": "Allemand"
+            }
+        }
     },
     {
         "name": {
@@ -8591,8 +8861,8 @@
                 "common": "\uc9c0\ubd80\ud2f0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062c\u06cc\u0628\u0648\u062a\u06cc",
-              "common": "\u062c\u06cc\u0628\u0648\u062a\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062c\u06cc\u0628\u0648\u062a\u06cc",
+                "common": "\u062c\u06cc\u0628\u0648\u062a\u06cc"
             }
         },
         "latlng": [
@@ -8607,7 +8877,13 @@
             "SOM"
         ],
         "area": 23200,
-        "flag": "\ud83c\udde9\ud83c\uddef"
+        "flag": "\ud83c\udde9\ud83c\uddef",
+        "demonyms": {
+            "fra": {
+                "f": "Djiboutienne",
+                "m": "Djiboutien"
+            }
+        }
     },
     {
         "name": {
@@ -8729,8 +9005,8 @@
                 "common": "\ub3c4\ubbf8\ub2c8\uce74 \uacf5\ud654\uad6d"
             },
             "per": {
-              "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0627",
-              "common": "\u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0627"
+                "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0627",
+                "common": "\u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0627"
             }
         },
         "latlng": [
@@ -8741,7 +9017,13 @@
         "landlocked": false,
         "borders": [],
         "area": 751,
-        "flag": "\ud83c\udde9\ud83c\uddf2"
+        "flag": "\ud83c\udde9\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Dominiquaise",
+                "m": "Dominiquais"
+            }
+        }
     },
     {
         "name": {
@@ -8863,8 +9145,8 @@
                 "common": "\ub374\ub9c8\ud06c"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u062f\u0627\u0646\u0645\u0627\u0631\u06a9",
-              "common": "\u062f\u0627\u0646\u0645\u0627\u0631\u06a9"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u062f\u0627\u0646\u0645\u0627\u0631\u06a9",
+                "common": "\u062f\u0627\u0646\u0645\u0627\u0631\u06a9"
             }
         },
         "latlng": [
@@ -8877,7 +9159,13 @@
             "DEU"
         ],
         "area": 43094,
-        "flag": "\ud83c\udde9\ud83c\uddf0"
+        "flag": "\ud83c\udde9\ud83c\uddf0",
+        "demonyms": {
+            "fra": {
+                "f": "Danoise",
+                "m": "Danois"
+            }
+        }
     },
     {
         "name": {
@@ -8998,8 +9286,8 @@
                 "common": "\ub3c4\ubbf8\ub2c8\uce74 \uacf5\ud654\uad6d"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0646",
-              "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0646",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0646"
             }
         },
         "latlng": [
@@ -9012,7 +9300,13 @@
             "HTI"
         ],
         "area": 48671,
-        "flag": "\ud83c\udde9\ud83c\uddf4"
+        "flag": "\ud83c\udde9\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Dominicaine",
+                "m": "Dominicain"
+            }
+        }
     },
     {
         "name": {
@@ -9134,8 +9428,8 @@
                 "common": "\uc54c\uc81c\ub9ac"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u062e\u0644\u0642 \u0627\u0644\u062c\u0632\u0627\u06cc\u0631",
-              "common": "\u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u062e\u0644\u0642 \u0627\u0644\u062c\u0632\u0627\u06cc\u0631",
+                "common": "\u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
             }
         },
         "latlng": [
@@ -9154,7 +9448,13 @@
             "MAR"
         ],
         "area": 2381741,
-        "flag": "\ud83c\udde9\ud83c\uddff"
+        "flag": "\ud83c\udde9\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Alg\u00e9rienne",
+                "m": "Alg\u00e9rien"
+            }
+        }
     },
     {
         "name": {
@@ -9275,8 +9575,8 @@
                 "common": "\uc5d0\ucf70\ub3c4\ub974"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u06a9\u0648\u0627\u062f\u0648\u0631",
-              "common": "\u0627\u06a9\u0648\u0627\u062f\u0648\u0631"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u06a9\u0648\u0627\u062f\u0648\u0631",
+                "common": "\u0627\u06a9\u0648\u0627\u062f\u0648\u0631"
             }
         },
         "latlng": [
@@ -9290,7 +9590,13 @@
             "PER"
         ],
         "area": 276841,
-        "flag": "\ud83c\uddea\ud83c\udde8"
+        "flag": "\ud83c\uddea\ud83c\udde8",
+        "demonyms": {
+            "fra": {
+                "f": "\u00c9quatorienne",
+                "m": "\u00c9quatorien"
+            }
+        }
     },
     {
         "name": {
@@ -9411,8 +9717,8 @@
                 "common": "\uc774\uc9d1\ud2b8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0639\u0631\u0628\u06cc \u0645\u0635\u0631",
-              "common": "\u0645\u0635\u0631"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0639\u0631\u0628\u06cc \u0645\u0635\u0631",
+                "common": "\u0645\u0635\u0631"
             }
         },
         "latlng": [
@@ -9428,7 +9734,13 @@
             "SDN"
         ],
         "area": 1002450,
-        "flag": "\ud83c\uddea\ud83c\uddec"
+        "flag": "\ud83c\uddea\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "\u00c9gyptienne",
+                "m": "\u00c9gyptien"
+            }
+        }
     },
     {
         "name": {
@@ -9562,8 +9874,8 @@
                 "common": "\uc5d0\ub9ac\ud2b8\ub808\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0631\u06cc\u062a\u0631\u0647",
-              "common": "\u0627\u0631\u06cc\u062a\u0631\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0631\u06cc\u062a\u0631\u0647",
+                "common": "\u0627\u0631\u06cc\u062a\u0631\u0647"
             }
         },
         "latlng": [
@@ -9578,7 +9890,13 @@
             "SDN"
         ],
         "area": 117600,
-        "flag": "\ud83c\uddea\ud83c\uddf7"
+        "flag": "\ud83c\uddea\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "\u00c9rythr\u00e9enne",
+                "m": "\u00c9rythr\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -9713,8 +10031,8 @@
                 "common": "\uc11c\uc0ac\ud558\ub77c"
             },
             "per": {
-              "official": "\u0635\u062d\u0631\u0627\u06cc \u063a\u0631\u0628\u06cc",
-              "common": "\u0635\u062d\u0631\u0627\u06cc \u063a\u0631\u0628\u06cc"
+                "official": "\u0635\u062d\u0631\u0627\u06cc \u063a\u0631\u0628\u06cc",
+                "common": "\u0635\u062d\u0631\u0627\u06cc \u063a\u0631\u0628\u06cc"
             }
         },
         "latlng": [
@@ -9846,8 +10164,8 @@
                 "common": "\uc2a4\ud398\uc778"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0627\u0633\u067e\u0627\u0646\u06cc\u0627",
-              "common": "\u0627\u0633\u067e\u0627\u0646\u06cc\u0627"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0627\u0633\u067e\u0627\u0646\u06cc\u0627",
+                "common": "\u0627\u0633\u067e\u0627\u0646\u06cc\u0627"
             }
         },
         "latlng": [
@@ -9864,7 +10182,13 @@
             "MAR"
         ],
         "area": 505992,
-        "flag": "\ud83c\uddea\ud83c\uddf8"
+        "flag": "\ud83c\uddea\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Espagnole",
+                "m": "Espagnol"
+            }
+        }
     },
     {
         "name": {
@@ -9986,8 +10310,8 @@
                 "common": "\uc5d0\uc2a4\ud1a0\ub2c8\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u062a\u0648\u0646\u06cc",
-              "common": "\u0627\u0650\u0633\u062a\u0648\u0646\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u062a\u0648\u0646\u06cc",
+                "common": "\u0627\u0650\u0633\u062a\u0648\u0646\u06cc"
             }
         },
         "latlng": [
@@ -10001,7 +10325,13 @@
             "RUS"
         ],
         "area": 45227,
-        "flag": "\ud83c\uddea\ud83c\uddea"
+        "flag": "\ud83c\uddea\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Estonienne",
+                "m": "Estonien"
+            }
+        }
     },
     {
         "name": {
@@ -10123,8 +10453,8 @@
                 "common": "\uc5d0\ud2f0\uc624\ud53c\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u0627\u062a\u06cc\u0648\u067e\u06cc",
-              "common": "\u0627\u0650\u062a\u06cc\u0648\u067e\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u0627\u062a\u06cc\u0648\u067e\u06cc",
+                "common": "\u0627\u0650\u062a\u06cc\u0648\u067e\u06cc"
             }
         },
         "latlng": [
@@ -10142,7 +10472,13 @@
             "SDN"
         ],
         "area": 1104300,
-        "flag": "\ud83c\uddea\ud83c\uddf9"
+        "flag": "\ud83c\uddea\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "\u00c9thiopienne",
+                "m": "\u00c9thiopien"
+            }
+        }
     },
     {
         "name": {
@@ -10266,8 +10602,8 @@
                 "common": "\ud540\ub780\ub4dc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u0646\u0644\u0627\u0646\u062f",
-              "common": "\u0641\u0646\u0644\u0627\u0646\u062f"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u0646\u0644\u0627\u0646\u062f",
+                "common": "\u0641\u0646\u0644\u0627\u0646\u062f"
             }
         },
         "latlng": [
@@ -10282,7 +10618,13 @@
             "RUS"
         ],
         "area": 338424,
-        "flag": "\ud83c\uddeb\ud83c\uddee"
+        "flag": "\ud83c\uddeb\ud83c\uddee",
+        "demonyms": {
+            "fra": {
+                "f": "Finlandaise",
+                "m": "Finlandais"
+            }
+        }
     },
     {
         "name": {
@@ -10411,8 +10753,8 @@
                 "common": "\ud53c\uc9c0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062c\u0632\u0627\u06cc\u0631 \u0641\u06cc\u062c\u06cc",
-              "common": "\u0641\u06cc\u062c\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062c\u0632\u0627\u06cc\u0631 \u0641\u06cc\u062c\u06cc",
+                "common": "\u0641\u06cc\u062c\u06cc"
             }
         },
         "latlng": [
@@ -10423,7 +10765,13 @@
         "landlocked": false,
         "borders": [],
         "area": 18272,
-        "flag": "\ud83c\uddeb\ud83c\uddef"
+        "flag": "\ud83c\uddeb\ud83c\uddef",
+        "demonyms": {
+            "fra": {
+                "f": "Fidjienne",
+                "m": "Fidjien"
+            }
+        }
     },
     {
         "name": {
@@ -10540,8 +10888,8 @@
                 "common": "\ud3ec\ud074\ub79c\ub4dc \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0644\u06a9\u0644\u0646\u062f",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0644\u06a9\u0644\u0646\u062f"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0644\u06a9\u0644\u0646\u062f",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0644\u06a9\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -10669,8 +11017,8 @@
                 "common": "\ud504\ub791\uc2a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u0631\u0627\u0646\u0633\u0647",
-              "common": "\u0641\u0631\u0627\u0646\u0633\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u0631\u0627\u0646\u0633\u0647",
+                "common": "\u0641\u0631\u0627\u0646\u0633\u0647"
             }
         },
         "latlng": [
@@ -10690,7 +11038,13 @@
             "CHE"
         ],
         "area": 551695,
-        "flag": "\ud83c\uddeb\ud83c\uddf7"
+        "flag": "\ud83c\uddeb\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Fran\u00e7aise",
+                "m": "Fran\u00e7ais"
+            }
+        }
     },
     {
         "name": {
@@ -10816,8 +11170,8 @@
                 "common": "\ud398\ub85c \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0631\u0648\u0626\u0647",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0631\u0648\u0626\u0647"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0631\u0648\u0626\u0647",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0641\u0627\u0631\u0648\u0626\u0647"
             }
         },
         "latlng": [
@@ -10940,8 +11294,8 @@
                 "common": "\ubbf8\ud06c\ub85c\ub124\uc2dc\uc544"
             },
             "per": {
-              "official": "\u0627\u06cc\u0627\u0644\u0627\u062a \u0641\u062f\u0631\u0627\u0644 \u0645\u06cc\u06a9\u0631\u0648\u0646\u0632\u06cc",
-              "common": "\u0645\u06cc\u06a9\u0631\u0648\u0646\u0632\u06cc"
+                "official": "\u0627\u06cc\u0627\u0644\u0627\u062a \u0641\u062f\u0631\u0627\u0644 \u0645\u06cc\u06a9\u0631\u0648\u0646\u0632\u06cc",
+                "common": "\u0645\u06cc\u06a9\u0631\u0648\u0646\u0632\u06cc"
             }
         },
         "latlng": [
@@ -10952,7 +11306,13 @@
         "landlocked": false,
         "borders": [],
         "area": 702,
-        "flag": "\ud83c\uddeb\ud83c\uddf2"
+        "flag": "\ud83c\uddeb\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Micron\u00e9sienne",
+                "m": "Micron\u00e9sien"
+            }
+        }
     },
     {
         "name": {
@@ -11069,8 +11429,8 @@
                 "common": "\uac00\ubd09"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u0627\u0628\u064f\u0646",
-              "common": "\u06af\u0627\u0628\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u0627\u0628\u064f\u0646",
+                "common": "\u06af\u0627\u0628\u0646"
             }
         },
         "latlng": [
@@ -11085,7 +11445,13 @@
             "GNQ"
         ],
         "area": 267668,
-        "flag": "\ud83c\uddec\ud83c\udde6"
+        "flag": "\ud83c\uddec\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Gabonaise",
+                "m": "Gabonais"
+            }
+        }
     },
     {
         "name": {
@@ -11202,8 +11568,8 @@
                 "common": "\uc601\uad6d"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0645\u062a\u062d\u062f \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627\u06cc \u06a9\u0628\u06cc\u0631 \u0648 \u0627\u06cc\u0631\u0644\u0646\u062f \u0634\u0645\u0627\u0644\u06cc",
-              "common": "\u0627\u0646\u06af\u0644\u06cc\u0633"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0645\u062a\u062d\u062f \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627\u06cc \u06a9\u0628\u06cc\u0631 \u0648 \u0627\u06cc\u0631\u0644\u0646\u062f \u0634\u0645\u0627\u0644\u06cc",
+                "common": "\u0627\u0646\u06af\u0644\u06cc\u0633"
             }
         },
         "latlng": [
@@ -11216,7 +11582,13 @@
             "IRL"
         ],
         "area": 242900,
-        "flag": "\ud83c\uddec\ud83c\udde7"
+        "flag": "\ud83c\uddec\ud83c\udde7",
+        "demonyms": {
+            "fra": {
+                "f": "Britannique",
+                "m": "Britannique"
+            }
+        }
     },
     {
         "name": {
@@ -11332,8 +11704,8 @@
                 "common": "\uc870\uc9c0\uc544"
             },
             "per": {
-              "official": "\u06af\u0631\u062c\u0633\u062a\u0627\u0646",
-              "common": "\u06af\u0631\u062c\u0633\u062a\u0627\u0646"
+                "official": "\u06af\u0631\u062c\u0633\u062a\u0627\u0646",
+                "common": "\u06af\u0631\u062c\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -11349,7 +11721,13 @@
             "TUR"
         ],
         "area": 69700,
-        "flag": "\ud83c\uddec\ud83c\uddea"
+        "flag": "\ud83c\uddec\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "G\u00e9orgienne",
+                "m": "G\u00e9orgien"
+            }
+        }
     },
     {
         "name": {
@@ -11480,8 +11858,8 @@
                 "common": "\uac74\uc9c0 \uc12c"
             },
             "per": {
-              "official": "\u06af\u0631\u0646\u0632\u06cc",
-              "common": "\u06af\u0631\u0646\u0632\u06cc"
+                "official": "\u06af\u0631\u0646\u0632\u06cc",
+                "common": "\u06af\u0631\u0646\u0632\u06cc"
             }
         },
         "latlng": [
@@ -11607,8 +11985,8 @@
                 "common": "\uac00\ub098"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u063a\u0646\u0627",
-              "common": "\u063a\u0646\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u063a\u0646\u0627",
+                "common": "\u063a\u0646\u0627"
             }
         },
         "latlng": [
@@ -11623,7 +12001,13 @@
             "TGO"
         ],
         "area": 238533,
-        "flag": "\ud83c\uddec\ud83c\udded"
+        "flag": "\ud83c\uddec\ud83c\udded",
+        "demonyms": {
+            "fra": {
+                "f": "Ghan\u00e9enne",
+                "m": "Ghan\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -11738,8 +12122,8 @@
                 "common": "\uc9c0\ube0c\ub864\ud130"
             },
             "per": {
-              "official": "\u062c\u0628\u0644 \u0637\u0627\u0631\u0642",
-              "common": "\u062c\u0628\u0644 \u0637\u0627\u0631\u0642"
+                "official": "\u062c\u0628\u0644 \u0637\u0627\u0631\u0642",
+                "common": "\u062c\u0628\u0644 \u0637\u0627\u0631\u0642"
             }
         },
         "latlng": [
@@ -11869,8 +12253,8 @@
                 "common": "\uae30\ub2c8"
             },
             "per": {
-              "official": "\u0645\u0645\u0644\u06a9\u062a \u0645\u0633\u062a\u0642\u0644 \u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647 \u0646\u0648",
-              "common": "\u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647 \u0646\u0648"
+                "official": "\u0645\u0645\u0644\u06a9\u062a \u0645\u0633\u062a\u0642\u0644 \u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647 \u0646\u0648",
+                "common": "\u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647 \u0646\u0648"
             }
         },
         "latlng": [
@@ -11888,7 +12272,13 @@
             "SLE"
         ],
         "area": 245857,
-        "flag": "\ud83c\uddec\ud83c\uddf3"
+        "flag": "\ud83c\uddec\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Guin\u00e9enne",
+                "m": "Guin\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -12004,8 +12394,8 @@
                 "common": "\uacfc\ub4e4\ub8e8\ud504"
             },
             "per": {
-              "official": "\u06af\u0648\u0627\u062f\u0644\u0648\u067e",
-              "common": "\u06af\u0648\u0627\u062f\u0644\u0648\u067e"
+                "official": "\u06af\u0648\u0627\u062f\u0644\u0648\u067e",
+                "common": "\u06af\u0648\u0627\u062f\u0644\u0648\u067e"
             }
         },
         "latlng": [
@@ -12132,8 +12522,8 @@
                 "common": "\uac10\ube44\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u0627\u0645\u0628\u06cc\u0627",
-              "common": "\u06af\u0627\u0645\u0628\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u0627\u0645\u0628\u06cc\u0627",
+                "common": "\u06af\u0627\u0645\u0628\u06cc\u0627"
             }
         },
         "latlng": [
@@ -12146,7 +12536,13 @@
             "SEN"
         ],
         "area": 10689,
-        "flag": "\ud83c\uddec\ud83c\uddf2"
+        "flag": "\ud83c\uddec\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Gambienne",
+                "m": "Gambien"
+            }
+        }
     },
     {
         "name": {
@@ -12268,8 +12664,8 @@
                 "common": "\uae30\ub2c8\ube44\uc0ac\uc6b0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u06cc\u0646\u0647 \u0628\u06cc\u0633\u0627\u0626\u0648",
-              "common": "\u06af\u06cc\u0646\u0647 \u0628\u06cc\u0633\u0627\u0626\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u06cc\u0646\u0647 \u0628\u06cc\u0633\u0627\u0626\u0648",
+                "common": "\u06af\u06cc\u0646\u0647 \u0628\u06cc\u0633\u0627\u0626\u0648"
             }
         },
         "latlng": [
@@ -12283,7 +12679,13 @@
             "SEN"
         ],
         "area": 36125,
-        "flag": "\ud83c\uddec\ud83c\uddfc"
+        "flag": "\ud83c\uddec\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Bissau-Guin\u00e9enne",
+                "m": "Bissau-Guin\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -12416,8 +12818,8 @@
                 "common": "\uc801\ub3c4 \uae30\ub2c8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u06cc\u0646\u0647 \u0627\u0633\u062a\u0648\u0627\u06cc\u06cc",
-              "common": "\u06af\u06cc\u0646\u0647 \u0627\u0633\u062a\u0648\u0627\u06cc\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u06cc\u0646\u0647 \u0627\u0633\u062a\u0648\u0627\u06cc\u06cc",
+                "common": "\u06af\u06cc\u0646\u0647 \u0627\u0633\u062a\u0648\u0627\u06cc\u06cc"
             }
         },
         "latlng": [
@@ -12431,7 +12833,13 @@
             "GAB"
         ],
         "area": 28051,
-        "flag": "\ud83c\uddec\ud83c\uddf6"
+        "flag": "\ud83c\uddec\ud83c\uddf6",
+        "demonyms": {
+            "fra": {
+                "f": "\u00c9quato-guin\u00e9enne",
+                "m": "\u00c9quato-guin\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -12549,8 +12957,8 @@
                 "common": "\uadf8\ub9ac\uc2a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06cc\u0648\u0646\u0627\u0646",
-              "common": "\u06cc\u0648\u0646\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06cc\u0648\u0646\u0627\u0646",
+                "common": "\u06cc\u0648\u0646\u0627\u0646"
             }
         },
         "latlng": [
@@ -12566,7 +12974,13 @@
             "MKD"
         ],
         "area": 131990,
-        "flag": "\ud83c\uddec\ud83c\uddf7"
+        "flag": "\ud83c\uddec\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Grecque",
+                "m": "Grec"
+            }
+        }
     },
     {
         "name": {
@@ -12681,8 +13095,8 @@
                 "common": "\uadf8\ub808\ub098\ub2e4"
             },
             "per": {
-              "official": "\u06af\u0631\u0646\u0627\u062f\u0627",
-              "common": "\u06af\u0631\u0646\u0627\u062f\u0627"
+                "official": "\u06af\u0631\u0646\u0627\u062f\u0627",
+                "common": "\u06af\u0631\u0646\u0627\u062f\u0627"
             }
         },
         "latlng": [
@@ -12693,7 +13107,13 @@
         "landlocked": false,
         "borders": [],
         "area": 344,
-        "flag": "\ud83c\uddec\ud83c\udde9"
+        "flag": "\ud83c\uddec\ud83c\udde9",
+        "demonyms": {
+            "fra": {
+                "f": "Grenadienne",
+                "m": "Grenadien"
+            }
+        }
     },
     {
         "name": {
@@ -12809,8 +13229,8 @@
                 "common": "\uadf8\ub9b0\ub780\ub4dc"
             },
             "per": {
-              "official": "\u06af\u0631\u0648\u0626\u0646\u0644\u0646\u062f",
-              "common": "\u06af\u0631\u06cc\u0646\u0644\u0646\u062f"
+                "official": "\u06af\u0631\u0648\u0626\u0646\u0644\u0646\u062f",
+                "common": "\u06af\u0631\u06cc\u0646\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -12936,8 +13356,8 @@
                 "common": "\uacfc\ud14c\ub9d0\ub77c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u0648\u0627\u062a\u0650\u0645\u0627\u0644\u0627",
-              "common": "\u06af\u0648\u0627\u062a\u0650\u0645\u0627\u0644\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06af\u0648\u0627\u062a\u0650\u0645\u0627\u0644\u0627",
+                "common": "\u06af\u0648\u0627\u062a\u0650\u0645\u0627\u0644\u0627"
             }
         },
         "latlng": [
@@ -12953,7 +13373,13 @@
             "MEX"
         ],
         "area": 108889,
-        "flag": "\ud83c\uddec\ud83c\uddf9"
+        "flag": "\ud83c\uddec\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Guat\u00e9malt\u00e8que",
+                "m": "Guat\u00e9malt\u00e8que"
+            }
+        }
     },
     {
         "name": {
@@ -13070,8 +13496,8 @@
                 "common": "\ud504\ub791\uc2a4\ub839 \uae30\uc544\ub098"
             },
             "per": {
-              "official": "\u06af\u0648\u06cc\u0627\u0646 \u0641\u0631\u0627\u0646\u0633\u0647",
-              "common": "\u06af\u0648\u06cc\u0627\u0646 \u0641\u0631\u0627\u0646\u0633\u0647"
+                "official": "\u06af\u0648\u06cc\u0627\u0646 \u0641\u0631\u0627\u0646\u0633\u0647",
+                "common": "\u06af\u0648\u06cc\u0627\u0646 \u0641\u0631\u0627\u0646\u0633\u0647"
             }
         },
         "latlng": [
@@ -13211,8 +13637,8 @@
                 "common": "\uad0c"
             },
             "per": {
-              "official": "\u06af\u0648\u0622\u0645",
-              "common": "\u06af\u0648\u0622\u0645"
+                "official": "\u06af\u0648\u0622\u0645",
+                "common": "\u06af\u0648\u0622\u0645"
             }
         },
         "latlng": [
@@ -13339,8 +13765,8 @@
                 "common": "\uac00\uc774\uc544\ub098"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0639\u0627\u0648\u0646\u06cc \u06af\u0648\u06cc\u0627\u0646",
-              "common": "\u06af\u0648\u06cc\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0639\u0627\u0648\u0646\u06cc \u06af\u0648\u06cc\u0627\u0646",
+                "common": "\u06af\u0648\u06cc\u0627\u0646"
             }
         },
         "latlng": [
@@ -13355,7 +13781,13 @@
             "VEN"
         ],
         "area": 214969,
-        "flag": "\ud83c\uddec\ud83c\uddfe"
+        "flag": "\ud83c\uddec\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Guyanienne",
+                "m": "Guyanien"
+            }
+        }
     },
     {
         "name": {
@@ -13472,8 +13904,8 @@
                 "common": "\ud64d\ucf69"
             },
             "per": {
-              "official": "\u0647\u064f\u0646\u06af \u06a9\u064f\u0646\u06af",
-              "common": "\u0647\u064f\u0646\u06af \u06a9\u064f\u0646\u06af"
+                "official": "\u0647\u064f\u0646\u06af \u06a9\u064f\u0646\u06af",
+                "common": "\u0647\u064f\u0646\u06af \u06a9\u064f\u0646\u06af"
             }
         },
         "latlng": [
@@ -13598,8 +14030,8 @@
                 "common": "\ud5c8\ub4dc \ub9e5\ub3c4\ub110\ub4dc \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u06cc\u0631\u0647 \u0647\u0631\u062f \u0648 \u062c\u0632\u0627\u06cc\u0631 \u0645\u06a9\u200c\u062f\u0648\u0646\u0627\u0644\u062f",
-              "common": "\u062c\u0632\u06cc\u0631\u0647 \u0647\u0631\u062f \u0648 \u062c\u0632\u0627\u06cc\u0631 \u0645\u06a9\u200c\u062f\u0648\u0646\u0627\u0644\u062f"
+                "official": "\u062c\u0632\u06cc\u0631\u0647 \u0647\u0631\u062f \u0648 \u062c\u0632\u0627\u06cc\u0631 \u0645\u06a9\u200c\u062f\u0648\u0646\u0627\u0644\u062f",
+                "common": "\u062c\u0632\u06cc\u0631\u0647 \u0647\u0631\u062f \u0648 \u062c\u0632\u0627\u06cc\u0631 \u0645\u06a9\u200c\u062f\u0648\u0646\u0627\u0644\u062f"
             }
         },
         "latlng": [
@@ -13727,8 +14159,8 @@
                 "common": "\uc628\ub450\ub77c\uc2a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0647\u0646\u062f\u0648\u0631\u0627\u0633",
-              "common": "\u0647\u064f\u0646\u062f\u0648\u0631\u0627\u0633"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0647\u0646\u062f\u0648\u0631\u0627\u0633",
+                "common": "\u0647\u064f\u0646\u062f\u0648\u0631\u0627\u0633"
             }
         },
         "latlng": [
@@ -13743,7 +14175,13 @@
             "NIC"
         ],
         "area": 112492,
-        "flag": "\ud83c\udded\ud83c\uddf3"
+        "flag": "\ud83c\udded\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Hondurienne",
+                "m": "Hondurien"
+            }
+        }
     },
     {
         "name": {
@@ -13865,8 +14303,8 @@
                 "common": "\ud06c\ub85c\uc544\ud2f0\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0631\u0648\u0627\u0633\u06cc",
-              "common": "\u06a9\u0631\u064f\u0648\u0627\u0633\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0631\u0648\u0627\u0633\u06cc",
+                "common": "\u06a9\u0631\u064f\u0648\u0627\u0633\u06cc"
             }
         },
         "latlng": [
@@ -13883,7 +14321,13 @@
             "SVN"
         ],
         "area": 56594,
-        "flag": "\ud83c\udded\ud83c\uddf7"
+        "flag": "\ud83c\udded\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Croate",
+                "m": "Croate"
+            }
+        }
     },
     {
         "name": {
@@ -14006,8 +14450,8 @@
                 "common": "\uc544\uc774\ud2f0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0647\u0627\u0626\u06cc\u062a\u06cc",
-              "common": "\u0647\u0627\u0626\u06cc\u062a\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0647\u0627\u0626\u06cc\u062a\u06cc",
+                "common": "\u0647\u0627\u0626\u06cc\u062a\u06cc"
             }
         },
         "latlng": [
@@ -14020,7 +14464,13 @@
             "DOM"
         ],
         "area": 27750,
-        "flag": "\ud83c\udded\ud83c\uddf9"
+        "flag": "\ud83c\udded\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Ha\u00eftienne",
+                "m": "Ha\u00eftien"
+            }
+        }
     },
     {
         "name": {
@@ -14135,8 +14585,8 @@
                 "common": "\ud5dd\uac00\ub9ac"
             },
             "per": {
-              "official": "\u0645\u062c\u0627\u0631\u0633\u062a\u0627\u0646",
-              "common": "\u0645\u062c\u0627\u0631\u0633\u062a\u0627\u0646"
+                "official": "\u0645\u062c\u0627\u0631\u0633\u062a\u0627\u0646",
+                "common": "\u0645\u062c\u0627\u0631\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -14155,7 +14605,13 @@
             "UKR"
         ],
         "area": 93028,
-        "flag": "\ud83c\udded\ud83c\uddfa"
+        "flag": "\ud83c\udded\ud83c\uddfa",
+        "demonyms": {
+            "fra": {
+                "f": "Hongroise",
+                "m": "Hongrois"
+            }
+        }
     },
     {
         "name": {
@@ -14272,8 +14728,8 @@
                 "common": "\uc778\ub3c4\ub124\uc2dc\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0646\u062f\u0648\u0646\u0632\u06cc",
-              "common": "\u0627\u0646\u062f\u0648\u0646\u0632\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0646\u062f\u0648\u0646\u0632\u06cc",
+                "common": "\u0627\u0646\u062f\u0648\u0646\u0632\u06cc"
             }
         },
         "latlng": [
@@ -14288,7 +14744,13 @@
             "PNG"
         ],
         "area": 1904569,
-        "flag": "\ud83c\uddee\ud83c\udde9"
+        "flag": "\ud83c\uddee\ud83c\udde9",
+        "demonyms": {
+            "fra": {
+                "f": "Indon\u00e9sienne",
+                "m": "Indon\u00e9sien"
+            }
+        }
     },
     {
         "name": {
@@ -14415,8 +14877,8 @@
                 "common": "\ub9e8\uc12c"
             },
             "per": {
-              "official": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0645\u064e\u0646",
-              "common": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0645\u064e\u0646"
+                "official": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0645\u064e\u0646",
+                "common": "\u062c\u0632\u06cc\u0631\u0647\u0654 \u0645\u064e\u0646"
             }
         },
         "latlng": [
@@ -14556,8 +15018,8 @@
                 "common": "\uc778\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0647\u0646\u062f\u0648\u0633\u062a\u0627\u0646",
-              "common": "\u0647\u0646\u062f"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0647\u0646\u062f\u0648\u0633\u062a\u0627\u0646",
+                "common": "\u0647\u0646\u062f"
             }
         },
         "latlng": [
@@ -14575,7 +15037,13 @@
             "PAK"
         ],
         "area": 3287590,
-        "flag": "\ud83c\uddee\ud83c\uddf3"
+        "flag": "\ud83c\uddee\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Indienne",
+                "m": "Indien"
+            }
+        }
     },
     {
         "name": {
@@ -14694,8 +15162,8 @@
                 "common": "\uc778\ub3c4"
             },
             "per": {
-              "official": "\u0642\u0644\u0645\u0631\u0648 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627 \u062f\u0631 \u0627\u0642\u06cc\u0627\u0646\u0648\u0633 \u0647\u0646\u062f",
-              "common": "\u0642\u0644\u0645\u0631\u0648 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627 \u062f\u0631 \u0627\u0642\u06cc\u0627\u0646\u0648\u0633 \u0647\u0646\u062f"
+                "official": "\u0642\u0644\u0645\u0631\u0648 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627 \u062f\u0631 \u0627\u0642\u06cc\u0627\u0646\u0648\u0633 \u0647\u0646\u062f",
+                "common": "\u0642\u0644\u0645\u0631\u0648 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627 \u062f\u0631 \u0627\u0642\u06cc\u0627\u0646\u0648\u0633 \u0647\u0646\u062f"
             }
         },
         "latlng": [
@@ -14829,8 +15297,8 @@
                 "common": "\uc544\uc77c\ub79c\ub4dc"
             },
             "per": {
-              "official": "\u0627\u06cc\u0631\u0644\u0646\u062f",
-              "common": "\u0627\u06cc\u0631\u0644\u0646\u062f"
+                "official": "\u0627\u06cc\u0631\u0644\u0646\u062f",
+                "common": "\u0627\u06cc\u0631\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -14843,7 +15311,13 @@
             "GBR"
         ],
         "area": 70273,
-        "flag": "\ud83c\uddee\ud83c\uddea"
+        "flag": "\ud83c\uddee\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Irlandaise",
+                "m": "Irlandais"
+            }
+        }
     },
     {
         "name": {
@@ -14978,7 +15452,13 @@
             "TKM"
         ],
         "area": 1648195,
-        "flag": "\ud83c\uddee\ud83c\uddf7"
+        "flag": "\ud83c\uddee\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Iranienne",
+                "m": "Iranien"
+            }
+        }
     },
     {
         "name": {
@@ -15105,8 +15585,8 @@
                 "common": "\uc774\ub77c\ud06c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0639\u0631\u0627\u0642",
-              "common": "\u0639\u0631\u0627\u0642"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0639\u0631\u0627\u0642",
+                "common": "\u0639\u0631\u0627\u0642"
             }
         },
         "latlng": [
@@ -15124,7 +15604,13 @@
             "TUR"
         ],
         "area": 438317,
-        "flag": "\ud83c\uddee\ud83c\uddf6"
+        "flag": "\ud83c\uddee\ud83c\uddf6",
+        "demonyms": {
+            "fra": {
+                "f": "Irakienne",
+                "m": "Irakien"
+            }
+        }
     },
     {
         "name": {
@@ -15242,8 +15728,8 @@
                 "common": "\uc544\uc774\uc2ac\ub780\ub4dc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u06cc\u0633\u0644\u0646\u062f",
-              "common": "\u0627\u06cc\u0633\u0644\u0646\u062f"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u06cc\u0633\u0644\u0646\u062f",
+                "common": "\u0627\u06cc\u0633\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -15254,7 +15740,13 @@
         "landlocked": false,
         "borders": [],
         "area": 103000,
-        "flag": "\ud83c\uddee\ud83c\uddf8"
+        "flag": "\ud83c\uddee\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Islandaise",
+                "m": "Islandais"
+            }
+        }
     },
     {
         "name": {
@@ -15376,8 +15868,8 @@
                 "common": "\uc774\uc2a4\ub77c\uc5d8"
             },
             "per": {
-              "official": "\u0641\u0644\u0633\u0637\u064a\u0646 \u0627\u0634\u063a\u0627\u0644\u06cc",
-              "common": "\u0641\u0644\u0633\u0637\u064a\u0646 \u0627\u0634\u063a\u0627\u0644\u06cc"
+                "official": "\u0641\u0644\u0633\u0637\u064a\u0646 \u0627\u0634\u063a\u0627\u0644\u06cc",
+                "common": "\u0641\u0644\u0633\u0637\u064a\u0646 \u0627\u0634\u063a\u0627\u0644\u06cc"
             }
         },
         "latlng": [
@@ -15394,7 +15886,13 @@
             "SYR"
         ],
         "area": 20770,
-        "flag": "\ud83c\uddee\ud83c\uddf1"
+        "flag": "\ud83c\uddee\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "Isra\u00e9lienne",
+                "m": "Isra\u00e9lien"
+            }
+        }
     },
     {
         "name": {
@@ -15511,8 +16009,8 @@
                 "common": "\uc774\ud0c8\ub9ac\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u06cc\u062a\u0627\u0644\u06cc\u0627",
-              "common": "\u0627\u06cc\u062a\u0627\u0644\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u06cc\u062a\u0627\u0644\u06cc\u0627",
+                "common": "\u0627\u06cc\u062a\u0627\u0644\u06cc\u0627"
             }
         },
         "latlng": [
@@ -15530,7 +16028,13 @@
             "VAT"
         ],
         "area": 301336,
-        "flag": "\ud83c\uddee\ud83c\uddf9"
+        "flag": "\ud83c\uddee\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Italienne",
+                "m": "Italien"
+            }
+        }
     },
     {
         "name": {
@@ -15650,8 +16154,8 @@
                 "common": "\uc790\uba54\uc774\uce74"
             },
             "per": {
-              "official": "\u062c\u0627\u0645\u0627\u0626\u06cc\u06a9\u0627",
-              "common": "\u062c\u0627\u0645\u0627\u0626\u06cc\u06a9\u0627"
+                "official": "\u062c\u0627\u0645\u0627\u0626\u06cc\u06a9\u0627",
+                "common": "\u062c\u0627\u0645\u0627\u0626\u06cc\u06a9\u0627"
             }
         },
         "latlng": [
@@ -15662,7 +16166,13 @@
         "landlocked": false,
         "borders": [],
         "area": 10991,
-        "flag": "\ud83c\uddef\ud83c\uddf2"
+        "flag": "\ud83c\uddef\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Jama\u00efcaine",
+                "m": "Jama\u00efcain"
+            }
+        }
     },
     {
         "name": {
@@ -15794,8 +16304,8 @@
                 "common": "\uc800\uc9c0 \uc12c"
             },
             "per": {
-              "official": "\u062c\u0631\u0632\u06cc",
-              "common": "\u062c\u0631\u0632\u06cc"
+                "official": "\u062c\u0631\u0632\u06cc",
+                "common": "\u062c\u0631\u0632\u06cc"
             }
         },
         "latlng": [
@@ -15924,8 +16434,8 @@
                 "common": "\uc694\ub974\ub2e8"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0627\u064f\u0631\u062f\u064f\u0646 \u0647\u0627\u0634\u0645\u06cc",
-              "common": "\u0627\u0631\u062f\u0646"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0627\u064f\u0631\u062f\u064f\u0646 \u0647\u0627\u0634\u0645\u06cc",
+                "common": "\u0627\u0631\u062f\u0646"
             }
         },
         "latlng": [
@@ -15942,7 +16452,13 @@
             "SYR"
         ],
         "area": 89342,
-        "flag": "\ud83c\uddef\ud83c\uddf4"
+        "flag": "\ud83c\uddef\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Jordanienne",
+                "m": "Jordanien"
+            }
+        }
     },
     {
         "name": {
@@ -16060,8 +16576,8 @@
                 "common": "\uc77c\ubcf8"
             },
             "per": {
-              "official": "\u0698\u0627\u067e\u0646",
-              "common": "\u0698\u0627\u067e\u0646"
+                "official": "\u0698\u0627\u067e\u0646",
+                "common": "\u0698\u0627\u067e\u0646"
             }
         },
         "latlng": [
@@ -16072,7 +16588,13 @@
         "landlocked": false,
         "borders": [],
         "area": 377930,
-        "flag": "\ud83c\uddef\ud83c\uddf5"
+        "flag": "\ud83c\uddef\ud83c\uddf5",
+        "demonyms": {
+            "fra": {
+                "f": "Japonaise",
+                "m": "Japonais"
+            }
+        }
     },
     {
         "name": {
@@ -16201,8 +16723,8 @@
                 "common": "\uce74\uc790\ud750\uc2a4\ud0c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0642\u0632\u0627\u0642\u0633\u062a\u0627\u0646",
-              "common": "\u0642\u0632\u0627\u0642\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0642\u0632\u0627\u0642\u0633\u062a\u0627\u0646",
+                "common": "\u0642\u0632\u0627\u0642\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -16219,7 +16741,13 @@
             "UZB"
         ],
         "area": 2724900,
-        "flag": "\ud83c\uddf0\ud83c\uddff"
+        "flag": "\ud83c\uddf0\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Kazakhstanaise",
+                "m": "Kazakhstanais"
+            }
+        }
     },
     {
         "name": {
@@ -16341,8 +16869,8 @@
                 "common": "\ucf00\ub0d0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0646\u06cc\u0627",
-              "common": "\u06a9\u0646\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0646\u06cc\u0627",
+                "common": "\u06a9\u0646\u06cc\u0627"
             }
         },
         "latlng": [
@@ -16359,7 +16887,13 @@
             "UGA"
         ],
         "area": 580367,
-        "flag": "\ud83c\uddf0\ud83c\uddea"
+        "flag": "\ud83c\uddf0\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "K\u00e9nyane",
+                "m": "K\u00e9nyan"
+            }
+        }
     },
     {
         "name": {
@@ -16483,8 +17017,8 @@
                 "common": "\ud0a4\ub974\uae30\uc2a4\uc2a4\ud0c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0642\u0650\u0631\u0642\u06cc\u0632\u0633\u062a\u0627\u0646",
-              "common": "\u0642\u0631\u0642\u06cc\u0632\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0642\u0650\u0631\u0642\u06cc\u0632\u0633\u062a\u0627\u0646",
+                "common": "\u0642\u0631\u0642\u06cc\u0632\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -16500,7 +17034,13 @@
             "UZB"
         ],
         "area": 199951,
-        "flag": "\ud83c\uddf0\ud83c\uddec"
+        "flag": "\ud83c\uddf0\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Kirghize",
+                "m": "Kirghize"
+            }
+        }
     },
     {
         "name": {
@@ -16624,8 +17164,8 @@
                 "common": "\uce84\ubcf4\ub514\uc544"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u06a9\u0627\u0645\u0628\u0648\u062c",
-              "common": "\u06a9\u0627\u0645\u0628\u0648\u062c"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u06a9\u0627\u0645\u0628\u0648\u062c",
+                "common": "\u06a9\u0627\u0645\u0628\u0648\u062c"
             }
         },
         "latlng": [
@@ -16640,7 +17180,13 @@
             "VNM"
         ],
         "area": 181035,
-        "flag": "\ud83c\uddf0\ud83c\udded"
+        "flag": "\ud83c\uddf0\ud83c\udded",
+        "demonyms": {
+            "fra": {
+                "f": "Cambodgienne",
+                "m": "Cambodgien"
+            }
+        }
     },
     {
         "name": {
@@ -16766,8 +17312,8 @@
                 "common": "\ud0a4\ub9ac\ubc14\uc2dc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc",
-              "common": "\u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc",
+                "common": "\u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc"
             }
         },
         "latlng": [
@@ -16778,7 +17324,13 @@
         "landlocked": false,
         "borders": [],
         "area": 811,
-        "flag": "\ud83c\uddf0\ud83c\uddee"
+        "flag": "\ud83c\uddf0\ud83c\uddee",
+        "demonyms": {
+            "fra": {
+                "f": "Kiribatienne",
+                "m": "Kiribatien"
+            }
+        }
     },
     {
         "name": {
@@ -16894,8 +17446,8 @@
                 "common": "\uc138\uc778\ud2b8\ud0a4\uce20 \ub124\ube44\uc2a4"
             },
             "per": {
-              "official": "\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0633\u0646\u062a \u06a9\u06cc\u062a\u0633 \u0648 \u0646\u0648\u06cc\u0633",
-              "common": "\u0633\u0646\u062a \u06a9\u06cc\u062a\u0633 \u0648 \u0646\u0648\u06cc\u0633"
+                "official": "\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0633\u0646\u062a \u06a9\u06cc\u062a\u0633 \u0648 \u0646\u0648\u06cc\u0633",
+                "common": "\u0633\u0646\u062a \u06a9\u06cc\u062a\u0633 \u0648 \u0646\u0648\u06cc\u0633"
             }
         },
         "latlng": [
@@ -16906,7 +17458,13 @@
         "landlocked": false,
         "borders": [],
         "area": 261,
-        "flag": "\ud83c\uddf0\ud83c\uddf3"
+        "flag": "\ud83c\uddf0\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Kittitienne-et-nevicienne",
+                "m": "Kittitien-et-nevicien"
+            }
+        }
     },
     {
         "name": {
@@ -17026,8 +17584,8 @@
                 "common": "\ud55c\uad6d"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0631\u0647",
-              "common": "\u06a9\u0631\u0647\u0654 \u062c\u0646\u0648\u0628\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0631\u0647",
+                "common": "\u06a9\u0631\u0647\u0654 \u062c\u0646\u0648\u0628\u06cc"
             }
         },
         "latlng": [
@@ -17040,7 +17598,13 @@
             "PRK"
         ],
         "area": 100210,
-        "flag": "\ud83c\uddf0\ud83c\uddf7"
+        "flag": "\ud83c\uddf0\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Sud-cor\u00e9enne",
+                "m": "Sud-cor\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -17155,8 +17719,8 @@
                 "common": "\ucf54\uc18c\ubcf4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0648\u0632\u0648\u0648",
-              "common": "\u06a9\u0648\u0632\u0648\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06a9\u0648\u0632\u0648\u0648",
+                "common": "\u06a9\u0648\u0632\u0648\u0648"
             }
         },
         "latlng": [
@@ -17172,7 +17736,13 @@
             "SRB"
         ],
         "area": 10908,
-        "flag": "\ud83c\uddfd\ud83c\uddf0"
+        "flag": "\ud83c\uddfd\ud83c\uddf0",
+        "demonyms": {
+            "fra": {
+                "f": "Kosovare",
+                "m": "Kosovar"
+            }
+        }
     },
     {
         "name": {
@@ -17289,8 +17859,8 @@
                 "common": "\ucfe0\uc6e8\uc774\ud2b8"
             },
             "per": {
-              "official": "\u062f\u0648\u0644\u062a \u06a9\u0648\u06cc\u062a",
-              "common": "\u06a9\u064f\u0648\u06cc\u062a"
+                "official": "\u062f\u0648\u0644\u062a \u06a9\u0648\u06cc\u062a",
+                "common": "\u06a9\u064f\u0648\u06cc\u062a"
             }
         },
         "latlng": [
@@ -17304,7 +17874,13 @@
             "SAU"
         ],
         "area": 17818,
-        "flag": "\ud83c\uddf0\ud83c\uddfc"
+        "flag": "\ud83c\uddf0\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Kowe\u00eftienne",
+                "m": "Kowe\u00eftien"
+            }
+        }
     },
     {
         "name": {
@@ -17422,8 +17998,8 @@
                 "common": "\ub77c\uc624\uc2a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9\u0020\u062e\u0644\u0642\u0020\u0644\u0627\u0626\u0648\u0633",
-              "common": "\u0644\u0627\u0626\u0648\u0633"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u062e\u0644\u0642 \u0644\u0627\u0626\u0648\u0633",
+                "common": "\u0644\u0627\u0626\u0648\u0633"
             }
         },
         "latlng": [
@@ -17440,7 +18016,13 @@
             "VNM"
         ],
         "area": 236800,
-        "flag": "\ud83c\uddf1\ud83c\udde6"
+        "flag": "\ud83c\uddf1\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Laotienne",
+                "m": "Laotien"
+            }
+        }
     },
     {
         "name": {
@@ -17562,8 +18144,8 @@
                 "common": "\ub808\ubc14\ub17c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0644\u0628\u0646\u0627\u0646",
-              "common": "\u0644\u0628\u0646\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0644\u0628\u0646\u0627\u0646",
+                "common": "\u0644\u0628\u0646\u0627\u0646"
             }
         },
         "latlng": [
@@ -17577,7 +18159,13 @@
             "SYR"
         ],
         "area": 10452,
-        "flag": "\ud83c\uddf1\ud83c\udde7"
+        "flag": "\ud83c\uddf1\ud83c\udde7",
+        "demonyms": {
+            "fra": {
+                "f": "Libanaise",
+                "m": "Libanais"
+            }
+        }
     },
     {
         "name": {
@@ -17693,8 +18281,8 @@
                 "common": "\ub77c\uc774\ubca0\ub9ac\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0644\u06cc\u0628\u0631\u06cc\u0627",
-              "common": "\u0644\u06cc\u0628\u0640\u0650\u0631\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0644\u06cc\u0628\u0631\u06cc\u0627",
+                "common": "\u0644\u06cc\u0628\u0640\u0650\u0631\u06cc\u0627"
             }
         },
         "latlng": [
@@ -17709,7 +18297,13 @@
             "SLE"
         ],
         "area": 111369,
-        "flag": "\ud83c\uddf1\ud83c\uddf7"
+        "flag": "\ud83c\uddf1\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Lib\u00e9rienne",
+                "m": "Lib\u00e9rien"
+            }
+        }
     },
     {
         "name": {
@@ -17826,8 +18420,8 @@
                 "common": "\ub9ac\ube44\uc544"
             },
             "per": {
-              "official": "\u062f\u0648\u0644\u062a\u0020\u0644\u06cc\u0628\u06cc",
-              "common": "\u0644\u06cc\u0628\u06cc"
+                "official": "\u062f\u0648\u0644\u062a \u0644\u06cc\u0628\u06cc",
+                "common": "\u0644\u06cc\u0628\u06cc"
             }
         },
         "latlng": [
@@ -17845,7 +18439,13 @@
             "TUN"
         ],
         "area": 1759540,
-        "flag": "\ud83c\uddf1\ud83c\uddfe"
+        "flag": "\ud83c\uddf1\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Libyenne",
+                "m": "Libyen"
+            }
+        }
     },
     {
         "name": {
@@ -17960,8 +18560,8 @@
                 "common": "\uc138\uc778\ud2b8\ub8e8\uc2dc\uc544"
             },
             "per": {
-              "official": "\u0633\u0646\u062a\u0020\u0644\u0648\u0633\u06cc\u0627",
-              "common": "\u0633\u0646\u062a\u0020\u0644\u0648\u0633\u06cc\u0627"
+                "official": "\u0633\u0646\u062a \u0644\u0648\u0633\u06cc\u0627",
+                "common": "\u0633\u0646\u062a \u0644\u0648\u0633\u06cc\u0627"
             }
         },
         "latlng": [
@@ -17972,7 +18572,13 @@
         "landlocked": false,
         "borders": [],
         "area": 616,
-        "flag": "\ud83c\uddf1\ud83c\udde8"
+        "flag": "\ud83c\uddf1\ud83c\udde8",
+        "demonyms": {
+            "fra": {
+                "f": "Saint-Lucienne",
+                "m": "Saint-Lucien"
+            }
+        }
     },
     {
         "name": {
@@ -18089,8 +18695,8 @@
                 "common": "\ub9ac\ud788\ud150\uc288\ud0c0\uc778"
             },
             "per": {
-              "official": "\u0634\u0627\u0647\u0632\u0627\u062f\u0647\u200c\u0646\u0634\u06cc\u0646\u0020\u0644\u06cc\u062e\u062a\u0646\u200c\u0627\u0634\u062a\u0627\u06cc\u0646",
-              "common": "\u0644\u06cc\u062e\u062a\u0646\u200c\u0627\u0634\u062a\u0627\u06cc\u0646"
+                "official": "\u0634\u0627\u0647\u0632\u0627\u062f\u0647\u200c\u0646\u0634\u06cc\u0646 \u0644\u06cc\u062e\u062a\u0646\u200c\u0627\u0634\u062a\u0627\u06cc\u0646",
+                "common": "\u0644\u06cc\u062e\u062a\u0646\u200c\u0627\u0634\u062a\u0627\u06cc\u0646"
             }
         },
         "latlng": [
@@ -18104,7 +18710,13 @@
             "CHE"
         ],
         "area": 160,
-        "flag": "\ud83c\uddf1\ud83c\uddee"
+        "flag": "\ud83c\uddf1\ud83c\uddee",
+        "demonyms": {
+            "fra": {
+                "f": "Liechtensteinoise",
+                "m": "Liechtensteinois"
+            }
+        }
     },
     {
         "name": {
@@ -18228,8 +18840,8 @@
                 "common": "\uc2a4\ub9ac\ub791\uce74"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9\u0020\u0633\u0648\u0633\u06cc\u0627\u0644\u06cc\u0633\u062a\u06cc\u0020\u0633\u0631\u06cc\u200c\u0644\u0627\u0646\u06a9\u0627",
-              "common": "\u0633\u0631\u06cc\u200c\u0644\u0627\u0646\u06a9\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u0633\u0648\u0633\u06cc\u0627\u0644\u06cc\u0633\u062a\u06cc \u0633\u0631\u06cc\u200c\u0644\u0627\u0646\u06a9\u0627",
+                "common": "\u0633\u0631\u06cc\u200c\u0644\u0627\u0646\u06a9\u0627"
             }
         },
         "latlng": [
@@ -18242,7 +18854,13 @@
             "IND"
         ],
         "area": 65610,
-        "flag": "\ud83c\uddf1\ud83c\uddf0"
+        "flag": "\ud83c\uddf1\ud83c\uddf0",
+        "demonyms": {
+            "fra": {
+                "f": "Sri-lankaise",
+                "m": "Sri-lankais"
+            }
+        }
     },
     {
         "name": {
@@ -18368,8 +18986,8 @@
                 "common": "\ub808\uc18c\ud1a0"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc\u0020\u0644\u0633\u0648\u062a\u0648",
-              "common": "\u0644\u0633\u0648\u062a\u0648"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0644\u0633\u0648\u062a\u0648",
+                "common": "\u0644\u0633\u0648\u062a\u0648"
             }
         },
         "latlng": [
@@ -18382,7 +19000,13 @@
             "ZAF"
         ],
         "area": 30355,
-        "flag": "\ud83c\uddf1\ud83c\uddf8"
+        "flag": "\ud83c\uddf1\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "L\u00e9sothienne",
+                "m": "L\u00e9sothien"
+            }
+        }
     },
     {
         "name": {
@@ -18499,8 +19123,8 @@
                 "common": "\ub9ac\ud22c\uc544\ub2c8\uc544"
             },
             "per": {
-              "official": "\u0644\u06cc\u062a\u0648\u0627\u0646\u06cc\u0627\u06cc\u06cc\u200c\u0647\u0627",
-              "common": "\u0644\u06cc\u062a\u0648\u0627\u0646\u06cc\u0627\u06cc\u06cc\u200c\u0647\u0627"
+                "official": "\u0644\u06cc\u062a\u0648\u0627\u0646\u06cc\u0627\u06cc\u06cc\u200c\u0647\u0627",
+                "common": "\u0644\u06cc\u062a\u0648\u0627\u0646\u06cc\u0627\u06cc\u06cc\u200c\u0647\u0627"
             }
         },
         "latlng": [
@@ -18516,7 +19140,13 @@
             "RUS"
         ],
         "area": 65300,
-        "flag": "\ud83c\uddf1\ud83c\uddf9"
+        "flag": "\ud83c\uddf1\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Lituanienne",
+                "m": "Lituanien"
+            }
+        }
     },
     {
         "name": {
@@ -18645,8 +19275,8 @@
                 "common": "\ub8e9\uc148\ubd80\ub974\ud06c"
             },
             "per": {
-              "official": "\u062f\u0648\u06a9\u200c\u0646\u0634\u06cc\u0646\u0020\u0644\u0648\u06a9\u0632\u0627\u0645\u0628\u0648\u0631\u06af",
-              "common": "\u0644\u0648\u06a9\u0632\u0627\u0645\u0628\u0648\u0631\u06af"
+                "official": "\u062f\u0648\u06a9\u200c\u0646\u0634\u06cc\u0646 \u0644\u0648\u06a9\u0632\u0627\u0645\u0628\u0648\u0631\u06af",
+                "common": "\u0644\u0648\u06a9\u0632\u0627\u0645\u0628\u0648\u0631\u06af"
             }
         },
         "latlng": [
@@ -18661,7 +19291,13 @@
             "DEU"
         ],
         "area": 2586,
-        "flag": "\ud83c\uddf1\ud83c\uddfa"
+        "flag": "\ud83c\uddf1\ud83c\uddfa",
+        "demonyms": {
+            "fra": {
+                "f": "Luxembourgeoise",
+                "m": "Luxembourgeois"
+            }
+        }
     },
     {
         "name": {
@@ -18778,8 +19414,8 @@
                 "common": "\ub77c\ud2b8\ube44\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0644\u062a\u0648\u0646\u06cc",
-              "common": "\u0644\u062a\u0648\u0646\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0644\u062a\u0648\u0646\u06cc",
+                "common": "\u0644\u062a\u0648\u0646\u06cc"
             }
         },
         "latlng": [
@@ -18795,7 +19431,13 @@
             "RUS"
         ],
         "area": 64559,
-        "flag": "\ud83c\uddf1\ud83c\uddfb"
+        "flag": "\ud83c\uddf1\ud83c\uddfb",
+        "demonyms": {
+            "fra": {
+                "f": "Lettone",
+                "m": "Letton"
+            }
+        }
     },
     {
         "name": {
@@ -18916,8 +19558,8 @@
                 "common": "\ub9c8\uce74\uc624"
             },
             "per": {
-              "official": "\u0645\u0627\u06a9\u0627\u0626\u0648",
-              "common": "\u0645\u0627\u06a9\u0627\u0626\u0648"
+                "official": "\u0645\u0627\u06a9\u0627\u0626\u0648",
+                "common": "\u0645\u0627\u06a9\u0627\u0626\u0648"
             }
         },
         "latlng": [
@@ -19049,8 +19691,8 @@
                 "common": "\uc0dd\ub9c8\ub974\ud0f1"
             },
             "per": {
-              "official": "\u0633\u0646\u0020\u0645\u0627\u0631\u062a\u0646",
-              "common": "\u0633\u0646\u0020\u0645\u0627\u0631\u062a\u0646"
+                "official": "\u0633\u0646 \u0645\u0627\u0631\u062a\u0646",
+                "common": "\u0633\u0646 \u0645\u0627\u0631\u062a\u0646"
             }
         },
         "latlng": [
@@ -19186,8 +19828,8 @@
                 "common": "\ubaa8\ub85c\ucf54"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc\u0020\u0645\u0631\u0627\u06a9\u0634",
-              "common": "\u0645\u0631\u0627\u06a9\u0634"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0645\u0631\u0627\u06a9\u0634",
+                "common": "\u0645\u0631\u0627\u06a9\u0634"
             }
         },
         "latlng": [
@@ -19202,7 +19844,13 @@
             "ESP"
         ],
         "area": 446550,
-        "flag": "\ud83c\uddf2\ud83c\udde6"
+        "flag": "\ud83c\uddf2\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Marocaine",
+                "m": "Marocain"
+            }
+        }
     },
     {
         "name": {
@@ -19319,8 +19967,8 @@
                 "common": "\ubaa8\ub098\ucf54"
             },
             "per": {
-              "official": "\u0634\u0627\u0647\u0632\u0627\u062f\u0647\u200c\u0646\u0634\u06cc\u0646\u0020\u0645\u0648\u0646\u0627\u06a9\u0648",
-              "common": "\u0645\u0648\u0646\u0627\u06a9\u0648"
+                "official": "\u0634\u0627\u0647\u0632\u0627\u062f\u0647\u200c\u0646\u0634\u06cc\u0646 \u0645\u0648\u0646\u0627\u06a9\u0648",
+                "common": "\u0645\u0648\u0646\u0627\u06a9\u0648"
             }
         },
         "latlng": [
@@ -19333,7 +19981,13 @@
             "FRA"
         ],
         "area": 2.02,
-        "flag": "\ud83c\uddf2\ud83c\udde8"
+        "flag": "\ud83c\uddf2\ud83c\udde8",
+        "demonyms": {
+            "fra": {
+                "f": "Mon\u00e9gasque",
+                "m": "Mon\u00e9gasque"
+            }
+        }
     },
     {
         "name": {
@@ -19451,8 +20105,8 @@
                 "common": "\ubab0\ub3c4\ubc14"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0645\u0648\u0644\u062f\u0627\u0648\u06cc",
-              "common": "\u0645\u0648\u0644\u062f\u0627\u0648\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0648\u0644\u062f\u0627\u0648\u06cc",
+                "common": "\u0645\u0648\u0644\u062f\u0627\u0648\u06cc"
             }
         },
         "latlng": [
@@ -19466,7 +20120,13 @@
             "UKR"
         ],
         "area": 33846,
-        "flag": "\ud83c\uddf2\ud83c\udde9"
+        "flag": "\ud83c\uddf2\ud83c\udde9",
+        "demonyms": {
+            "fra": {
+                "f": "Moldave",
+                "m": "Moldave"
+            }
+        }
     },
     {
         "name": {
@@ -19589,8 +20249,8 @@
                 "common": "\ub9c8\ub2e4\uac00\uc2a4\uce74\ub974"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0645\u0627\u062f\u0627\u06af\u0627\u0633\u06a9\u0627\u0631",
-              "common": "\u0645\u0627\u062f\u0627\u06af\u0627\u0633\u06a9\u0627\u0631"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0627\u062f\u0627\u06af\u0627\u0633\u06a9\u0627\u0631",
+                "common": "\u0645\u0627\u062f\u0627\u06af\u0627\u0633\u06a9\u0627\u0631"
             }
         },
         "latlng": [
@@ -19601,7 +20261,13 @@
         "landlocked": false,
         "borders": [],
         "area": 587041,
-        "flag": "\ud83c\uddf2\ud83c\uddec"
+        "flag": "\ud83c\uddf2\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Malgache",
+                "m": "Malgache"
+            }
+        }
     },
     {
         "name": {
@@ -19719,8 +20385,8 @@
                 "common": "\ubab0\ub514\ube0c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0645\u0627\u0644\u062f\u06cc\u0648",
-              "common": "\u0645\u0627\u0644\u062f\u06cc\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0627\u0644\u062f\u06cc\u0648",
+                "common": "\u0645\u0627\u0644\u062f\u06cc\u0648"
             }
         },
         "latlng": [
@@ -19731,7 +20397,13 @@
         "landlocked": false,
         "borders": [],
         "area": 300,
-        "flag": "\ud83c\uddf2\ud83c\uddfb"
+        "flag": "\ud83c\uddf2\ud83c\uddfb",
+        "demonyms": {
+            "fra": {
+                "f": "Maldivienne",
+                "m": "Maldivien"
+            }
+        }
     },
     {
         "name": {
@@ -19849,8 +20521,8 @@
                 "common": "\uba55\uc2dc\ucf54"
             },
             "per": {
-              "official": "\u0627\u06cc\u0627\u0644\u0627\u062a\u0020\u0645\u062a\u062d\u062f\u0020\u0645\u06a9\u0632\u06cc\u06a9",
-              "common": "\u0645\u06a9\u0632\u06cc\u06a9"
+                "official": "\u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f \u0645\u06a9\u0632\u06cc\u06a9",
+                "common": "\u0645\u06a9\u0632\u06cc\u06a9"
             }
         },
         "latlng": [
@@ -19865,7 +20537,13 @@
             "USA"
         ],
         "area": 1964375,
-        "flag": "\ud83c\uddf2\ud83c\uddfd"
+        "flag": "\ud83c\uddf2\ud83c\uddfd",
+        "demonyms": {
+            "fra": {
+                "f": "Mexicaine",
+                "m": "Mexicain"
+            }
+        }
     },
     {
         "name": {
@@ -19987,8 +20665,8 @@
                 "common": "\ub9c8\uc15c \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u062c\u0632\u0627\u06cc\u0631\u0020\u0645\u0627\u0631\u0634\u0627\u0644",
-              "common": "\u062c\u0632\u0627\u06cc\u0631\u0020\u0645\u0627\u0631\u0634\u0627\u0644"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062c\u0632\u0627\u06cc\u0631 \u0645\u0627\u0631\u0634\u0627\u0644",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0645\u0627\u0631\u0634\u0627\u0644"
             }
         },
         "latlng": [
@@ -19999,7 +20677,13 @@
         "landlocked": false,
         "borders": [],
         "area": 181,
-        "flag": "\ud83c\uddf2\ud83c\udded"
+        "flag": "\ud83c\uddf2\ud83c\udded",
+        "demonyms": {
+            "fra": {
+                "f": "Marshallaise",
+                "m": "Marshallais"
+            }
+        }
     },
     {
         "name": {
@@ -20117,8 +20801,8 @@
                 "common": "\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0645\u0642\u062f\u0648\u0646\u06cc\u0647\u0020\u0634\u0645\u0627\u0644\u06cc",
-              "common": "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647\u0020\u0634\u0645\u0627\u0644\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc",
+                "common": "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc"
             }
         },
         "latlng": [
@@ -20135,7 +20819,13 @@
             "SRB"
         ],
         "area": 25713,
-        "flag": "\ud83c\uddf2\ud83c\uddf0"
+        "flag": "\ud83c\uddf2\ud83c\uddf0",
+        "demonyms": {
+            "fra": {
+                "f": "Mac\u00e9donienne",
+                "m": "Mac\u00e9donien"
+            }
+        }
     },
     {
         "name": {
@@ -20252,8 +20942,8 @@
                 "common": "\ub9d0\ub9ac"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0645\u0627\u0644\u06cc",
-              "common": "\u0645\u0627\u0644\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0627\u0644\u06cc",
+                "common": "\u0645\u0627\u0644\u06cc"
             }
         },
         "latlng": [
@@ -20272,7 +20962,13 @@
             "SEN"
         ],
         "area": 1240192,
-        "flag": "\ud83c\uddf2\ud83c\uddf1"
+        "flag": "\ud83c\uddf2\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "Malienne",
+                "m": "Malien"
+            }
+        }
     },
     {
         "name": {
@@ -20394,8 +21090,8 @@
                 "common": "\ubab0\ud0c0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc\u0020\u0645\u0627\u0644\u062a",
-              "common": "\u0645\u0627\u0644\u062a"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0627\u0644\u062a",
+                "common": "\u0645\u0627\u0644\u062a"
             }
         },
         "latlng": [
@@ -20406,7 +21102,13 @@
         "landlocked": false,
         "borders": [],
         "area": 316,
-        "flag": "\ud83c\uddf2\ud83c\uddf9"
+        "flag": "\ud83c\uddf2\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Maltaise",
+                "m": "Maltais"
+            }
+        }
     },
     {
         "name": {
@@ -20524,8 +21226,8 @@
                 "common": "\ubbf8\uc580\ub9c8"
             },
             "per": {
-              "official": "\u0627\u062a\u062d\u0627\u062f\u06cc\u0647 \u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u06cc\u0627\u0646\u0645\u0627\u0631",
-              "common": "\u0645\u06cc\u0627\u0646\u0645\u0627\u0631"
+                "official": "\u0627\u062a\u062d\u0627\u062f\u06cc\u0647 \u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u06cc\u0627\u0646\u0645\u0627\u0631",
+                "common": "\u0645\u06cc\u0627\u0646\u0645\u0627\u0631"
             }
         },
         "latlng": [
@@ -20542,7 +21244,13 @@
             "THA"
         ],
         "area": 676578,
-        "flag": "\ud83c\uddf2\ud83c\uddf2"
+        "flag": "\ud83c\uddf2\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Birmane",
+                "m": "Birman"
+            }
+        }
     },
     {
         "name": {
@@ -20658,8 +21366,8 @@
                 "common": "\ubaac\ud14c\ub124\uadf8\ub85c"
             },
             "per": {
-              "official": "\u0645\u0648\u0646\u062a\u0647\u200c\u0646\u06af\u0631\u0648",
-              "common": "\u0645\u0648\u0646\u062a\u0647\u200c\u0646\u06af\u0631\u0648"
+                "official": "\u0645\u0648\u0646\u062a\u0647\u200c\u0646\u06af\u0631\u0648",
+                "common": "\u0645\u0648\u0646\u062a\u0647\u200c\u0646\u06af\u0631\u0648"
             }
         },
         "latlng": [
@@ -20676,7 +21384,13 @@
             "SRB"
         ],
         "area": 13812,
-        "flag": "\ud83c\uddf2\ud83c\uddea"
+        "flag": "\ud83c\uddf2\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Mont\u00e9n\u00e9grine",
+                "m": "Mont\u00e9n\u00e9grin"
+            }
+        }
     },
     {
         "name": {
@@ -20791,8 +21505,8 @@
                 "common": "\ubabd\uace8\uad6d"
             },
             "per": {
-              "official": "\u0645\u063a\u0648\u0644\u0633\u062a\u0627\u0646",
-              "common": "\u0645\u063a\u0648\u0644\u0633\u062a\u0627\u0646"
+                "official": "\u0645\u063a\u0648\u0644\u0633\u062a\u0627\u0646",
+                "common": "\u0645\u063a\u0648\u0644\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -20806,7 +21520,13 @@
             "RUS"
         ],
         "area": 1564110,
-        "flag": "\ud83c\uddf2\ud83c\uddf3"
+        "flag": "\ud83c\uddf2\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Mongole",
+                "m": "Mongol"
+            }
+        }
     },
     {
         "name": {
@@ -20933,8 +21653,8 @@
                 "common": "\ubd81\ub9c8\ub9ac\uc544\ub098 \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0645\u0627\u0631\u06cc\u0627\u0646\u0627\u06cc \u0634\u0645\u0627\u0644\u06cc",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u0645\u0627\u0631\u06cc\u0627\u0646\u0627\u06cc \u0634\u0645\u0627\u0644\u06cc"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0645\u0627\u0631\u06cc\u0627\u0646\u0627\u06cc \u0634\u0645\u0627\u0644\u06cc",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0645\u0627\u0631\u06cc\u0627\u0646\u0627\u06cc \u0634\u0645\u0627\u0644\u06cc"
             }
         },
         "latlng": [
@@ -21062,8 +21782,8 @@
                 "common": "\ubaa8\uc7a0\ube44\ud06c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0648\u0632\u0627\u0645\u0628\u06cc\u06a9",
-              "common": "\u0645\u0648\u0632\u0627\u0645\u0628\u06cc\u06a9"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0648\u0632\u0627\u0645\u0628\u06cc\u06a9",
+                "common": "\u0645\u0648\u0632\u0627\u0645\u0628\u06cc\u06a9"
             }
         },
         "latlng": [
@@ -21081,7 +21801,13 @@
             "ZWE"
         ],
         "area": 801590,
-        "flag": "\ud83c\uddf2\ud83c\uddff"
+        "flag": "\ud83c\uddf2\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Mozambicaine",
+                "m": "Mozambicain"
+            }
+        }
     },
     {
         "name": {
@@ -21198,8 +21924,8 @@
                 "common": "\ubaa8\ub9ac\ud0c0\ub2c8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc \u0645\u0648\u0631\u06cc\u062a\u0627\u0646\u06cc",
-              "common": "\u0645\u0648\u0631\u06cc\u062a\u0627\u0646\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc \u0645\u0648\u0631\u06cc\u062a\u0627\u0646\u06cc",
+                "common": "\u0645\u0648\u0631\u06cc\u062a\u0627\u0646\u06cc"
             }
         },
         "latlng": [
@@ -21215,7 +21941,13 @@
             "ESH"
         ],
         "area": 1030700,
-        "flag": "\ud83c\uddf2\ud83c\uddf7"
+        "flag": "\ud83c\uddf2\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Mauritanienne",
+                "m": "Mauritanien"
+            }
+        }
     },
     {
         "name": {
@@ -21330,8 +22062,8 @@
                 "common": "\ubaac\ud2b8\uc138\ub7ab"
             },
             "per": {
-              "official": "\u0645\u0648\u0646\u062a\u0633\u0631\u0627\u062a",
-              "common": "\u0645\u0648\u0646\u062a\u0633\u0631\u0627\u062a"
+                "official": "\u0645\u0648\u0646\u062a\u0633\u0631\u0627\u062a",
+                "common": "\u0645\u0648\u0646\u062a\u0633\u0631\u0627\u062a"
             }
         },
         "latlng": [
@@ -21457,8 +22189,8 @@
                 "common": "\ub9c8\ub974\ud2f0\ub2c8\ud06c"
             },
             "per": {
-              "official": "\u0645\u0627\u0631\u062a\u06cc\u0646\u06cc\u06a9",
-              "common": "\u0645\u0627\u0631\u062a\u06cc\u0646\u06cc\u06a9"
+                "official": "\u0645\u0627\u0631\u062a\u06cc\u0646\u06cc\u06a9",
+                "common": "\u0645\u0627\u0631\u062a\u06cc\u0646\u06cc\u06a9"
             }
         },
         "latlng": [
@@ -21596,8 +22328,8 @@
                 "common": "\ubaa8\ub9ac\uc154\uc2a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0648\u0631\u06cc\u0633",
-              "common": "\u0645\u0648\u0631\u06cc\u0633"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0648\u0631\u06cc\u0633",
+                "common": "\u0645\u0648\u0631\u06cc\u0633"
             }
         },
         "latlng": [
@@ -21608,7 +22340,13 @@
         "landlocked": false,
         "borders": [],
         "area": 2040,
-        "flag": "\ud83c\uddf2\ud83c\uddfa"
+        "flag": "\ud83c\uddf2\ud83c\uddfa",
+        "demonyms": {
+            "fra": {
+                "f": "Mauricienne",
+                "m": "Mauricien"
+            }
+        }
     },
     {
         "name": {
@@ -21729,8 +22467,8 @@
                 "common": "\ub9d0\ub77c\uc704"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0627\u0644\u0627\u0648\u06cc",
-              "common": "\u0645\u0627\u0644\u0627\u0648\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u0627\u0644\u0627\u0648\u06cc",
+                "common": "\u0645\u0627\u0644\u0627\u0648\u06cc"
             }
         },
         "latlng": [
@@ -21745,7 +22483,13 @@
             "ZMB"
         ],
         "area": 118484,
-        "flag": "\ud83c\uddf2\ud83c\uddfc"
+        "flag": "\ud83c\uddf2\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Malawienne",
+                "m": "Malawien"
+            }
+        }
     },
     {
         "name": {
@@ -21865,8 +22609,8 @@
                 "common": "\ub9d0\ub808\uc774\uc2dc\uc544"
             },
             "per": {
-              "official": "\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0645\u0627\u0644\u0632\u06cc",
-              "common": "\u0645\u0627\u0644\u0632\u06cc"
+                "official": "\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0645\u0627\u0644\u0632\u06cc",
+                "common": "\u0645\u0627\u0644\u0632\u06cc"
             }
         },
         "latlng": [
@@ -21881,7 +22625,13 @@
             "THA"
         ],
         "area": 330803,
-        "flag": "\ud83c\uddf2\ud83c\uddfe"
+        "flag": "\ud83c\uddf2\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Malaisienne",
+                "m": "Malaisien"
+            }
+        }
     },
     {
         "name": {
@@ -21998,8 +22748,8 @@
                 "common": "\ub9c8\uc694\ud2b8"
             },
             "per": {
-              "official": "\u0645\u062c\u0645\u0648\u0639\u0647 \u0634\u0647\u0631\u0633\u062a\u0627\u0646\u06cc \u0645\u0627\u06cc\u0648\u062a",
-              "common": "\u0645\u0627\u06cc\u0648\u062a"
+                "official": "\u0645\u062c\u0645\u0648\u0639\u0647 \u0634\u0647\u0631\u0633\u062a\u0627\u0646\u06cc \u0645\u0627\u06cc\u0648\u062a",
+                "common": "\u0645\u0627\u06cc\u0648\u062a"
             }
         },
         "latlng": [
@@ -22171,8 +22921,8 @@
                 "common": "\ub098\ubbf8\ube44\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u0627\u0645\u06cc\u0628\u06cc\u0627",
-              "common": "\u0646\u0627\u0645\u06cc\u0628\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u0627\u0645\u06cc\u0628\u06cc\u0627",
+                "common": "\u0646\u0627\u0645\u06cc\u0628\u06cc\u0627"
             }
         },
         "latlng": [
@@ -22188,7 +22938,13 @@
             "ZMB"
         ],
         "area": 825615,
-        "flag": "\ud83c\uddf3\ud83c\udde6"
+        "flag": "\ud83c\uddf3\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Namibienne",
+                "m": "Namibien"
+            }
+        }
     },
     {
         "name": {
@@ -22303,8 +23059,8 @@
                 "common": "\ub204\ubca8\uce7c\ub808\ub3c4\ub2c8"
             },
             "per": {
-              "official": "\u06a9\u0627\u0644\u062f\u0648\u0646\u06cc\u0627\u06cc \u062c\u062f\u06cc\u062f",
-              "common": "\u06a9\u0627\u0644\u062f\u0648\u0646\u06cc\u0627\u06cc \u062c\u062f\u06cc\u062f"
+                "official": "\u06a9\u0627\u0644\u062f\u0648\u0646\u06cc\u0627\u06cc \u062c\u062f\u06cc\u062f",
+                "common": "\u06a9\u0627\u0644\u062f\u0648\u0646\u06cc\u0627\u06cc \u062c\u062f\u06cc\u062f"
             }
         },
         "latlng": [
@@ -22431,8 +23187,8 @@
                 "common": "\ub2c8\uc81c\ub974"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u06cc\u062c\u0631",
-              "common": "\u0646\u06cc\u062c\u0631"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u06cc\u062c\u0631",
+                "common": "\u0646\u06cc\u062c\u0631"
             }
         },
         "latlng": [
@@ -22451,7 +23207,13 @@
             "NGA"
         ],
         "area": 1267000,
-        "flag": "\ud83c\uddf3\ud83c\uddea"
+        "flag": "\ud83c\uddf3\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Nig\u00e9rienne",
+                "m": "Nig\u00e9rien"
+            }
+        }
     },
     {
         "name": {
@@ -22573,8 +23335,8 @@
                 "common": "\ub178\ud37d \uc12c"
             },
             "per": {
-              "official": "\u0642\u0644\u0645\u0631\u0648 \u062c\u0632\u0627\u06cc\u0631 \u0646\u0648\u0631\u0641\u06a9",
-              "common": "\u062c\u0632\u06cc\u0631\u0647 \u0646\u0648\u0631\u0641\u06a9"
+                "official": "\u0642\u0644\u0645\u0631\u0648 \u062c\u0632\u0627\u06cc\u0631 \u0646\u0648\u0631\u0641\u06a9",
+                "common": "\u062c\u0632\u06cc\u0631\u0647 \u0646\u0648\u0631\u0641\u06a9"
             }
         },
         "latlng": [
@@ -22703,8 +23465,8 @@
                 "common": "\ub098\uc774\uc9c0\ub9ac\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u0646\u06cc\u062c\u0631\u06cc\u0647",
-              "common": "\u0646\u06cc\u062c\u0631\u06cc\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u0646\u06cc\u062c\u0631\u06cc\u0647",
+                "common": "\u0646\u06cc\u062c\u0631\u06cc\u0647"
             }
         },
         "latlng": [
@@ -22720,7 +23482,13 @@
             "NER"
         ],
         "area": 923768,
-        "flag": "\ud83c\uddf3\ud83c\uddec"
+        "flag": "\ud83c\uddf3\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Nig\u00e9riane",
+                "m": "Nig\u00e9rian"
+            }
+        }
     },
     {
         "name": {
@@ -22837,8 +23605,8 @@
                 "common": "\ub2c8\uce74\ub77c\uacfc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u06cc\u06a9\u0627\u0631\u0627\u06af\u0648\u0626\u0647",
-              "common": "\u0646\u06cc\u06a9\u0627\u0631\u0627\u06af\u0648\u0626\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u06cc\u06a9\u0627\u0631\u0627\u06af\u0648\u0626\u0647",
+                "common": "\u0646\u06cc\u06a9\u0627\u0631\u0627\u06af\u0648\u0626\u0647"
             }
         },
         "latlng": [
@@ -22852,7 +23620,13 @@
             "HND"
         ],
         "area": 130373,
-        "flag": "\ud83c\uddf3\ud83c\uddee"
+        "flag": "\ud83c\uddf3\ud83c\uddee",
+        "demonyms": {
+            "fra": {
+                "f": "Nicaraguayenne",
+                "m": "Nicaraguayen"
+            }
+        }
     },
     {
         "name": {
@@ -22972,8 +23746,8 @@
                 "common": "\ub2c8\uc6b0\uc5d0"
             },
             "per": {
-              "official": "\u0646\u06cc\u0648\u0648\u06cc",
-              "common": "\u0646\u06cc\u0648\u0648\u06cc"
+                "official": "\u0646\u06cc\u0648\u0648\u06cc",
+                "common": "\u0646\u06cc\u0648\u0648\u06cc"
             }
         },
         "latlng": [
@@ -23102,8 +23876,8 @@
                 "common": "\ub124\ub35c\ub780\ub4dc"
             },
             "per": {
-              "official": "\u0647\u0644\u0646\u062f",
-              "common": "\u0647\u0644\u0646\u062f"
+                "official": "\u0647\u0644\u0646\u062f",
+                "common": "\u0647\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -23117,7 +23891,13 @@
             "DEU"
         ],
         "area": 41850,
-        "flag": "\ud83c\uddf3\ud83c\uddf1"
+        "flag": "\ud83c\uddf3\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "N\u00e9erlandaise",
+                "m": "N\u00e9erlandais"
+            }
+        }
     },
     {
         "name": {
@@ -23247,8 +24027,8 @@
                 "common": "\ub178\ub974\uc6e8\uc774"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0646\u0631\u0648\u0698",
-              "common": "\u0646\u0631\u0648\u0698"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0646\u0631\u0648\u0698",
+                "common": "\u0646\u0631\u0648\u0698"
             }
         },
         "latlng": [
@@ -23263,7 +24043,13 @@
             "RUS"
         ],
         "area": 323802,
-        "flag": "\ud83c\uddf3\ud83c\uddf4"
+        "flag": "\ud83c\uddf3\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Norv\u00e9gienne",
+                "m": "Norv\u00e9gien"
+            }
+        }
     },
     {
         "name": {
@@ -23380,8 +24166,8 @@
                 "common": "\ub124\ud314"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u0646\u067e\u0627\u0644",
-              "common": "\u0646\u067e\u0627\u0644"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u0646\u067e\u0627\u0644",
+                "common": "\u0646\u067e\u0627\u0644"
             }
         },
         "latlng": [
@@ -23395,7 +24181,13 @@
             "IND"
         ],
         "area": 147181,
-        "flag": "\ud83c\uddf3\ud83c\uddf5"
+        "flag": "\ud83c\uddf3\ud83c\uddf5",
+        "demonyms": {
+            "fra": {
+                "f": "N\u00e9palaise",
+                "m": "N\u00e9palais"
+            }
+        }
     },
     {
         "name": {
@@ -23519,8 +24311,8 @@
                 "common": "\ub098\uc6b0\ub8e8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u0627\u0626\u0648\u0631\u0648",
-              "common": "\u0646\u0627\u0626\u0648\u0631\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0646\u0627\u0626\u0648\u0631\u0648",
+                "common": "\u0646\u0627\u0626\u0648\u0631\u0648"
             }
         },
         "latlng": [
@@ -23531,7 +24323,13 @@
         "landlocked": false,
         "borders": [],
         "area": 21,
-        "flag": "\ud83c\uddf3\ud83c\uddf7"
+        "flag": "\ud83c\uddf3\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Nauruane",
+                "m": "Nauruan"
+            }
+        }
     },
     {
         "name": {
@@ -23657,8 +24455,8 @@
                 "common": "\ub274\uc9c8\ub79c\ub4dc"
             },
             "per": {
-              "official": "\u0646\u06cc\u0648\u0632\u06cc\u0644\u0646\u062f",
-              "common": "\u0646\u06cc\u0648\u0632\u06cc\u0644\u0646\u062f"
+                "official": "\u0646\u06cc\u0648\u0632\u06cc\u0644\u0646\u062f",
+                "common": "\u0646\u06cc\u0648\u0632\u06cc\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -23669,7 +24467,13 @@
         "landlocked": false,
         "borders": [],
         "area": 270467,
-        "flag": "\ud83c\uddf3\ud83c\uddff"
+        "flag": "\ud83c\uddf3\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Neo-zelandaise",
+                "m": "Neo-zelandais"
+            }
+        }
     },
     {
         "name": {
@@ -23786,8 +24590,8 @@
                 "common": "\uc624\ub9cc"
             },
             "per": {
-              "official": "\u0633\u0644\u0637\u0627\u0646\u200c\u0646\u0634\u06cc\u0646 \u0639\u064f\u0645\u0627\u0646",
-              "common": "\u0639\u0645\u0627\u0646"
+                "official": "\u0633\u0644\u0637\u0627\u0646\u200c\u0646\u0634\u06cc\u0646 \u0639\u064f\u0645\u0627\u0646",
+                "common": "\u0639\u0645\u0627\u0646"
             }
         },
         "latlng": [
@@ -23802,7 +24606,13 @@
             "YEM"
         ],
         "area": 309500,
-        "flag": "\ud83c\uddf4\ud83c\uddf2"
+        "flag": "\ud83c\uddf4\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Omanaise",
+                "m": "Omanais"
+            }
+        }
     },
     {
         "name": {
@@ -23925,8 +24735,8 @@
                 "common": "\ud30c\ud0a4\uc2a4\ud0c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc \u067e\u0627\u06a9\u0633\u062a\u0627\u0646",
-              "common": "\u067e\u0627\u06a9\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0627\u0645\u06cc \u067e\u0627\u06a9\u0633\u062a\u0627\u0646",
+                "common": "\u067e\u0627\u06a9\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -23942,7 +24752,13 @@
             "IRN"
         ],
         "area": 881912,
-        "flag": "\ud83c\uddf5\ud83c\uddf0"
+        "flag": "\ud83c\uddf5\ud83c\uddf0",
+        "demonyms": {
+            "fra": {
+                "f": "Pakistanaise",
+                "m": "Pakistanais"
+            }
+        }
     },
     {
         "name": {
@@ -24063,8 +24879,8 @@
                 "common": "\ud30c\ub098\ub9c8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0627\u0646\u0627\u0645\u0627",
-              "common": "\u067e\u0627\u0646\u0627\u0645\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0627\u0646\u0627\u0645\u0627",
+                "common": "\u067e\u0627\u0646\u0627\u0645\u0627"
             }
         },
         "latlng": [
@@ -24078,7 +24894,13 @@
             "CRI"
         ],
         "area": 75417,
-        "flag": "\ud83c\uddf5\ud83c\udde6"
+        "flag": "\ud83c\uddf5\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Panam\u00e9enne",
+                "m": "Panam\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -24195,8 +25017,8 @@
                 "common": "\ud54f\ucf00\uc5b8 \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u067e\u06cc\u062a\u200c\u06a9\u0631\u0646",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u067e\u06cc\u062a\u200c\u06a9\u0631\u0646"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u067e\u06cc\u062a\u200c\u06a9\u0631\u0646",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u067e\u06cc\u062a\u200c\u06a9\u0631\u0646"
             }
         },
         "latlng": [
@@ -24334,8 +25156,8 @@
                 "common": "\ud398\ub8e8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0631\u0648",
-              "common": "\u067e\u0631\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0631\u0648",
+                "common": "\u067e\u0631\u0648"
             }
         },
         "latlng": [
@@ -24352,7 +25174,13 @@
             "ECU"
         ],
         "area": 1285216,
-        "flag": "\ud83c\uddf5\ud83c\uddea"
+        "flag": "\ud83c\uddf5\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "P\u00e9ruvienne",
+                "m": "P\u00e9ruvien"
+            }
+        }
     },
     {
         "name": {
@@ -24474,8 +25302,8 @@
                 "common": "\ud544\ub9ac\ud540"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u06cc\u0644\u06cc\u067e\u06cc\u0646",
-              "common": "\u0641\u06cc\u0644\u06cc\u067e\u06cc\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u06cc\u0644\u06cc\u067e\u06cc\u0646",
+                "common": "\u0641\u06cc\u0644\u06cc\u067e\u06cc\u0646"
             }
         },
         "latlng": [
@@ -24486,7 +25314,13 @@
         "landlocked": false,
         "borders": [],
         "area": 342353,
-        "flag": "\ud83c\uddf5\ud83c\udded"
+        "flag": "\ud83c\uddf5\ud83c\udded",
+        "demonyms": {
+            "fra": {
+                "f": "Philippine",
+                "m": "Philippin"
+            }
+        }
     },
     {
         "name": {
@@ -24608,8 +25442,8 @@
                 "common": "\ud314\ub77c\uc6b0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0627\u0644\u0627\u0626\u0648",
-              "common": "\u067e\u0627\u0644\u0627\u0626\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0627\u0644\u0627\u0626\u0648",
+                "common": "\u067e\u0627\u0644\u0627\u0626\u0648"
             }
         },
         "latlng": [
@@ -24620,7 +25454,13 @@
         "landlocked": false,
         "borders": [],
         "area": 459,
-        "flag": "\ud83c\uddf5\ud83c\uddfc"
+        "flag": "\ud83c\uddf5\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Paluane",
+                "m": "Paluan"
+            }
+        }
     },
     {
         "name": {
@@ -24747,8 +25587,8 @@
                 "common": "\ud30c\ud478\uc544\ub274\uae30\ub2c8"
             },
             "per": {
-              "official": "\u0645\u0645\u0644\u06a9\u062a \u0645\u0633\u062a\u0642\u0644 \u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647\u0654 \u0646\u0648",
-              "common": "\u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647 \u0646\u0648"
+                "official": "\u0645\u0645\u0644\u06a9\u062a \u0645\u0633\u062a\u0642\u0644 \u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647\u0654 \u0646\u0648",
+                "common": "\u067e\u0627\u067e\u0648\u0622 \u06af\u06cc\u0646\u0647 \u0646\u0648"
             }
         },
         "latlng": [
@@ -24761,7 +25601,13 @@
             "IDN"
         ],
         "area": 462840,
-        "flag": "\ud83c\uddf5\ud83c\uddec"
+        "flag": "\ud83c\uddf5\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Papouane-neoguineenne",
+                "m": "Papouane-neoguineen"
+            }
+        }
     },
     {
         "name": {
@@ -24878,8 +25724,8 @@
                 "common": "\ud3f4\ub780\ub4dc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0644\u0647\u0633\u062a\u0627\u0646",
-              "common": "\u0644\u0647\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0644\u0647\u0633\u062a\u0627\u0646",
+                "common": "\u0644\u0647\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -24898,7 +25744,13 @@
             "UKR"
         ],
         "area": 312679,
-        "flag": "\ud83c\uddf5\ud83c\uddf1"
+        "flag": "\ud83c\uddf5\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "Polonaise",
+                "m": "Polonais"
+            }
+        }
     },
     {
         "name": {
@@ -25021,8 +25873,8 @@
                 "common": "\ud478\uc5d0\ub974\ud1a0\ub9ac\ucf54"
             },
             "per": {
-              "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u067e\u0648\u0631\u062a\u0648\u0631\u06cc\u06a9\u0648",
-              "common": "\u067e\u0648\u0631\u062a\u0648\u0631\u06cc\u06a9\u0648"
+                "official": "\u0642\u0644\u0645\u0631\u0648 \u0647\u0645\u0633\u0648\u062f \u067e\u0648\u0631\u062a\u0648\u0631\u06cc\u06a9\u0648",
+                "common": "\u067e\u0648\u0631\u062a\u0648\u0631\u06cc\u06a9\u0648"
             }
         },
         "latlng": [
@@ -25033,7 +25885,13 @@
         "landlocked": false,
         "borders": [],
         "area": 8870,
-        "flag": "\ud83c\uddf5\ud83c\uddf7"
+        "flag": "\ud83c\uddf5\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Portoricaine",
+                "m": "Portoricain"
+            }
+        }
     },
     {
         "name": {
@@ -25154,8 +26012,8 @@
                 "common": "\uc870\uc120"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u062e\u0644\u0642 \u06a9\u0631\u0647",
-              "common": "\u06a9\u064f\u0631\u0647 \u0634\u0645\u0627\u0644\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u062e\u0644\u0642 \u06a9\u0631\u0647",
+                "common": "\u06a9\u064f\u0631\u0647 \u0634\u0645\u0627\u0644\u06cc"
             }
         },
         "latlng": [
@@ -25170,7 +26028,13 @@
             "RUS"
         ],
         "area": 120538,
-        "flag": "\ud83c\uddf0\ud83c\uddf5"
+        "flag": "\ud83c\uddf0\ud83c\uddf5",
+        "demonyms": {
+            "fra": {
+                "f": "Nord-cor\u00e9enne",
+                "m": "Nord-cor\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -25288,8 +26152,8 @@
                 "common": "\ud3ec\ub974\ud22c\uac08"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0631\u062a\u063a\u0627\u0644",
-              "common": "\u067e\u0631\u062a\u063a\u0627\u0644"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0631\u062a\u063a\u0627\u0644",
+                "common": "\u067e\u0631\u062a\u063a\u0627\u0644"
             }
         },
         "latlng": [
@@ -25302,7 +26166,13 @@
             "ESP"
         ],
         "area": 92090,
-        "flag": "\ud83c\uddf5\ud83c\uddf9"
+        "flag": "\ud83c\uddf5\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Portugaise",
+                "m": "Portugais"
+            }
+        }
     },
     {
         "name": {
@@ -25425,8 +26295,8 @@
                 "common": "\ud30c\ub77c\uacfc\uc774"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0627\u0631\u0627\u06af\u0648\u0626\u0647",
-              "common": "\u067e\u0627\u0631\u0627\u06af\u0648\u0626\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u067e\u0627\u0631\u0627\u06af\u0648\u0626\u0647",
+                "common": "\u067e\u0627\u0631\u0627\u06af\u0648\u0626\u0647"
             }
         },
         "latlng": [
@@ -25441,7 +26311,13 @@
             "BRA"
         ],
         "area": 406752,
-        "flag": "\ud83c\uddf5\ud83c\uddfe"
+        "flag": "\ud83c\uddf5\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Paraguayenne",
+                "m": "Paraguayen"
+            }
+        }
     },
     {
         "name": {
@@ -25568,8 +26444,8 @@
                 "common": "\ud314\ub808\uc2a4\ud0c0\uc778"
             },
             "per": {
-              "official": "\u062f\u0648\u0644\u062a \u0641\u0644\u0633\u0637\u06cc\u0646",
-              "common": "\u0641\u0644\u0633\u0637\u06cc\u0646"
+                "official": "\u062f\u0648\u0644\u062a \u0641\u0644\u0633\u0637\u06cc\u0646",
+                "common": "\u0641\u0644\u0633\u0637\u06cc\u0646"
             }
         },
         "latlng": [
@@ -25584,7 +26460,13 @@
             "JOR"
         ],
         "area": 6220,
-        "flag": "\ud83c\uddf5\ud83c\uddf8"
+        "flag": "\ud83c\uddf5\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Palestinienne",
+                "m": "Palestinien"
+            }
+        }
     },
     {
         "name": {
@@ -25702,8 +26584,8 @@
                 "common": "\ud504\ub791\uc2a4\ub839 \ud3f4\ub9ac\ub124\uc2dc\uc544"
             },
             "per": {
-              "official": "\u067e\u064f\u0644\u06cc\u200c\u0646\u0650\u0632\u06cc \u0641\u0631\u0627\u0646\u0633\u0647",
-              "common": "\u067e\u064f\u0644\u06cc\u200c\u0646\u0650\u0632\u06cc \u0641\u0631\u0627\u0646\u0633\u0647"
+                "official": "\u067e\u064f\u0644\u06cc\u200c\u0646\u0650\u0632\u06cc \u0641\u0631\u0627\u0646\u0633\u0647",
+                "common": "\u067e\u064f\u0644\u06cc\u200c\u0646\u0650\u0632\u06cc \u0641\u0631\u0627\u0646\u0633\u0647"
             }
         },
         "latlng": [
@@ -25832,8 +26714,8 @@
                 "common": "\uce74\ud0c0\ub974"
             },
             "per": {
-              "official": "\u062f\u0648\u0644\u062a \u0642\u0637\u0631",
-              "common": "\u0642\u0637\u0631"
+                "official": "\u062f\u0648\u0644\u062a \u0642\u0637\u0631",
+                "common": "\u0642\u0637\u0631"
             }
         },
         "latlng": [
@@ -25846,7 +26728,13 @@
             "SAU"
         ],
         "area": 11586,
-        "flag": "\ud83c\uddf6\ud83c\udde6"
+        "flag": "\ud83c\uddf6\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Qatarienne",
+                "m": "Qatarien"
+            }
+        }
     },
     {
         "name": {
@@ -25962,8 +26850,8 @@
                 "common": "\ub808\uc704\ub2c8\uc639"
             },
             "per": {
-              "official": "\u0631\u0626\u0648\u0646\u06cc\u0648\u0646",
-              "common": "\u0631\u0626\u0648\u0646\u06cc\u0648\u0646"
+                "official": "\u0631\u0626\u0648\u0646\u06cc\u0648\u0646",
+                "common": "\u0631\u0626\u0648\u0646\u06cc\u0648\u0646"
             }
         },
         "latlng": [
@@ -26092,8 +26980,8 @@
                 "common": "\ub8e8\ub9c8\ub2c8\uc544"
             },
             "per": {
-              "official": "\u0631\u0648\u0645\u0627\u0646\u06cc",
-              "common": "\u0631\u0648\u0645\u0627\u0646\u06cc"
+                "official": "\u0631\u0648\u0645\u0627\u0646\u06cc",
+                "common": "\u0631\u0648\u0645\u0627\u0646\u06cc"
             }
         },
         "latlng": [
@@ -26110,7 +26998,13 @@
             "UKR"
         ],
         "area": 238391,
-        "flag": "\ud83c\uddf7\ud83c\uddf4"
+        "flag": "\ud83c\uddf7\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Roumaine",
+                "m": "Roumain"
+            }
+        }
     },
     {
         "name": {
@@ -26233,8 +27127,8 @@
                 "common": "\ub7ec\uc2dc\uc544"
             },
             "per": {
-              "official": "\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0631\u0648\u0633\u06cc\u0647",
-              "common": "\u0631\u0648\u0633\u06cc\u0647"
+                "official": "\u0641\u062f\u0631\u0627\u0633\u06cc\u0648\u0646 \u0631\u0648\u0633\u06cc\u0647",
+                "common": "\u0631\u0648\u0633\u06cc\u0647"
             }
         },
         "latlng": [
@@ -26260,7 +27154,13 @@
             "UKR"
         ],
         "area": 17098242,
-        "flag": "\ud83c\uddf7\ud83c\uddfa"
+        "flag": "\ud83c\uddf7\ud83c\uddfa",
+        "demonyms": {
+            "fra": {
+                "f": "Russe",
+                "m": "Russe"
+            }
+        }
     },
     {
         "name": {
@@ -26388,8 +27288,8 @@
                 "common": "\ub974\uc644\ub2e4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0631\u0648\u0627\u0646\u062f\u0627",
-              "common": "\u0631\u0648\u0627\u0646\u062f\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0631\u0648\u0627\u0646\u062f\u0627",
+                "common": "\u0631\u0648\u0627\u0646\u062f\u0627"
             }
         },
         "latlng": [
@@ -26405,7 +27305,13 @@
             "UGA"
         ],
         "area": 26338,
-        "flag": "\ud83c\uddf7\ud83c\uddfc"
+        "flag": "\ud83c\uddf7\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Rwandaise",
+                "m": "Rwandais"
+            }
+        }
     },
     {
         "name": {
@@ -26524,8 +27430,8 @@
                 "common": "\uc0ac\uc6b0\ub514\uc544\ub77c\ube44\uc544"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0639\u0631\u0628\u06cc \u0633\u064e\u0639\u0648\u062f\u06cc",
-              "common": "\u0639\u0631\u0628\u0633\u062a\u0627\u0646 \u0633\u0639\u0648\u062f\u06cc"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0639\u0631\u0628\u06cc \u0633\u064e\u0639\u0648\u062f\u06cc",
+                "common": "\u0639\u0631\u0628\u0633\u062a\u0627\u0646 \u0633\u0639\u0648\u062f\u06cc"
             }
         },
         "latlng": [
@@ -26544,7 +27450,13 @@
             "YEM"
         ],
         "area": 2149690,
-        "flag": "\ud83c\uddf8\ud83c\udde6"
+        "flag": "\ud83c\uddf8\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Saoudienne",
+                "m": "Saoudien"
+            }
+        }
     },
     {
         "name": {
@@ -26666,8 +27578,8 @@
                 "common": "\uc218\ub2e8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u062f\u0627\u0646",
-              "common": "\u0633\u0648\u062f\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u062f\u0627\u0646",
+                "common": "\u0633\u0648\u062f\u0627\u0646"
             }
         },
         "latlng": [
@@ -26686,7 +27598,13 @@
             "SSD"
         ],
         "area": 1886068,
-        "flag": "\ud83c\uddf8\ud83c\udde9"
+        "flag": "\ud83c\uddf8\ud83c\udde9",
+        "demonyms": {
+            "fra": {
+                "f": "Soudanaise",
+                "m": "Soudanais"
+            }
+        }
     },
     {
         "name": {
@@ -26803,8 +27721,8 @@
                 "common": "\uc138\ub124\uac08"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0646\u06af\u0627\u0644",
-              "common": "\u0633\u0646\u06af\u0627\u0644"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0646\u06af\u0627\u0644",
+                "common": "\u0633\u0646\u06af\u0627\u0644"
             }
         },
         "latlng": [
@@ -26821,7 +27739,13 @@
             "MRT"
         ],
         "area": 196722,
-        "flag": "\ud83c\uddf8\ud83c\uddf3"
+        "flag": "\ud83c\uddf8\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "S\u00e9n\u00e9galaise",
+                "m": "S\u00e9n\u00e9galais"
+            }
+        }
     },
     {
         "name": {
@@ -26952,8 +27876,8 @@
                 "common": "\uc2f1\uac00\ud3ec\ub974"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0646\u06af\u0627\u067e\u0648\u0631",
-              "common": "\u0633\u0646\u06af\u0627\u067e\u0648\u0631"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0646\u06af\u0627\u067e\u0648\u0631",
+                "common": "\u0633\u0646\u06af\u0627\u067e\u0648\u0631"
             }
         },
         "latlng": [
@@ -26964,7 +27888,13 @@
         "landlocked": false,
         "borders": [],
         "area": 710,
-        "flag": "\ud83c\uddf8\ud83c\uddec"
+        "flag": "\ud83c\uddf8\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Singapourienne",
+                "m": "Singapourien"
+            }
+        }
     },
     {
         "name": {
@@ -27080,8 +28010,8 @@
                 "common": "\uc870\uc9c0\uc544"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u062c\u0648\u0631\u062c\u06cc\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u0633\u0627\u0646\u062f\u0648\u06cc\u0686 \u062c\u0646\u0648\u0628\u06cc",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u062c\u0648\u0631\u062c\u06cc\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u0633\u0627\u0646\u062f\u0648\u06cc\u0686 \u062c\u0646\u0648\u0628\u06cc"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u062c\u0648\u0631\u062c\u06cc\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u0633\u0627\u0646\u062f\u0648\u06cc\u0686 \u062c\u0646\u0648\u0628\u06cc",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u062c\u0648\u0631\u062c\u06cc\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc \u0648 \u0633\u0627\u0646\u062f\u0648\u06cc\u0686 \u062c\u0646\u0648\u0628\u06cc"
             }
         },
         "latlng": [
@@ -27208,8 +28138,8 @@
                 "common": "\uc2a4\ubc1c\ubc14\ub974 \uc580\ub9c8\uc60c \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u0633\u0648\u0627\u0644\u0628\u0627\u0631\u062f \u0648 \u06cc\u0627\u0646 \u0645\u0627\u06cc\u0646",
-              "common": "\u0633\u0648\u0627\u0644\u0628\u0627\u0631\u062f \u0648 \u06cc\u0627\u0646 \u0645\u0627\u06cc\u0646"
+                "official": "\u0633\u0648\u0627\u0644\u0628\u0627\u0631\u062f \u0648 \u06cc\u0627\u0646 \u0645\u0627\u06cc\u0646",
+                "common": "\u0633\u0648\u0627\u0644\u0628\u0627\u0631\u062f \u0648 \u06cc\u0627\u0646 \u0645\u0627\u06cc\u0646"
             }
         },
         "latlng": [
@@ -27335,8 +28265,8 @@
                 "common": "\uc194\ub85c\ubaac \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0633\u0644\u06cc\u0645\u0627\u0646",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u0633\u0644\u06cc\u0645\u0627\u0646"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0633\u0644\u06cc\u0645\u0627\u0646",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0633\u0644\u06cc\u0645\u0627\u0646"
             }
         },
         "latlng": [
@@ -27347,7 +28277,13 @@
         "landlocked": false,
         "borders": [],
         "area": 28896,
-        "flag": "\ud83c\uddf8\ud83c\udde7"
+        "flag": "\ud83c\uddf8\ud83c\udde7",
+        "demonyms": {
+            "fra": {
+                "f": "Salomonienne",
+                "m": "Salomonien"
+            }
+        }
     },
     {
         "name": {
@@ -27463,8 +28399,8 @@
                 "common": "\uc2dc\uc5d0\ub77c\ub9ac\uc628"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u06cc\u0631\u0627\u0644\u0626\u0648\u0646",
-              "common": "\u0633\u06cc\u0631\u0627\u0644\u0626\u0648\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u06cc\u0631\u0627\u0644\u0626\u0648\u0646",
+                "common": "\u0633\u06cc\u0631\u0627\u0644\u0626\u0648\u0646"
             }
         },
         "latlng": [
@@ -27478,7 +28414,13 @@
             "LBR"
         ],
         "area": 71740,
-        "flag": "\ud83c\uddf8\ud83c\uddf1"
+        "flag": "\ud83c\uddf8\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "Sierra-leonaise",
+                "m": "Sierra-leonais"
+            }
+        }
     },
     {
         "name": {
@@ -27599,8 +28541,8 @@
                 "common": "\uc5d8\uc0b4\ubc14\ub3c4\ub974"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0644\u0633\u0627\u0644\u0648\u0627\u062f\u0648\u0631",
-              "common": "\u0627\u0644\u0633\u0627\u0644\u0648\u0627\u062f\u0648\u0631"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0644\u0633\u0627\u0644\u0648\u0627\u062f\u0648\u0631",
+                "common": "\u0627\u0644\u0633\u0627\u0644\u0648\u0627\u062f\u0648\u0631"
             }
         },
         "latlng": [
@@ -27614,7 +28556,13 @@
             "HND"
         ],
         "area": 21041,
-        "flag": "\ud83c\uddf8\ud83c\uddfb"
+        "flag": "\ud83c\uddf8\ud83c\uddfb",
+        "demonyms": {
+            "fra": {
+                "f": "Salvadorienne",
+                "m": "Salvadorien"
+            }
+        }
     },
     {
         "name": {
@@ -27731,8 +28679,8 @@
                 "common": "\uc0b0\ub9c8\ub9ac\ub178"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0627\u0646 \u0645\u0627\u0631\u06cc\u0646\u0648",
-              "common": "\u0633\u0627\u0646 \u0645\u0627\u0631\u06cc\u0646\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0627\u0646 \u0645\u0627\u0631\u06cc\u0646\u0648",
+                "common": "\u0633\u0627\u0646 \u0645\u0627\u0631\u06cc\u0646\u0648"
             }
         },
         "latlng": [
@@ -27745,7 +28693,13 @@
             "ITA"
         ],
         "area": 61,
-        "flag": "\ud83c\uddf8\ud83c\uddf2"
+        "flag": "\ud83c\uddf8\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Saint-Marinaise",
+                "m": "Saint-Marinais"
+            }
+        }
     },
     {
         "name": {
@@ -27869,8 +28823,8 @@
                 "common": "\uc18c\ub9d0\ub9ac\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u0633\u0648\u0645\u0627\u0644\u06cc",
-              "common": "\u0633\u0648\u0645\u0627\u0644\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0641\u062f\u0631\u0627\u0644 \u0633\u0648\u0645\u0627\u0644\u06cc",
+                "common": "\u0633\u0648\u0645\u0627\u0644\u06cc"
             }
         },
         "latlng": [
@@ -27885,7 +28839,13 @@
             "KEN"
         ],
         "area": 637657,
-        "flag": "\ud83c\uddf8\ud83c\uddf4"
+        "flag": "\ud83c\uddf8\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Somalienne",
+                "m": "Somalien"
+            }
+        }
     },
     {
         "name": {
@@ -28001,8 +28961,8 @@
                 "common": "\uc0dd\ud53c\uc5d0\ub974 \ubbf8\ud074\ub871"
             },
             "per": {
-              "official": "\u0633\u0646\u002d\u067e\u06cc\u0631\u002d\u0627\u002d\u0645\u06cc\u06a9\u0644\u0648\u0646",
-              "common": "\u0633\u0646\u002d\u067e\u06cc\u0650\u0631 \u0648 \u0645\u06cc\u06a9\u0644\u064f\u0646"
+                "official": "\u0633\u0646-\u067e\u06cc\u0631-\u0627-\u0645\u06cc\u06a9\u0644\u0648\u0646",
+                "common": "\u0633\u0646-\u067e\u06cc\u0650\u0631 \u0648 \u0645\u06cc\u06a9\u0644\u064f\u0646"
             }
         },
         "latlng": [
@@ -28133,8 +29093,8 @@
                 "common": "\uc138\ub974\ube44\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0635\u0631\u0628\u0633\u062a\u0627\u0646",
-              "common": "\u0635\u0631\u0628\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0635\u0631\u0628\u0633\u062a\u0627\u0646",
+                "common": "\u0635\u0631\u0628\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -28154,7 +29114,13 @@
             "ROU"
         ],
         "area": 88361,
-        "flag": "\ud83c\uddf7\ud83c\uddf8"
+        "flag": "\ud83c\uddf7\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Serbe",
+                "m": "Serbe"
+            }
+        }
     },
     {
         "name": {
@@ -28269,8 +29235,8 @@
                 "common": "\ub0a8\uc218\ub2e8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u062f\u0627\u0646 \u062c\u0646\u0648\u0628\u06cc",
-              "common": "\u0633\u0648\u062f\u0627\u0646 \u062c\u0646\u0648\u0628\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u062f\u0627\u0646 \u062c\u0646\u0648\u0628\u06cc",
+                "common": "\u0633\u0648\u062f\u0627\u0646 \u062c\u0646\u0648\u0628\u06cc"
             }
         },
         "latlng": [
@@ -28288,7 +29254,13 @@
             "UGA"
         ],
         "area": 619745,
-        "flag": "\ud83c\uddf8\ud83c\uddf8"
+        "flag": "\ud83c\uddf8\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Sud-Soudanaise",
+                "m": "Sud-Soudanais"
+            }
+        }
     },
     {
         "name": {
@@ -28406,8 +29378,8 @@
                 "common": "\uc0c1\ud22c\uba54 \ud504\ub9b0\uc2dc\ud398"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u0633\u0627\u0626\u0648\u062a\u0648\u0645\u0647 \u0648 \u067e\u0631\u0646\u0633\u06cc\u067e",
-              "common": "\u0633\u0627\u0626\u0648\u062a\u0648\u0645\u0647 \u0648 \u067e\u0631\u0646\u0633\u06cc\u067e"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u0633\u0627\u0626\u0648\u062a\u0648\u0645\u0647 \u0648 \u067e\u0631\u0646\u0633\u06cc\u067e",
+                "common": "\u0633\u0627\u0626\u0648\u062a\u0648\u0645\u0647 \u0648 \u067e\u0631\u0646\u0633\u06cc\u067e"
             }
         },
         "latlng": [
@@ -28418,7 +29390,13 @@
         "landlocked": false,
         "borders": [],
         "area": 964,
-        "flag": "\ud83c\uddf8\ud83c\uddf9"
+        "flag": "\ud83c\uddf8\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Santom\u00e9enne",
+                "m": "Santom\u00e9en"
+            }
+        }
     },
     {
         "name": {
@@ -28537,8 +29515,8 @@
                 "common": "\uc218\ub9ac\ub0a8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u0631\u06cc\u0646\u0627\u0645",
-              "common": "\u0633\u0648\u0631\u06cc\u0646\u0627\u0645"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u0631\u06cc\u0646\u0627\u0645",
+                "common": "\u0633\u0648\u0631\u06cc\u0646\u0627\u0645"
             }
         },
         "latlng": [
@@ -28553,7 +29531,13 @@
             "GUY"
         ],
         "area": 163820,
-        "flag": "\ud83c\uddf8\ud83c\uddf7"
+        "flag": "\ud83c\uddf8\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Surinamaise",
+                "m": "Surinamais"
+            }
+        }
     },
     {
         "name": {
@@ -28670,8 +29654,8 @@
                 "common": "\uc2ac\ub85c\ubc14\ud0a4\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0648\u0627\u06a9\u06cc",
-              "common": "\u0627\u0650\u0633\u0644\u064f\u0648\u0627\u06a9\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0648\u0627\u06a9\u06cc",
+                "common": "\u0627\u0650\u0633\u0644\u064f\u0648\u0627\u06a9\u06cc"
             }
         },
         "latlng": [
@@ -28688,7 +29672,13 @@
             "UKR"
         ],
         "area": 49037,
-        "flag": "\ud83c\uddf8\ud83c\uddf0"
+        "flag": "\ud83c\uddf8\ud83c\uddf0",
+        "demonyms": {
+            "fra": {
+                "f": "Slovaque",
+                "m": "Slovaque"
+            }
+        }
     },
     {
         "name": {
@@ -28805,8 +29795,8 @@
                 "common": "\uc2ac\ub85c\ubca0\ub2c8\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0648\u0648\u0646\u06cc",
-              "common": "\u0627\u0633\u0644\u0648\u0648\u0646\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0633\u0644\u0648\u0648\u0646\u06cc",
+                "common": "\u0627\u0633\u0644\u0648\u0648\u0646\u06cc"
             }
         },
         "latlng": [
@@ -28822,7 +29812,13 @@
             "HUN"
         ],
         "area": 20273,
-        "flag": "\ud83c\uddf8\ud83c\uddee"
+        "flag": "\ud83c\uddf8\ud83c\uddee",
+        "demonyms": {
+            "fra": {
+                "f": "Slov\u00e8ne",
+                "m": "Slov\u00e8ne"
+            }
+        }
     },
     {
         "name": {
@@ -28939,8 +29935,8 @@
                 "common": "\uc2a4\uc6e8\ub374"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0633\u0648\u0626\u062f",
-              "common": "\u0633\u0648\u0626\u062f"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0633\u0648\u0626\u062f",
+                "common": "\u0633\u0648\u0626\u062f"
             }
         },
         "latlng": [
@@ -28954,7 +29950,13 @@
             "NOR"
         ],
         "area": 450295,
-        "flag": "\ud83c\uddf8\ud83c\uddea"
+        "flag": "\ud83c\uddf8\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Su\u00e9doise",
+                "m": "Su\u00e9dois"
+            }
+        }
     },
     {
         "name": {
@@ -29080,8 +30082,8 @@
                 "common": "\uc5d0\uc2a4\uc640\ud2f0\ub2c8"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0633\u0648\u0627\u0632\u06cc\u0644\u0646\u062f",
-              "common": "\u0627\u0633\u0648\u0627\u062a\u06cc\u0646\u06cc"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u0633\u0648\u0627\u0632\u06cc\u0644\u0646\u062f",
+                "common": "\u0627\u0633\u0648\u0627\u062a\u06cc\u0646\u06cc"
             }
         },
         "latlng": [
@@ -29095,7 +30097,13 @@
             "ZAF"
         ],
         "area": 17364,
-        "flag": "\ud83c\uddf8\ud83c\uddff"
+        "flag": "\ud83c\uddf8\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Swazie",
+                "m": "Swazie"
+            }
+        }
     },
     {
         "name": {
@@ -29221,8 +30229,8 @@
                 "common": "\uc2e0\ud2b8\ub9c8\ub974\ud134"
             },
             "per": {
-              "official": "\u0633\u0646 \u0645\u0627\u0631\u062a\u0646",
-              "common": "\u0633\u0646 \u0645\u0627\u0631\u062a\u0646"
+                "official": "\u0633\u0646 \u0645\u0627\u0631\u062a\u0646",
+                "common": "\u0633\u0646 \u0645\u0627\u0631\u062a\u0646"
             }
         },
         "latlng": [
@@ -29235,7 +30243,13 @@
             "MAF"
         ],
         "area": 34,
-        "flag": "\ud83c\uddf8\ud83c\uddfd"
+        "flag": "\ud83c\uddf8\ud83c\uddfd",
+        "demonyms": {
+            "fra": {
+                "f": "Saint-Martinoise",
+                "m": "Saint-Martinois"
+            }
+        }
     },
     {
         "name": {
@@ -29363,8 +30377,8 @@
                 "common": "\uc138\uc774\uc178"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u06cc\u0634\u0644",
-              "common": "\u0633\u06cc\u0634\u0644"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u06cc\u0634\u0644",
+                "common": "\u0633\u06cc\u0634\u0644"
             }
         },
         "latlng": [
@@ -29375,7 +30389,13 @@
         "landlocked": false,
         "borders": [],
         "area": 452,
-        "flag": "\ud83c\uddf8\ud83c\udde8"
+        "flag": "\ud83c\uddf8\ud83c\udde8",
+        "demonyms": {
+            "fra": {
+                "f": "Seychelloise",
+                "m": "Seychellois"
+            }
+        }
     },
     {
         "name": {
@@ -29493,8 +30513,8 @@
                 "common": "\uc2dc\ub9ac\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0639\u0631\u0628\u06cc \u0633\u0648\u0631\u06cc\u0647",
-              "common": "\u0633\u0648\u0631\u06cc\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0639\u0631\u0628\u06cc \u0633\u0648\u0631\u06cc\u0647",
+                "common": "\u0633\u0648\u0631\u06cc\u0647"
             }
         },
         "latlng": [
@@ -29511,7 +30531,13 @@
             "TUR"
         ],
         "area": 185180,
-        "flag": "\ud83c\uddf8\ud83c\uddfe"
+        "flag": "\ud83c\uddf8\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Syrienne",
+                "m": "Syrien"
+            }
+        }
     },
     {
         "name": {
@@ -29626,8 +30652,8 @@
                 "common": "\ud130\ud06c\uc2a4 \ucf00\uc774\ucee4\uc2a4 \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u062a\u0648\u0631\u06a9\u0633 \u0648 \u06a9\u0627\u06cc\u06a9\u0648\u0633",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u062a\u0648\u0631\u06a9\u0633 \u0648 \u06a9\u0627\u06cc\u06a9\u0648\u0633"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u062a\u0648\u0631\u06a9\u0633 \u0648 \u06a9\u0627\u06cc\u06a9\u0648\u0633",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u062a\u0648\u0631\u06a9\u0633 \u0648 \u06a9\u0627\u06cc\u06a9\u0648\u0633"
             }
         },
         "latlng": [
@@ -29765,8 +30791,8 @@
                 "common": "\ucc28\ub4dc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u0627\u062f",
-              "common": "\u0686\u0627\u062f"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u0627\u062f",
+                "common": "\u0686\u0627\u062f"
             }
         },
         "latlng": [
@@ -29784,7 +30810,13 @@
             "SDN"
         ],
         "area": 1284000,
-        "flag": "\ud83c\uddf9\ud83c\udde9"
+        "flag": "\ud83c\uddf9\ud83c\udde9",
+        "demonyms": {
+            "fra": {
+                "f": "Tchadienne",
+                "m": "Tchadien"
+            }
+        }
     },
     {
         "name": {
@@ -29902,8 +30934,8 @@
                 "common": "\ud1a0\uace0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0648\u06af\u0648",
-              "common": "\u062a\u0648\u06af\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0648\u06af\u0648",
+                "common": "\u062a\u0648\u06af\u0648"
             }
         },
         "latlng": [
@@ -29918,7 +30950,13 @@
             "GHA"
         ],
         "area": 56785,
-        "flag": "\ud83c\uddf9\ud83c\uddec"
+        "flag": "\ud83c\uddf9\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Togolaise",
+                "m": "Togolais"
+            }
+        }
     },
     {
         "name": {
@@ -30039,8 +31077,8 @@
                 "common": "\ud0dc\uad6d"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u062a\u0627\u06cc\u0644\u0646\u062f",
-              "common": "\u062a\u0627\u06cc\u0644\u0646\u062f"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u062a\u0627\u06cc\u0644\u0646\u062f",
+                "common": "\u062a\u0627\u06cc\u0644\u0646\u062f"
             }
         },
         "latlng": [
@@ -30056,7 +31094,13 @@
             "MYS"
         ],
         "area": 513120,
-        "flag": "\ud83c\uddf9\ud83c\udded"
+        "flag": "\ud83c\uddf9\ud83c\udded",
+        "demonyms": {
+            "fra": {
+                "f": "Tha\u00eflandaise",
+                "m": "Tha\u00eflandais"
+            }
+        }
     },
     {
         "name": {
@@ -30180,8 +31224,8 @@
                 "common": "\ud0c0\uc9c0\ud0a4\uc2a4\ud0c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0627\u062c\u06cc\u06a9\u0633\u062a\u0627\u0646",
-              "common": "\u062a\u0627\u062c\u06cc\u06a9\u0650\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0627\u062c\u06cc\u06a9\u0633\u062a\u0627\u0646",
+                "common": "\u062a\u0627\u062c\u06cc\u06a9\u0650\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -30197,7 +31241,13 @@
             "UZB"
         ],
         "area": 143100,
-        "flag": "\ud83c\uddf9\ud83c\uddef"
+        "flag": "\ud83c\uddf9\ud83c\uddef",
+        "demonyms": {
+            "fra": {
+                "f": "Tadjike",
+                "m": "Tadjike"
+            }
+        }
     },
     {
         "name": {
@@ -30322,8 +31372,8 @@
                 "common": "\ud1a0\ucf08\ub77c\uc6b0"
             },
             "per": {
-              "official": "\u062a\u0648\u06a9\u0644\u0627\u0626\u0648",
-              "common": "\u062a\u0648\u06a9\u0644\u0627\u0626\u0648"
+                "official": "\u062a\u0648\u06a9\u0644\u0627\u0626\u0648",
+                "common": "\u062a\u0648\u06a9\u0644\u0627\u0626\u0648"
             }
         },
         "latlng": [
@@ -30454,8 +31504,8 @@
                 "common": "\ud22c\ub974\ud06c\uba54\ub2c8\uc2a4\ud0c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062e\u0644\u0642 \u062a\u0631\u06a9\u0645\u0646\u0633\u062a\u0627\u0646",
-              "common": "\u062a\u0631\u06a9\u0645\u0646\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062e\u0644\u0642 \u062a\u0631\u06a9\u0645\u0646\u0633\u062a\u0627\u0646",
+                "common": "\u062a\u0631\u06a9\u0645\u0646\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -30471,7 +31521,13 @@
             "UZB"
         ],
         "area": 488100,
-        "flag": "\ud83c\uddf9\ud83c\uddf2"
+        "flag": "\ud83c\uddf9\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Turkm\u00e8ne",
+                "m": "Turkm\u00e8ne"
+            }
+        }
     },
     {
         "name": {
@@ -30597,8 +31653,8 @@
                 "common": "\ub3d9\ud2f0\ubaa8\ub974"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u062a\u06cc\u0645\u0648\u0631 \u0634\u0631\u0642\u06cc",
-              "common": "\u062a\u06cc\u0645\u0648\u0631 \u0634\u0631\u0642\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062f\u0645\u0648\u06a9\u0631\u0627\u062a\u06cc\u06a9 \u062a\u06cc\u0645\u0648\u0631 \u0634\u0631\u0642\u06cc",
+                "common": "\u062a\u06cc\u0645\u0648\u0631 \u0634\u0631\u0642\u06cc"
             }
         },
         "latlng": [
@@ -30611,7 +31667,13 @@
             "IDN"
         ],
         "area": 14874,
-        "flag": "\ud83c\uddf9\ud83c\uddf1"
+        "flag": "\ud83c\uddf9\ud83c\uddf1",
+        "demonyms": {
+            "fra": {
+                "f": "Est-timoraise",
+                "m": "Est-timorais"
+            }
+        }
     },
     {
         "name": {
@@ -30731,8 +31793,8 @@
                 "common": "\ud1b5\uac00"
             },
             "per": {
-              "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u062a\u0648\u0646\u06af\u0627",
-              "common": "\u062a\u0648\u0646\u06af\u0627"
+                "official": "\u067e\u0627\u062f\u0634\u0627\u0647\u06cc \u062a\u0648\u0646\u06af\u0627",
+                "common": "\u062a\u0648\u0646\u06af\u0627"
             }
         },
         "latlng": [
@@ -30743,7 +31805,13 @@
         "landlocked": false,
         "borders": [],
         "area": 747,
-        "flag": "\ud83c\uddf9\ud83c\uddf4"
+        "flag": "\ud83c\uddf9\ud83c\uddf4",
+        "demonyms": {
+            "fra": {
+                "f": "Tonguienne",
+                "m": "Tonguien"
+            }
+        }
     },
     {
         "name": {
@@ -30859,8 +31927,8 @@
                 "common": "\ud2b8\ub9ac\ub2c8\ub2e4\ub4dc \ud1a0\ubc14\uace0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0631\u06cc\u0646\u06cc\u062f\u0627\u062f \u0648 \u062a\u0648\u0628\u0627\u06af\u0648",
-              "common": "\u062a\u0631\u06cc\u0646\u06cc\u062f\u0627\u062f \u0648 \u062a\u0648\u0628\u0627\u06af\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0631\u06cc\u0646\u06cc\u062f\u0627\u062f \u0648 \u062a\u0648\u0628\u0627\u06af\u0648",
+                "common": "\u062a\u0631\u06cc\u0646\u06cc\u062f\u0627\u062f \u0648 \u062a\u0648\u0628\u0627\u06af\u0648"
             }
         },
         "latlng": [
@@ -30871,7 +31939,13 @@
         "landlocked": false,
         "borders": [],
         "area": 5130,
-        "flag": "\ud83c\uddf9\ud83c\uddf9"
+        "flag": "\ud83c\uddf9\ud83c\uddf9",
+        "demonyms": {
+            "fra": {
+                "f": "Trinidadienne",
+                "m": "Trinidadien"
+            }
+        }
     },
     {
         "name": {
@@ -30988,8 +32062,8 @@
                 "common": "\ud280\ub2c8\uc9c0"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0648\u0646\u0633",
-              "common": "\u062a\u0648\u0646\u0633"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0648\u0646\u0633",
+                "common": "\u062a\u0648\u0646\u0633"
             }
         },
         "latlng": [
@@ -31003,7 +32077,13 @@
             "LBY"
         ],
         "area": 163610,
-        "flag": "\ud83c\uddf9\ud83c\uddf3"
+        "flag": "\ud83c\uddf9\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Tunisienne",
+                "m": "Tunisien"
+            }
+        }
     },
     {
         "name": {
@@ -31121,8 +32201,8 @@
                 "common": "\ud130\ud0a4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0631\u06a9\u06cc\u0647",
-              "common": "\u062a\u0631\u06a9\u06cc\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u062a\u0631\u06a9\u06cc\u0647",
+                "common": "\u062a\u0631\u06a9\u06cc\u0647"
             }
         },
         "latlng": [
@@ -31142,7 +32222,13 @@
             "SYR"
         ],
         "area": 783562,
-        "flag": "\ud83c\uddf9\ud83c\uddf7"
+        "flag": "\ud83c\uddf9\ud83c\uddf7",
+        "demonyms": {
+            "fra": {
+                "f": "Turque",
+                "m": "Turc"
+            }
+        }
     },
     {
         "name": {
@@ -31266,8 +32352,8 @@
                 "common": "\ud22c\ubc1c\ub8e8"
             },
             "per": {
-              "official": "\u062a\u0648\u0648\u0627\u0644\u0648",
-              "common": "\u062a\u0648\u0648\u0627\u0644\u0648"
+                "official": "\u062a\u0648\u0648\u0627\u0644\u0648",
+                "common": "\u062a\u0648\u0648\u0627\u0644\u0648"
             }
         },
         "latlng": [
@@ -31278,7 +32364,13 @@
         "landlocked": false,
         "borders": [],
         "area": 26,
-        "flag": "\ud83c\uddf9\ud83c\uddfb"
+        "flag": "\ud83c\uddf9\ud83c\uddfb",
+        "demonyms": {
+            "fra": {
+                "f": "Tuvaluane",
+                "m": "Tuvaluan"
+            }
+        }
     },
     {
         "name": {
@@ -31396,8 +32488,8 @@
                 "common": "\ub300\ub9cc"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u06cc\u0646",
-              "common": "\u062a\u0627\u06cc\u0648\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0686\u06cc\u0646",
+                "common": "\u062a\u0627\u06cc\u0648\u0627\u0646"
             }
         },
         "latlng": [
@@ -31408,7 +32500,13 @@
         "landlocked": false,
         "borders": [],
         "area": 36193,
-        "flag": "\ud83c\uddf9\ud83c\uddfc"
+        "flag": "\ud83c\uddf9\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Ta\u00efwanaise",
+                "m": "Ta\u00efwanais"
+            }
+        }
     },
     {
         "name": {
@@ -31531,8 +32629,8 @@
                 "common": "\ud0c4\uc790\ub2c8\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u062a\u062d\u062f \u062a\u0627\u0646\u0632\u0627\u0646\u06cc\u0627",
-              "common": "\u062a\u0627\u0646\u0632\u0627\u0646\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0645\u062a\u062d\u062f \u062a\u0627\u0646\u0632\u0627\u0646\u06cc\u0627",
+                "common": "\u062a\u0627\u0646\u0632\u0627\u0646\u06cc\u0627"
             }
         },
         "latlng": [
@@ -31552,7 +32650,13 @@
             "ZMB"
         ],
         "area": 945087,
-        "flag": "\ud83c\uddf9\ud83c\uddff"
+        "flag": "\ud83c\uddf9\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Tanzanienne",
+                "m": "Tanzanien"
+            }
+        }
     },
     {
         "name": {
@@ -31674,8 +32778,8 @@
                 "common": "\uc6b0\uac04\ub2e4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0648\u06af\u0627\u0646\u062f\u0627",
-              "common": "\u0627\u0648\u06af\u0627\u0646\u062f\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0648\u06af\u0627\u0646\u062f\u0627",
+                "common": "\u0627\u0648\u06af\u0627\u0646\u062f\u0627"
             }
         },
         "latlng": [
@@ -31692,7 +32796,13 @@
             "TZA"
         ],
         "area": 241550,
-        "flag": "\ud83c\uddfa\ud83c\uddec"
+        "flag": "\ud83c\uddfa\ud83c\uddec",
+        "demonyms": {
+            "fra": {
+                "f": "Ougandaise",
+                "m": "Ougandais"
+            }
+        }
     },
     {
         "name": {
@@ -31809,8 +32919,8 @@
                 "common": "\uc6b0\ud06c\ub77c\uc774\ub098"
             },
             "per": {
-              "official": "\u0627\u0648\u06a9\u0631\u0627\u06cc\u0646",
-              "common": "\u0627\u0648\u06a9\u0631\u0627\u06cc\u0646"
+                "official": "\u0627\u0648\u06a9\u0631\u0627\u06cc\u0646",
+                "common": "\u0627\u0648\u06a9\u0631\u0627\u06cc\u0646"
             }
         },
         "latlng": [
@@ -31829,7 +32939,13 @@
             "SVK"
         ],
         "area": 603500,
-        "flag": "\ud83c\uddfa\ud83c\udde6"
+        "flag": "\ud83c\uddfa\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Ukrainienne",
+                "m": "Ukrainien"
+            }
+        }
     },
     {
         "name": {
@@ -31944,8 +33060,8 @@
                 "common": "\ubbf8\uad6d\ub839 \uad70\uc18c \uc81c\ub3c4"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u0686\u06a9 \u062d\u0627\u0634\u06cc\u0647\u200c\u0627\u06cc \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u0686\u06a9 \u062d\u0627\u0634\u06cc\u0647\u200c\u0627\u06cc \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u0686\u06a9 \u062d\u0627\u0634\u06cc\u0647\u200c\u0627\u06cc \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u06a9\u0648\u0686\u06a9 \u062d\u0627\u0634\u06cc\u0647\u200c\u0627\u06cc \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627"
             }
         },
         "latlng": [
@@ -32073,8 +33189,8 @@
                 "common": "\uc6b0\ub8e8\uacfc\uc774"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0631\u0648\u06af\u0648\u0626\u0647",
-              "common": "\u0627\u0631\u0648\u06af\u0648\u0626\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0631\u0648\u06af\u0648\u0626\u0647",
+                "common": "\u0627\u0631\u0648\u06af\u0648\u0626\u0647"
             }
         },
         "latlng": [
@@ -32088,7 +33204,13 @@
             "BRA"
         ],
         "area": 181034,
-        "flag": "\ud83c\uddfa\ud83c\uddfe"
+        "flag": "\ud83c\uddfa\ud83c\uddfe",
+        "demonyms": {
+            "fra": {
+                "f": "Uruguayenne",
+                "m": "Uruguayen"
+            }
+        }
     },
     {
         "name": {
@@ -32521,8 +33643,8 @@
                 "common": "\ubbf8\uad6d"
             },
             "per": {
-              "official": "\u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627",
-              "common": "\u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627"
+                "official": "\u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627",
+                "common": "\u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627"
             }
         },
         "latlng": [
@@ -32536,7 +33658,13 @@
             "MEX"
         ],
         "area": 9372610,
-        "flag": "\ud83c\uddfa\ud83c\uddf8"
+        "flag": "\ud83c\uddfa\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Am\u00e9ricaine",
+                "m": "Am\u00e9ricain"
+            }
+        }
     },
     {
         "name": {
@@ -32659,8 +33787,8 @@
                 "common": "\uc6b0\uc988\ubca0\ud0a4\uc2a4\ud0c4"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0632\u0628\u06a9\u0633\u062a\u0627\u0646",
-              "common": "\u0627\u0632\u0628\u06a9\u0633\u062a\u0627\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0627\u0632\u0628\u06a9\u0633\u062a\u0627\u0646",
+                "common": "\u0627\u0632\u0628\u06a9\u0633\u062a\u0627\u0646"
             }
         },
         "latlng": [
@@ -32677,7 +33805,13 @@
             "TKM"
         ],
         "area": 447400,
-        "flag": "\ud83c\uddfa\ud83c\uddff"
+        "flag": "\ud83c\uddfa\ud83c\uddff",
+        "demonyms": {
+            "fra": {
+                "f": "Ouzb\u00e8ke",
+                "m": "Ouzb\u00e8ke"
+            }
+        }
     },
     {
         "name": {
@@ -32801,8 +33935,8 @@
                 "common": "\ubc14\ud2f0\uce78"
             },
             "per": {
-              "official": "\u062f\u0648\u0644\u062a\u200c\u0634\u0647\u0631 \u0648\u0627\u062a\u06cc\u06a9\u0627\u0646",
-              "common": "\u0648\u0627\u062a\u06cc\u06a9\u0627\u0646"
+                "official": "\u062f\u0648\u0644\u062a\u200c\u0634\u0647\u0631 \u0648\u0627\u062a\u06cc\u06a9\u0627\u0646",
+                "common": "\u0648\u0627\u062a\u06cc\u06a9\u0627\u0646"
             }
         },
         "latlng": [
@@ -32815,7 +33949,13 @@
             "ITA"
         ],
         "area": 0.44,
-        "flag": "\ud83c\uddfb\ud83c\udde6"
+        "flag": "\ud83c\uddfb\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Vaticane",
+                "m": "Vatican"
+            }
+        }
     },
     {
         "name": {
@@ -32930,8 +34070,8 @@
                 "common": "\uc138\uc778\ud2b8\ube48\uc13c\ud2b8 \uadf8\ub808\ub098\ub518"
             },
             "per": {
-              "official": "\u0633\u0646\u062a \u0648\u06cc\u0646\u0633\u0646\u062a \u0648 \u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627",
-              "common": "\u0633\u0646\u062a \u0648\u06cc\u0646\u0633\u0646\u062a \u0648 \u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627"
+                "official": "\u0633\u0646\u062a \u0648\u06cc\u0646\u0633\u0646\u062a \u0648 \u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627",
+                "common": "\u0633\u0646\u062a \u0648\u06cc\u0646\u0633\u0646\u062a \u0648 \u06af\u0631\u0646\u0627\u062f\u06cc\u0646\u200c\u0647\u0627"
             }
         },
         "latlng": [
@@ -32942,7 +34082,13 @@
         "landlocked": false,
         "borders": [],
         "area": 389,
-        "flag": "\ud83c\uddfb\ud83c\udde8"
+        "flag": "\ud83c\uddfb\ud83c\udde8",
+        "demonyms": {
+            "fra": {
+                "f": "Saint-Vincentaise-et-Grenadine",
+                "m": "Saint-Vincentaise-et-Grenadin"
+            }
+        }
     },
     {
         "name": {
@@ -33060,8 +34206,8 @@
                 "common": "\ubca0\ub124\uc218\uc5d8\ub77c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u0644\u06cc\u0648\u0627\u0631\u06cc \u0648\u0646\u0632\u0648\u0626\u0644\u0627",
-              "common": "\u0648\u0646\u0632\u0648\u0626\u0644\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0628\u0648\u0644\u06cc\u0648\u0627\u0631\u06cc \u0648\u0646\u0632\u0648\u0626\u0644\u0627",
+                "common": "\u0648\u0646\u0632\u0648\u0626\u0644\u0627"
             }
         },
         "latlng": [
@@ -33076,7 +34222,13 @@
             "GUY"
         ],
         "area": 916445,
-        "flag": "\ud83c\uddfb\ud83c\uddea"
+        "flag": "\ud83c\uddfb\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "V\u00e9n\u00e9zu\u00e9lienne",
+                "m": "V\u00e9n\u00e9zu\u00e9lien"
+            }
+        }
     },
     {
         "name": {
@@ -33192,8 +34344,8 @@
                 "common": "\uc601\uad6d\ub839 \ubc84\uc9c4\uc544\uc77c\ub79c\ub4dc"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0628\u0631\u06cc\u062a\u0627\u0646\u06cc\u0627"
             }
         },
         "latlng": [
@@ -33320,8 +34472,8 @@
                 "common": "\ubbf8\uad6d\ub839 \ubc84\uc9c4\uc544\uc77c\ub79c\ub4dc"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627",
-              "common": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627",
+                "common": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u06cc\u0631\u062c\u06cc\u0646 \u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627"
             }
         },
         "latlng": [
@@ -33450,8 +34602,8 @@
                 "common": "\ubca0\ud2b8\ub0a8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u0633\u06cc\u0627\u0644\u06cc\u0633\u062a\u06cc \u0648\u06cc\u062a\u0646\u0627\u0645",
-              "common": "\u0648\u06cc\u062a\u0646\u0627\u0645"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0633\u0648\u0633\u06cc\u0627\u0644\u06cc\u0633\u062a\u06cc \u0648\u06cc\u062a\u0646\u0627\u0645",
+                "common": "\u0648\u06cc\u062a\u0646\u0627\u0645"
             }
         },
         "latlng": [
@@ -33466,7 +34618,13 @@
             "LAO"
         ],
         "area": 331212,
-        "flag": "\ud83c\uddfb\ud83c\uddf3"
+        "flag": "\ud83c\uddfb\ud83c\uddf3",
+        "demonyms": {
+            "fra": {
+                "f": "Vietnamienne",
+                "m": "Vietnamien"
+            }
+        }
     },
     {
         "name": {
@@ -33594,8 +34752,8 @@
                 "common": "\ubc14\ub204\uc544\ud22c"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0648\u0627\u0646\u0648\u0627\u062a\u0648",
-              "common": "\u0648\u0627\u0646\u0648\u0627\u062a\u0648"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0648\u0627\u0646\u0648\u0627\u062a\u0648",
+                "common": "\u0648\u0627\u0646\u0648\u0627\u062a\u0648"
             }
         },
         "latlng": [
@@ -33606,7 +34764,13 @@
         "landlocked": false,
         "borders": [],
         "area": 12189,
-        "flag": "\ud83c\uddfb\ud83c\uddfa"
+        "flag": "\ud83c\uddfb\ud83c\uddfa",
+        "demonyms": {
+            "fra": {
+                "f": "Vanuatuane",
+                "m": "Vanuatuan"
+            }
+        }
     },
     {
         "name": {
@@ -33723,8 +34887,8 @@
                 "common": "\uc648\ub9ac\uc2a4 \ud4cc\ud280\ub098"
             },
             "per": {
-              "official": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u0627\u0644\u06cc\u0633 \u0648 \u0641\u0648\u062a\u0648\u0646\u0627",
-              "common": "\u0648\u0627\u0644\u06cc\u0633 \u0648 \u0641\u0648\u062a\u0648\u0646\u0627"
+                "official": "\u062c\u0632\u0627\u06cc\u0631 \u0648\u0627\u0644\u06cc\u0633 \u0648 \u0641\u0648\u062a\u0648\u0646\u0627",
+                "common": "\u0648\u0627\u0644\u06cc\u0633 \u0648 \u0641\u0648\u062a\u0648\u0646\u0627"
             }
         },
         "latlng": [
@@ -33857,8 +35021,8 @@
                 "common": "\uc0ac\ubaa8\uc544"
             },
             "per": {
-              "official": "\u0627\u06cc\u0627\u0644\u062a \u0645\u0633\u062a\u0642\u0644 \u0633\u0627\u0645\u0648\u0622",
-              "common": "\u0633\u0627\u0645\u0648\u0622"
+                "official": "\u0627\u06cc\u0627\u0644\u062a \u0645\u0633\u062a\u0642\u0644 \u0633\u0627\u0645\u0648\u0622",
+                "common": "\u0633\u0627\u0645\u0648\u0622"
             }
         },
         "latlng": [
@@ -33869,7 +35033,13 @@
         "landlocked": false,
         "borders": [],
         "area": 2842,
-        "flag": "\ud83c\uddfc\ud83c\uddf8"
+        "flag": "\ud83c\uddfc\ud83c\uddf8",
+        "demonyms": {
+            "fra": {
+                "f": "Samoane",
+                "m": "Samoan"
+            }
+        }
     },
     {
         "name": {
@@ -33986,8 +35156,8 @@
                 "common": "\uc608\uba58"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06cc\u0645\u0646",
-              "common": "\u06cc\u0645\u0646"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u06cc\u0645\u0646",
+                "common": "\u06cc\u0645\u0646"
             }
         },
         "latlng": [
@@ -34001,7 +35171,13 @@
             "SAU"
         ],
         "area": 527968,
-        "flag": "\ud83c\uddfe\ud83c\uddea"
+        "flag": "\ud83c\uddfe\ud83c\uddea",
+        "demonyms": {
+            "fra": {
+                "f": "Y\u00e9m\u00e9nite",
+                "m": "Y\u00e9m\u00e9nite"
+            }
+        }
     },
     {
         "name": {
@@ -34171,8 +35347,8 @@
                 "common": "\ub0a8\uc544\ud504\ub9ac\uce74"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc",
-              "common": "\u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc",
+                "common": "\u0622\u0641\u0631\u06cc\u0642\u0627\u06cc \u062c\u0646\u0648\u0628\u06cc"
             }
         },
         "latlng": [
@@ -34190,7 +35366,13 @@
             "ZWE"
         ],
         "area": 1221037,
-        "flag": "\ud83c\uddff\ud83c\udde6"
+        "flag": "\ud83c\uddff\ud83c\udde6",
+        "demonyms": {
+            "fra": {
+                "f": "Sud-africaine",
+                "m": "Sud-africain"
+            }
+        }
     },
     {
         "name": {
@@ -34306,8 +35488,8 @@
                 "common": "\uc7a0\ube44\uc544"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0632\u0627\u0645\u0628\u06cc\u0627",
-              "common": "\u0632\u0627\u0645\u0628\u06cc\u0627"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0632\u0627\u0645\u0628\u06cc\u0627",
+                "common": "\u0632\u0627\u0645\u0628\u06cc\u0627"
             }
         },
         "latlng": [
@@ -34327,7 +35509,13 @@
             "ZWE"
         ],
         "area": 752612,
-        "flag": "\ud83c\uddff\ud83c\uddf2"
+        "flag": "\ud83c\uddff\ud83c\uddf2",
+        "demonyms": {
+            "fra": {
+                "f": "Zambienne",
+                "m": "Zambien"
+            }
+        }
     },
     {
         "name": {
@@ -34545,8 +35733,8 @@
                 "common": "\uc9d0\ubc14\ube0c\uc6e8"
             },
             "per": {
-              "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0632\u06cc\u0645\u0628\u0627\u0628\u0648\u0647",
-              "common": "\u0632\u06cc\u0645\u0628\u0627\u0628\u0648\u0647"
+                "official": "\u062c\u0645\u0647\u0648\u0631\u06cc \u0632\u06cc\u0645\u0628\u0627\u0628\u0648\u0647",
+                "common": "\u0632\u06cc\u0645\u0628\u0627\u0628\u0648\u0647"
             }
         },
         "latlng": [
@@ -34562,6 +35750,12 @@
             "ZMB"
         ],
         "area": 390757,
-        "flag": "\ud83c\uddff\ud83c\uddfc"
+        "flag": "\ud83c\uddff\ud83c\uddfc",
+        "demonyms": {
+            "fra": {
+                "f": "Zimbabw\u00e9enne",
+                "m": "Zimbabw\u00e9en"
+            }
+        }
     }
 ]


### PR DESCRIPTION
Hi,

First of all, thank you for this project 💯 

As suggested in #165, I added translated demonyms (in French). 
It is indexed by `f` or `m` to manage gender inflection. 
I decided to **add** a new key rather than changing the structure, to keep things backward compatible. Tell me if it's ok for you. 

I used a PHP script to decode/encode the `countries.json` file, so some indentation may have changed (I used `json_encode` with `JSON_PRETTY_PRINT` option). You can add `?w=1` to the GitHub URL to get rid of whitespace changes. 