### PR TITLE
Add alt spellings found in ourworldindata.org Covid-19 data

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -4861,7 +4861,8 @@
         },
         "capital": [],
         "altSpellings": [
-            "BES islands"
+            "BES islands",
+            "Bonaire Sint Eustatius and Saba"
         ],
         "region": "Americas",
         "subregion": "Caribbean",
@@ -6839,6 +6840,7 @@
         "altSpellings": [
             "CI",
             "C\u00f4te d'Ivoire",
+            "Cote d'Ivoire",
             "Ivory Coast",
             "Republic of C\u00f4te d'Ivoire",
             "R\u00e9publique de C\u00f4te d'Ivoire"
@@ -7165,6 +7167,7 @@
             "DR Congo",
             "Congo-Kinshasa",
             "Congo, the Democratic Republic of the",
+            "Democratic Republic of Congo",
             "DRC"
         ],
         "region": "Africa",
@@ -11739,7 +11742,8 @@
         "altSpellings": [
             "FO",
             "F\u00f8royar",
-            "F\u00e6r\u00f8erne"
+            "F\u00e6r\u00f8erne",
+            "Faeroe Islands"
         ],
         "region": "Europe",
         "subregion": "Northern Europe",
@@ -21939,7 +21943,8 @@
             "The former Yugoslav Republic of Macedonia",
             "Republic of North Macedonia",
             "Macedonia, The Former Yugoslav Republic of",
-            "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+            "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
+            "Macedonia"
         ],
         "region": "Europe",
         "subregion": "Southern Europe",
@@ -33420,6 +33425,7 @@
         "altSpellings": [
             "TL",
             "East Timor",
+            "Timor",
             "Democratic Republic of Timor-Leste",
             "Rep\u00fablica Democr\u00e1tica de Timor-Leste",
             "Rep\u00fablika Demokr\u00e1tika Tim\u00f3r-Leste",
@@ -35810,6 +35816,7 @@
             "VA",
             "Holy See (Vatican City State)",
             "Vatican City State",
+            "Vatican",
             "Stato della Citt\u00e0 del Vaticano"
         ],
         "region": "Europe",


### PR DESCRIPTION
I'm using altSpellings in countries.json to map country names to country codes for parsing Covid-19 data from ourworldindata.org. The well-known website uses a few names that aren't yet found as altSpellings.