### PR TITLE
Fix Spanish spelling for Haiti

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -14645,7 +14645,7 @@
             },
             "spa": {
                 "official": "Rep\u00fablica de Hait\u00ed",
-                "common": "Haiti"
+                "common": "Hait\u00ed"
             },
             "fin": {
                 "official": "Haitin tasavalta",


### PR DESCRIPTION
Should be `Haití` in Spanish translation