### PR TITLE
Added altSpelling to Macedonia

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -21066,6 +21066,7 @@
             "MK",
             "The former Yugoslav Republic of Macedonia",
             "Republic of North Macedonia",
+            "Macedonia, The Former Yugoslav Republic of",
             "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
         ],
         "region": "Europe",


### PR DESCRIPTION
Added "Macedonia, The Former Yugoslav Republic of"

I did not commit the generated dist folder as i noticed it modified more than then just Macedonia and I did not want to override others contributions 