### PR TITLE
Change 'United State Dollar' to 'United States Dollar'

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1392,7 +1392,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -3301,7 +3301,7 @@
                 "symbol": "$"
             },
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -4433,7 +4433,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -13117,7 +13117,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -20838,7 +20838,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -24926,7 +24926,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -30499,7 +30499,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -31853,7 +31853,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },
@@ -33228,7 +33228,7 @@
         "status": "officially-assigned",
         "currencies": {
             "USD": {
-                "name": "United State Dollar",
+                "name": "United States Dollar",
                 "symbol": "$"
             }
         },


### PR DESCRIPTION
Re: issue #351 

Change "United State Dollar" to "United States Dollar"