### PR TITLE
Fix README misleading statement of its data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Downloads](https://img.shields.io/npm/dm/world-countries.svg?style=flat)](https://www.npmjs.com/package/world-countries)
 
 ## Countries data
-This repository contains lists of world countries, as defined by [ISO Standard 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1),
+This repository contains lists of world countries, majorly based on [ISO Standard 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1),
 in JSON, CSV and XML. Each line contains the country:
 
  - `name`


### PR DESCRIPTION
As @nobodxbodon kindly pointed out, the data presented here isn't entirely matching ISO-3166.  Ensure the status is properly described in the README.

Fixes https://github.com/mledoze/countries/issues/4#issuecomment-526325280_ .

Refer-to: Please remove “Province of China” from Taiwan · Issue #4 · mledoze/countries <https://github.com/mledoze/countries/issues/4>
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>