### PR TITLE
Add Swedish translations to countries.json (both common and official)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- add Swedish translation (#398)
 - add a changelog (#383)
 - add Hungarian translation (#385)
 ### Changed
@@ -68,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Before**
 
      "currency": ["SHP", "GBP"]
- 
+
 **After**
 
     "currencies": {
@@ -148,13 +149,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add scrutinizer badge
 
 ## [v2.0.0] - 2018-02-08
-This project now requires the latest version of PHP 5, which is 5.6.33. This will be the last release to support PHP 5. 
+This project now requires the latest version of PHP 5, which is 5.6.33. This will be the last release to support PHP 5.
 The next major release (v3.0.0) will require PHP 7.2.
 ### Breaking changes
 - change type of property capitals from string to array to support countries with multiple capitals
-- change semicolon to comma for CSV format 
+- change semicolon to comma for CSV format
 (see https://github.com/mledoze/countries/blob/e2de3c46402c2b7a90d30fa1d6d1151e97420992/dist/countries.csv)
-- move SHN and BES divisions back into the main `countries.json` as two separate entries; also removed files 
+- move SHN and BES divisions back into the main `countries.json` as two separate entries; also removed files
 `data/shn.divisions.json` and `data/bes.divisions.json`
 - remove region specific languages (see #181)
 - remove South Sudan from Chad's neighbours
@@ -230,7 +231,7 @@ The next major release (v3.0.0) will require PHP 7.2.
 
 ## [v1.7.3] - 2015-04-05
 ### Breaking changes
-- remove Bonaire and Saint Helena, Ascension and Tristan da Cunha from countries.json and moved them respectively in 
+- remove Bonaire and Saint Helena, Ascension and Tristan da Cunha from countries.json and moved them respectively in
 `data/bes.divisions.json` and `data/shn.divisions.json` (see #93)
 ### Added
 - add new property: International Olympic Committee country code (cioc)
@@ -366,7 +367,7 @@ As proposed by @herrniemand, the format for translations has been updated to inc
 ### Added
 - add alternative name and spellings for East Timor
 ### Build
-A new build system has been introduced by @petert82. The single script is split up into individual files in src/ and 
+A new build system has been introduced by @petert82. The single script is split up into individual files in src/ and
 the symfony Console component as a dependency, to make it nice and easy to extend the conversion options in future.
 
 To build the dist files, the command is now `php countries.php convert`.
@@ -397,7 +398,7 @@ To build the dist files, the command is now `php countries.php convert`.
 - add portuguese country name translations
 - add missing area data
 - add russian language to Azerbaijan
-### Build 
+### Build
 - add a yaml converter
 - add processEmptyArrays method for JSON converters
 - refactor loop for fields to keep
@@ -413,7 +414,7 @@ To build the dist files, the command is now `php countries.php convert`.
 ## [v1.6] - 2014-09-12
 ### Breaking changes
 New format for country names.
-The name property is now an object containing the common and official names of the country both in english and in the 
+The name property is now an object containing the common and official names of the country both in english and in the
 official native language of the country (the language used for this is identified by the new nativeLanguage property;
  see below).
 
@@ -438,15 +439,15 @@ official native language of the country (the language used for this is identifie
         },
         "..."
     }
- 
+
 - New format for country languages:
-    - The language property is now an object where keys are ISO 639-3 codes (alpha 3) and values are the name of the 
+    - The language property is now an object where keys are ISO 639-3 codes (alpha 3) and values are the name of the
     language in english.
     - The nativeLanguage property contains the ISO 639-3 code of the language used for the native country names.
 
 **Before**
 
-    {   
+    {
         "...",
         "language": ["Finnish", "Swedish"],
         "languageCodes": ["fi", "sv"]
@@ -491,7 +492,7 @@ _Credits to @herrniemand and @petert82 for the original idea and help on this._
 ### Breaking changes
 - remove Ascension Island (merged with Saint Helena, see #57)
 ### Added
-- add countries GeoJSON outline 
+- add countries GeoJSON outline
 (example https://github.com/mledoze/countries/blob/4251a5f95d5255a913a397d831dd75080e370f33/data/deu.geo.json)
 - add russian translations for all countries (thanks @eugene-lazarev)
 - add unescaped JSON version
@@ -556,7 +557,7 @@ _Credits to @herrniemand and @petert82 for the original idea and help on this._
 - add country official language(s) in english
 - add alt spellings: official country name in english and in its official language(s)
 - add region and subregion for Bonaire, Sint Maarten and South Sudan
-- add capital for British Indian Ocean Territory, Micronesia, Réunion, South Georgia, Virgin Islands (British) and 
+- add capital for British Indian Ocean Territory, Micronesia, Réunion, South Georgia, Virgin Islands (British) and
 Virgin Islands (U.S.)
 - add currency for Palestinian Territory
 - add examples in README
@@ -581,7 +582,7 @@ Virgin Islands (U.S.)
 - fix South Georgia currency
 - fix relevance for Åland Islands and Finland
 - fix ccn3 padding
-- fix subregion for Brunei Darussalam, Cambodia, Indonesia, Laos, Malaysia, Myanmar, Philippines, Singapore, Thailand, 
+- fix subregion for Brunei Darussalam, Cambodia, Indonesia, Laos, Malaysia, Myanmar, Philippines, Singapore, Thailand,
 Timor-Leste and Vietnam
 - fix TLD for Bonaire, Heard and McDonald Islands, Kazakhstan and Saint Martin
 - fix capital for Moldova
@@ -590,7 +591,7 @@ Timor-Leste and Vietnam
 ## [v1.1] - 2013-10-05
 ### Added
 - add capital cities
-### Fixed 
+### Fixed
 - fix accented characters encoding in JSON file
 
 ## [v1.0] - 2013-07-26

--- a/countries.json
+++ b/countries.json
@@ -8706,8 +8706,8 @@
                 "common": "\u5e93\u62c9\u7d22"
             },
             "swe": {
-                "official": "Curaçao",
-                "common": "Curaçao"
+                "official": "Cura\u00e7ao",
+                "common": "Cura\u00e7ao"
             }
         },
         "latlng": [
@@ -23672,8 +23672,8 @@
                 "common": "\u83ab\u6851\u6bd4\u514b"
             },
             "swe": {
-                "official": "Republiken Moçambique",
-                "common": "Moçambique"
+                "official": "Republiken Mo\u00e7ambique",
+                "common": "Mo\u00e7ambique"
             }
         },
         "latlng": [

--- a/countries.json
+++ b/countries.json
@@ -123,6 +123,10 @@
             "zho": {
                 "official": "\u963f\u9c81\u5df4",
                 "common": "\u963f\u9c81\u5df4"
+            },
+            "swe": {
+                "official": "Aruba",
+                "common": "Aruba"
             }
         },
         "latlng": [
@@ -278,6 +282,10 @@
             "zho": {
                 "official": "\u963f\u5bcc\u6c57\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u963f\u5bcc\u6c57"
+            },
+            "swe": {
+                "official": "Islamiska republiken Afghanistan",
+                "common": "Afghanistan"
             }
         },
         "latlng": [
@@ -431,6 +439,10 @@
             "zho": {
                 "official": "\u5b89\u54e5\u62c9\u5171\u548c\u56fd",
                 "common": "\u5b89\u54e5\u62c9"
+            },
+            "swe": {
+                "official": "Republiken Angola",
+                "common": "Angola"
             }
         },
         "latlng": [
@@ -576,6 +588,10 @@
             "zho": {
                 "official": "\u5b89\u572d\u62c9",
                 "common": "\u5b89\u572d\u62c9"
+            },
+            "swe": {
+                "official": "Anguilla",
+                "common": "Anguilla"
             }
         },
         "latlng": [
@@ -719,6 +735,10 @@
             "zho": {
                 "official": "\u5965\u5170\u7fa4\u5c9b",
                 "common": "\u5965\u5170\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "\u00c5land",
+                "common": "\u00c5land"
             }
         },
         "latlng": [
@@ -866,6 +886,10 @@
             "zho": {
                 "official": "\u963f\u5c14\u5df4\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u963f\u5c14\u5df4\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Albanien",
+                "common": "Albanien"
             }
         },
         "latlng": [
@@ -1017,6 +1041,10 @@
             "zho": {
                 "official": "\u5b89\u9053\u5c14\u516c\u56fd",
                 "common": "\u5b89\u9053\u5c14"
+            },
+            "swe": {
+                "official": "Furstend\u00f6met Andorra",
+                "common": "Andorra"
             }
         },
         "latlng": [
@@ -1163,6 +1191,10 @@
             "zho": {
                 "official": "\u963f\u62c9\u4f2f\u8054\u5408\u914b\u957f\u56fd",
                 "common": "\u963f\u62c9\u4f2f\u8054\u5408\u914b\u957f\u56fd"
+            },
+            "swe": {
+                "official": "F\u00f6renade Arabemiraten",
+                "common": "F\u00f6renade Arabemiraten"
             }
         },
         "latlng": [
@@ -1317,6 +1349,10 @@
             "zho": {
                 "official": "\u963f\u6839\u5ef7\u5171\u548c\u56fd",
                 "common": "\u963f\u6839\u5ef7"
+            },
+            "swe": {
+                "official": "Republiken Argentina",
+                "common": "Argentina"
             }
         },
         "latlng": [
@@ -1470,6 +1506,10 @@
             "zho": {
                 "official": "\u4e9a\u7f8e\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u4e9a\u7f8e\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Armenien",
+                "common": "Armenien"
             }
         },
         "latlng": [
@@ -1623,6 +1663,10 @@
             "zho": {
                 "official": "\u7f8e\u5c5e\u8428\u6469\u4e9a",
                 "common": "\u7f8e\u5c5e\u8428\u6469\u4e9a"
+            },
+            "swe": {
+                "official": "Amerikanska Samoa",
+                "common": "Amerikanska Samoa"
             }
         },
         "latlng": [
@@ -1753,6 +1797,10 @@
             "zho": {
                 "official": "\u5357\u6781\u6d32",
                 "common": "\u5357\u6781\u6d32"
+            },
+            "swe": {
+                "official": "Antarktis",
+                "common": "Antarktis"
             }
         },
         "latlng": [
@@ -1894,6 +1942,10 @@
             "zho": {
                 "official": "\u6cd5\u56fd\u5357\u90e8\u548c\u5357\u6781\u571f\u5730",
                 "common": "\u6cd5\u56fd\u5357\u90e8\u548c\u5357\u6781\u571f\u5730"
+            },
+            "swe": {
+                "official": "Franska syd- och Antarktisterritorierna",
+                "common": "Franska s\u00f6dra territorierna"
             }
         },
         "latlng": [
@@ -2038,6 +2090,10 @@
             "zho": {
                 "official": "\u5b89\u63d0\u74dc\u548c\u5df4\u5e03\u8fbe",
                 "common": "\u5b89\u63d0\u74dc\u548c\u5df4\u5e03\u8fbe"
+            },
+            "swe": {
+                "official": "Antigua och Barbuda",
+                "common": "Antigua och Barbuda"
             }
         },
         "latlng": [
@@ -2182,6 +2238,10 @@
             "zho": {
                 "official": "\u6fb3\u5927\u5229\u4e9a\u8054\u90a6",
                 "common": "\u6fb3\u5927\u5229\u4e9a"
+            },
+            "swe": {
+                "official": "Australiska statsf\u00f6rbundet",
+                "common": "Australien"
             }
         },
         "latlng": [
@@ -2328,6 +2388,10 @@
             "zho": {
                 "official": "\u5965\u5730\u5229\u5171\u548c\u56fd",
                 "common": "\u5965\u5730\u5229"
+            },
+            "swe": {
+                "official": "Republiken \u00d6sterrike",
+                "common": "\u00d6sterrike"
             }
         },
         "latlng": [
@@ -2488,6 +2552,10 @@
             "zho": {
                 "official": "\u963f\u585e\u62dc\u7586\u5171\u548c\u56fd",
                 "common": "\u963f\u585e\u62dc\u7586"
+            },
+            "swe": {
+                "official": "Republiken Azerbajdzjan",
+                "common": "Azerbajdzjan"
             }
         },
         "latlng": [
@@ -2646,6 +2714,10 @@
             "zho": {
                 "official": "\u5e03\u9686\u8fea\u5171\u548c\u56fd",
                 "common": "\u5e03\u9686\u8fea"
+            },
+            "swe": {
+                "official": "Republiken Burundi",
+                "common": "Burundi"
             }
         },
         "latlng": [
@@ -2812,6 +2884,10 @@
             "zho": {
                 "official": "\u6bd4\u5229\u65f6\u738b\u56fd",
                 "common": "\u6bd4\u5229\u65f6"
+            },
+            "swe": {
+                "official": "Konungariket Belgien",
+                "common": "Belgien"
             }
         },
         "latlng": [
@@ -2963,6 +3039,10 @@
             "zho": {
                 "official": "\u8d1d\u5b81\u5171\u548c\u56fd",
                 "common": "\u8d1d\u5b81"
+            },
+            "swe": {
+                "official": "Republiken Benin",
+                "common": "Benin"
             }
         },
         "latlng": [
@@ -3112,6 +3192,10 @@
             "zho": {
                 "official": "\u5e03\u57fa\u7eb3\u6cd5\u7d22",
                 "common": "\u5e03\u57fa\u7eb3\u6cd5\u7d22"
+            },
+            "swe": {
+                "official": "Burkina Faso",
+                "common": "Burkina Faso"
             }
         },
         "latlng": [
@@ -3265,6 +3349,10 @@
             "zho": {
                 "official": "\u5b5f\u52a0\u62c9\u4eba\u6c11\u5171\u548c\u56fd",
                 "common": "\u5b5f\u52a0\u62c9\u56fd"
+            },
+            "swe": {
+                "official": "Folkrepubliken Bangladesh",
+                "common": "Bangladesh"
             }
         },
         "latlng": [
@@ -3414,6 +3502,10 @@
             "zho": {
                 "official": "\u4fdd\u52a0\u5229\u4e9a\u5171\u548c\u56fd",
                 "common": "\u4fdd\u52a0\u5229\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Bulgarien",
+                "common": "Bulgarien"
             }
         },
         "latlng": [
@@ -3566,6 +3658,10 @@
             "zho": {
                 "official": "\u5df4\u6797\u738b\u56fd",
                 "common": "\u5df4\u6797"
+            },
+            "swe": {
+                "official": "Konungariket Bahrain",
+                "common": "Bahrain"
             }
         },
         "latlng": [
@@ -3715,6 +3811,10 @@
             "zho": {
                 "official": "\u5df4\u54c8\u9a6c\u8054\u90a6",
                 "common": "\u5df4\u54c8\u9a6c"
+            },
+            "swe": {
+                "official": "Samv\u00e4ldet Bahamas",
+                "common": "Bahamas"
             }
         },
         "latlng": [
@@ -3871,6 +3971,10 @@
             "zho": {
                 "official": "\u6ce2\u65af\u5c3c\u4e9a\u548c\u9ed1\u585e\u54e5\u7ef4\u90a3",
                 "common": "\u6ce2\u65af\u5c3c\u4e9a\u548c\u9ed1\u585e\u54e5\u7ef4\u90a3"
+            },
+            "swe": {
+                "official": "Bosnien och Hercegovina",
+                "common": "Bosnien och Hercegovina"
             }
         },
         "latlng": [
@@ -4018,6 +4122,10 @@
             "zho": {
                 "official": "\u5723\u5df4\u6cf0\u52d2\u7c73\u96c6\u4f53",
                 "common": "\u5723\u5df4\u6cf0\u52d2\u7c73"
+            },
+            "swe": {
+                "official": "Saint-Barth\u00e9lemy",
+                "common": "Saint-Barth\u00e9lemy"
             }
         },
         "latlng": [
@@ -4165,6 +4273,10 @@
             "zho": {
                 "official": "\u5723\u8d6b\u52d2\u62ff\u3001\u963f\u68ee\u677e\u548c\u7279\u91cc\u65af\u5766-\u8fbe\u5e93\u5c3c\u4e9a",
                 "common": "\u5723\u8d6b\u52d2\u62ff\u3001\u963f\u68ee\u677e\u548c\u7279\u91cc\u65af\u5766-\u8fbe\u5e93\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Sankta Helena",
+                "common": "Sankta Helena"
             }
         },
         "latlng": [
@@ -4318,6 +4430,10 @@
             "zho": {
                 "official": "\u767d\u4fc4\u7f57\u65af\u5171\u548c\u56fd",
                 "common": "\u767d\u4fc4\u7f57\u65af"
+            },
+            "swe": {
+                "official": "Republiken Vitryssland",
+                "common": "Belarus"
             }
         },
         "latlng": [
@@ -4478,6 +4594,10 @@
             "zho": {
                 "official": "\u4f2f\u5229\u5179",
                 "common": "\u4f2f\u5229\u5179"
+            },
+            "swe": {
+                "official": "Belize",
+                "common": "Belize"
             }
         },
         "latlng": [
@@ -4628,6 +4748,10 @@
             "zho": {
                 "official": "\u767e\u6155\u5927",
                 "common": "\u767e\u6155\u5927"
+            },
+            "swe": {
+                "official": "Bermuda",
+                "common": "Bermuda"
             }
         },
         "latlng": [
@@ -4795,6 +4919,10 @@
             "zho": {
                 "official": "\u591a\u6c11\u65cf\u73bb\u5229\u7ef4\u4e9a\u56fd",
                 "common": "\u73bb\u5229\u7ef4\u4e9a"
+            },
+            "swe": {
+                "official": "M\u00e5ngnationella staten Bolivia",
+                "common": "Bolivia"
             }
         },
         "latlng": [
@@ -4946,6 +5074,10 @@
             "zho": {
                 "official": "\u8377\u862d\u52a0\u52d2\u6bd4\u5340",
                 "common": "\u8377\u862d\u52a0\u52d2\u6bd4\u5340"
+            },
+            "swe": {
+                "official": "Bonaire, Sint Eustatius and Saba",
+                "common": "Karibiska Nederl\u00e4nderna"
             }
         },
         "latlng": [
@@ -5093,6 +5225,10 @@
             "zho": {
                 "official": "\u5df4\u897f\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u5df4\u897f"
+            },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Brasilien",
+                "common": "Brasilien"
             }
         },
         "latlng": [
@@ -5248,6 +5384,10 @@
             "zho": {
                 "official": "\u5df4\u5df4\u591a\u65af",
                 "common": "\u5df4\u5df4\u591a\u65af"
+            },
+            "swe": {
+                "official": "Barbados",
+                "common": "Barbados"
             }
         },
         "latlng": [
@@ -5399,6 +5539,10 @@
             "zho": {
                 "official": "\u6587\u83b1\u548c\u5e73\u4e4b\u56fd",
                 "common": "\u6587\u83b1"
+            },
+            "swe": {
+                "official": "Brunei Darussalam",
+                "common": "Brunei"
             }
         },
         "latlng": [
@@ -5550,6 +5694,10 @@
             "zho": {
                 "official": "\u4e0d\u4e39\u738b\u56fd",
                 "common": "\u4e0d\u4e39"
+            },
+            "swe": {
+                "official": "Konungariket Bhutan",
+                "common": "Bhutan"
             }
         },
         "latlng": [
@@ -5690,6 +5838,10 @@
             "zho": {
                 "official": "\u5e03\u7ef4\u5c9b",
                 "common": "\u5e03\u7ef4\u5c9b"
+            },
+            "swe": {
+                "official": "Bouvet\u00f6n",
+                "common": "Bouvet\u00f6n"
             }
         },
         "latlng": [
@@ -5837,6 +5989,10 @@
             "zho": {
                 "official": "\u535a\u8328\u74e6\u7eb3\u5171\u548c\u56fd",
                 "common": "\u535a\u8328\u74e6\u7eb3"
+            },
+            "swe": {
+                "official": "Republiken Botswana",
+                "common": "Botswana"
             }
         },
         "latlng": [
@@ -5993,6 +6149,10 @@
             "zho": {
                 "official": "\u4e2d\u975e\u5171\u548c\u56fd",
                 "common": "\u4e2d\u975e\u5171\u548c\u56fd"
+            },
+            "swe": {
+                "official": "Centralafrikanska republiken",
+                "common": "Centralafrikanska republiken"
             }
         },
         "latlng": [
@@ -6149,6 +6309,10 @@
             "zho": {
                 "official": "\u52a0\u62ff\u5927",
                 "common": "\u52a0\u62ff\u5927"
+            },
+            "swe": {
+                "official": "Kanada",
+                "common": "Kanada"
             }
         },
         "latlng": [
@@ -6297,6 +6461,10 @@
             "zho": {
                 "official": "\u79d1\u79d1\u65af",
                 "common": "\u79d1\u79d1\u65af"
+            },
+            "swe": {
+                "official": "Kokos\u00f6arna",
+                "common": "Kokos\u00f6arna"
             }
         },
         "latlng": [
@@ -6457,6 +6625,10 @@
             "zho": {
                 "official": "\u745e\u58eb\u8054\u90a6",
                 "common": "\u745e\u58eb"
+            },
+            "swe": {
+                "official": "Schweiziska edsf\u00f6rbundet",
+                "common": "Schweiz"
             }
         },
         "latlng": [
@@ -6609,6 +6781,10 @@
             "zho": {
                 "official": "\u667a\u5229\u5171\u548c\u56fd",
                 "common": "\u667a\u5229"
+            },
+            "swe": {
+                "official": "Republiken Chile",
+                "common": "Chile"
             }
         },
         "latlng": [
@@ -6763,6 +6939,10 @@
             "urd": {
                 "official": "\u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646",
                 "common": "\u0686\u06cc\u0646"
+            },
+            "swe": {
+                "official": "Folkrepubliken Kina",
+                "common": "Kina"
             }
         },
         "latlng": [
@@ -6924,6 +7104,10 @@
             "zho": {
                 "official": "\u79d1\u7279\u8fea\u74e6\u5171\u548c\u56fd",
                 "common": "\u79d1\u7279\u8fea\u74e6"
+            },
+            "swe": {
+                "official": "Republiken Elfenbenskusten",
+                "common": "Elfenbenskusten"
             }
         },
         "latlng": [
@@ -7081,6 +7265,10 @@
             "zho": {
                 "official": "\u5580\u9ea6\u9686\u5171\u548c\u56fd",
                 "common": "\u5580\u9ea6\u9686"
+            },
+            "swe": {
+                "official": "Republiken Kamerun",
+                "common": "Kamerun"
             }
         },
         "latlng": [
@@ -7256,6 +7444,10 @@
             "zho": {
                 "official": "\u521a\u679c\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u6c11\u4e3b\u521a\u679c"
+            },
+            "swe": {
+                "official": "Demokratiska republiken Kongo",
+                "common": "Kongo-Kinshasa"
             }
         },
         "latlng": [
@@ -7422,6 +7614,10 @@
             "zho": {
                 "official": "\u521a\u679c\u5171\u548c\u56fd",
                 "common": "\u521a\u679c"
+            },
+            "swe": {
+                "official": "Republiken Kongo",
+                "common": "Kongo-Brazzaville"
             }
         },
         "latlng": [
@@ -7582,6 +7778,10 @@
             "zho": {
                 "official": "\u5e93\u514b\u7fa4\u5c9b",
                 "common": "\u5e93\u514b\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Cook\u00f6arna",
+                "common": "Cook\u00f6arna"
             }
         },
         "latlng": [
@@ -7728,6 +7928,10 @@
             "zho": {
                 "official": "\u54e5\u4f26\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u54e5\u4f26\u6bd4\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Colombia",
+                "common": "Colombia"
             }
         },
         "latlng": [
@@ -7892,6 +8096,10 @@
             "zho": {
                 "official": "\u79d1\u6469\u7f57\u8054\u76df",
                 "common": "\u79d1\u6469\u7f57"
+            },
+            "swe": {
+                "official": "Unionen Komorerna",
+                "common": "Komorerna"
             }
         },
         "latlng": [
@@ -8038,6 +8246,10 @@
             "zho": {
                 "official": "\u4f5b\u5f97\u89d2\u5171\u548c\u56fd",
                 "common": "\u4f5b\u5f97\u89d2"
+            },
+            "swe": {
+                "official": "Republiken Kap Verde",
+                "common": "Kap Verde"
             }
         },
         "latlng": [
@@ -8184,6 +8396,10 @@
             "zho": {
                 "official": "\u54e5\u65af\u8fbe\u9ece\u52a0\u5171\u548c\u56fd",
                 "common": "\u54e5\u65af\u8fbe\u9ece\u52a0"
+            },
+            "swe": {
+                "official": "Republiken Costa Rica",
+                "common": "Costa Rica"
             }
         },
         "latlng": [
@@ -8337,6 +8553,10 @@
             "zho": {
                 "official": "\u53e4\u5df4\u5171\u548c\u56fd",
                 "common": "\u53e4\u5df4"
+            },
+            "swe": {
+                "official": "Republiken Kuba",
+                "common": "Kuba"
             }
         },
         "latlng": [
@@ -8484,6 +8704,10 @@
             "zho": {
                 "official": "\u5e93\u62c9\u7d22",
                 "common": "\u5e93\u62c9\u7d22"
+            },
+            "swe": {
+                "official": "Curaçao",
+                "common": "Curaçao"
             }
         },
         "latlng": [
@@ -8629,6 +8853,10 @@
             "zho": {
                 "official": "\u5723\u8bde\u5c9b",
                 "common": "\u5723\u8bde\u5c9b"
+            },
+            "swe": {
+                "official": "Jul\u00f6n",
+                "common": "Jul\u00f6n"
             }
         },
         "latlng": [
@@ -8773,6 +9001,10 @@
             "zho": {
                 "official": "\u5f00\u66fc\u7fa4\u5c9b",
                 "common": "\u5f00\u66fc\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Cayman\u00f6arna",
+                "common": "Cayman\u00f6arna"
             }
         },
         "latlng": [
@@ -8927,6 +9159,10 @@
             "zho": {
                 "official": "\u585e\u6d66\u8def\u65af\u5171\u548c\u56fd",
                 "common": "\u585e\u6d66\u8def\u65af"
+            },
+            "swe": {
+                "official": "Republiken Cypern",
+                "common": "Cypern"
             }
         },
         "latlng": [
@@ -9078,6 +9314,10 @@
             "zho": {
                 "official": "\u6377\u514b\u5171\u548c\u56fd",
                 "common": "\u6377\u514b"
+            },
+            "swe": {
+                "official": "Republiken Tjeckien",
+                "common": "Tjeckien"
             }
         },
         "latlng": [
@@ -9225,6 +9465,10 @@
             "zho": {
                 "official": "\u5fb7\u610f\u5fd7\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u5fb7\u56fd"
+            },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Tyskland",
+                "common": "Tyskland"
             }
         },
         "latlng": [
@@ -9390,6 +9634,10 @@
             "zho": {
                 "official": "\u5409\u5e03\u63d0\u5171\u548c\u56fd",
                 "common": "\u5409\u5e03\u63d0"
+            },
+            "swe": {
+                "official": "Republiken Djibouti",
+                "common": "Djibouti"
             }
         },
         "latlng": [
@@ -9541,6 +9789,10 @@
             "zho": {
                 "official": "\u591a\u7c73\u5c3c\u52a0\u5171\u548c\u56fd",
                 "common": "\u591a\u7c73\u5c3c\u52a0"
+            },
+            "swe": {
+                "official": "Samv\u00e4ldet Dominica",
+                "common": "Dominica"
             }
         },
         "latlng": [
@@ -9688,6 +9940,10 @@
             "zho": {
                 "official": "\u4e39\u9ea6\u738b\u56fd",
                 "common": "\u4e39\u9ea6"
+            },
+            "swe": {
+                "official": "Konungariket Danmark",
+                "common": "Danmark"
             }
         },
         "latlng": [
@@ -9836,6 +10092,10 @@
             "zho": {
                 "official": "\u591a\u660e\u5c3c\u52a0\u5171\u548c\u56fd",
                 "common": "\u591a\u660e\u5c3c\u52a0"
+            },
+            "swe": {
+                "official": "Dominikanska republiken",
+                "common": "Dominikanska republiken"
             }
         },
         "latlng": [
@@ -9985,6 +10245,10 @@
             "zho": {
                 "official": "\u963f\u5c14\u53ca\u5229\u4e9a\u4eba\u6c11\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u963f\u5c14\u53ca\u5229\u4e9a"
+            },
+            "swe": {
+                "official": "Demokratiska folkrepubliken Algeriet",
+                "common": "Algeriet"
             }
         },
         "latlng": [
@@ -10139,6 +10403,10 @@
             "zho": {
                 "official": "\u5384\u74dc\u591a\u5c14\u5171\u548c\u56fd",
                 "common": "\u5384\u74dc\u591a\u5c14"
+            },
+            "swe": {
+                "official": "Republiken Ecuador",
+                "common": "Ecuador"
             }
         },
         "latlng": [
@@ -10288,6 +10556,10 @@
             "zho": {
                 "official": "\u963f\u62c9\u4f2f\u57c3\u53ca\u5171\u548c\u56fd",
                 "common": "\u57c3\u53ca"
+            },
+            "swe": {
+                "official": "Arabrepubliken Egypten",
+                "common": "Egypten"
             }
         },
         "latlng": [
@@ -10452,6 +10724,10 @@
             "zho": {
                 "official": "\u5384\u7acb\u7279\u91cc\u4e9a",
                 "common": "\u5384\u7acb\u7279\u91cc\u4e9a"
+            },
+            "swe": {
+                "official": "Staten Eritrea",
+                "common": "Eritrea"
             }
         },
         "latlng": [
@@ -10616,6 +10892,10 @@
             "zho": {
                 "official": "\u963f\u62c9\u4f2f\u6492\u54c8\u62c9\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u897f\u6492\u54c8\u62c9"
+            },
+            "swe": {
+                "official": "V\u00e4stsahara",
+                "common": "V\u00e4stsahara"
             }
         },
         "latlng": [
@@ -10762,6 +11042,10 @@
             "zho": {
                 "official": "\u897f\u73ed\u7259\u738b\u56fd",
                 "common": "\u897f\u73ed\u7259"
+            },
+            "swe": {
+                "official": "Konungariket Spanien",
+                "common": "Spanien"
             }
         },
         "latlng": [
@@ -10915,6 +11199,10 @@
             "zho": {
                 "official": "\u7231\u6c99\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u7231\u6c99\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Estland",
+                "common": "Estland"
             }
         },
         "latlng": [
@@ -11065,6 +11353,10 @@
             "zho": {
                 "official": "\u57c3\u585e\u4fc4\u6bd4\u4e9a\u8054\u90a6\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u57c3\u585e\u4fc4\u6bd4\u4e9a"
+            },
+            "swe": {
+                "official": "Demokratiska f\u00f6rbundsrepubliken Etiopien",
+                "common": "Etiopien"
             }
         },
         "latlng": [
@@ -11221,6 +11513,10 @@
             "zho": {
                 "official": "\u82ac\u5170\u5171\u548c\u56fd",
                 "common": "\u82ac\u5170"
+            },
+            "swe": {
+                "official": "Republiken Finland",
+                "common": "Finland"
             }
         },
         "latlng": [
@@ -11379,6 +11675,10 @@
             "zho": {
                 "official": "\u6590\u6d4e\u5171\u548c\u56fd",
                 "common": "\u6590\u6d4e"
+            },
+            "swe": {
+                "official": "Republiken Fiji",
+                "common": "Fiji"
             }
         },
         "latlng": [
@@ -11521,6 +11821,10 @@
             "zho": {
                 "official": "\u798f\u514b\u5170\u7fa4\u5c9b",
                 "common": "\u798f\u514b\u5170\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Falklands\u00f6arna",
+                "common": "Falklands\u00f6arna"
             }
         },
         "latlng": [
@@ -11663,6 +11967,10 @@
             "zho": {
                 "official": "\u6cd5\u5170\u897f\u5171\u548c\u56fd",
                 "common": "\u6cd5\u56fd"
+            },
+            "swe": {
+                "official": "Republiken Frankrike",
+                "common": "Frankrike"
             }
         },
         "latlng": [
@@ -11823,6 +12131,10 @@
             "zho": {
                 "official": "\u6cd5\u7f57\u7fa4\u5c9b",
                 "common": "\u6cd5\u7f57\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "F\u00e4r\u00f6arna",
+                "common": "F\u00e4r\u00f6arna"
             }
         },
         "latlng": [
@@ -11960,6 +12272,10 @@
             "zho": {
                 "official": "\u5bc6\u514b\u7f57\u5c3c\u897f\u4e9a\u8054\u90a6",
                 "common": "\u5bc6\u514b\u7f57\u5c3c\u897f\u4e9a"
+            },
+            "swe": {
+                "official": "Mikronesiska federationen",
+                "common": "Mikronesiska federationen"
             }
         },
         "latlng": [
@@ -12102,6 +12418,10 @@
             "zho": {
                 "official": "\u52a0\u84ec\u5171\u548c\u56fd",
                 "common": "\u52a0\u84ec"
+            },
+            "swe": {
+                "official": "Republiken Gabon",
+                "common": "Gabon"
             }
         },
         "latlng": [
@@ -12248,6 +12568,10 @@
             "zho": {
                 "official": "\u5927\u4e0d\u5217\u98a0\u53ca\u5317\u7231\u5c14\u5170\u8054\u5408\u738b\u56fd",
                 "common": "\u82f1\u56fd"
+            },
+            "swe": {
+                "official": "F\u00f6renade konungariket Storbritannien och Nordirland",
+                "common": "Storbritannien"
             }
         },
         "latlng": [
@@ -12391,6 +12715,10 @@
             "zho": {
                 "official": "\u683c\u9c81\u5409\u4e9a",
                 "common": "\u683c\u9c81\u5409\u4e9a"
+            },
+            "swe": {
+                "official": "Georgien",
+                "common": "Georgien"
             }
         },
         "latlng": [
@@ -12552,6 +12880,10 @@
             "zho": {
                 "official": "\u6839\u897f\u5c9b",
                 "common": "\u6839\u897f\u5c9b"
+            },
+            "swe": {
+                "official": "Guernsey",
+                "common": "Guernsey"
             }
         },
         "latlng": [
@@ -12692,6 +13024,10 @@
             "zho": {
                 "official": "\u52a0\u7eb3\u5171\u548c\u56fd",
                 "common": "\u52a0\u7eb3"
+            },
+            "swe": {
+                "official": "Republiken Ghana",
+                "common": "Ghana"
             }
         },
         "latlng": [
@@ -12836,6 +13172,10 @@
             "zho": {
                 "official": "\u76f4\u5e03\u7f57\u9640",
                 "common": "\u76f4\u5e03\u7f57\u9640"
+            },
+            "swe": {
+                "official": "Gibraltar",
+                "common": "Gibraltar"
             }
         },
         "latlng": [
@@ -12980,6 +13320,10 @@
             "zho": {
                 "official": "\u51e0\u5185\u4e9a\u5171\u548c\u56fd",
                 "common": "\u51e0\u5185\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Guinea",
+                "common": "Guinea"
             }
         },
         "latlng": [
@@ -13128,6 +13472,10 @@
             "zho": {
                 "official": "\u74dc\u5fb7\u7f57\u666e\u5c9b",
                 "common": "\u74dc\u5fb7\u7f57\u666e\u5c9b"
+            },
+            "swe": {
+                "official": "Guadeloupe",
+                "common": "Guadeloupe"
             }
         },
         "latlng": [
@@ -13269,6 +13617,10 @@
             "zho": {
                 "official": "\u5188\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u5188\u6bd4\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Gambia",
+                "common": "Gambia"
             }
         },
         "latlng": [
@@ -13418,6 +13770,10 @@
             "zho": {
                 "official": "\u51e0\u5185\u4e9a\u6bd4\u7ecd\u5171\u548c\u56fd",
                 "common": "\u51e0\u5185\u4e9a\u6bd4\u7ecd"
+            },
+            "swe": {
+                "official": "Republiken Guinea-Bissau",
+                "common": "Guinea-Bissau"
             }
         },
         "latlng": [
@@ -13579,6 +13935,10 @@
             "zho": {
                 "official": "\u8d64\u9053\u51e0\u5185\u4e9a\u5171\u548c\u56fd",
                 "common": "\u8d64\u9053\u51e0\u5185\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Ekvatorialguinea",
+                "common": "Ekvatorialguinea"
             }
         },
         "latlng": [
@@ -13725,6 +14085,10 @@
             "zho": {
                 "official": "\u5e0c\u814a\u5171\u548c\u56fd",
                 "common": "\u5e0c\u814a"
+            },
+            "swe": {
+                "official": "Republiken Grekland",
+                "common": "Grekland"
             }
         },
         "latlng": [
@@ -13870,6 +14234,10 @@
             "zho": {
                 "official": "\u683c\u6797\u7eb3\u8fbe",
                 "common": "\u683c\u6797\u7eb3\u8fbe"
+            },
+            "swe": {
+                "official": "Grenada",
+                "common": "Grenada"
             }
         },
         "latlng": [
@@ -14011,6 +14379,10 @@
             "zho": {
                 "official": "\u683c\u9675\u5170",
                 "common": "\u683c\u9675\u5170"
+            },
+            "swe": {
+                "official": "Gr\u00f6nland",
+                "common": "Gr\u00f6nland"
             }
         },
         "latlng": [
@@ -14151,6 +14523,10 @@
             "zho": {
                 "official": "\u5371\u5730\u9a6c\u62c9\u5171\u548c\u56fd",
                 "common": "\u5371\u5730\u9a6c\u62c9"
+            },
+            "swe": {
+                "official": "Republiken Guatemala",
+                "common": "Guatemala"
             }
         },
         "latlng": [
@@ -14298,6 +14674,10 @@
             "zho": {
                 "official": "\u6cd5\u5c5e\u572d\u4e9a\u90a3",
                 "common": "\u6cd5\u5c5e\u572d\u4e9a\u90a3"
+            },
+            "swe": {
+                "official": "Franska Guyana",
+                "common": "Franska Guyana"
             }
         },
         "latlng": [
@@ -14452,6 +14832,10 @@
             "zho": {
                 "official": "\u5173\u5c9b",
                 "common": "\u5173\u5c9b"
+            },
+            "swe": {
+                "official": "Guam",
+                "common": "Guam"
             }
         },
         "latlng": [
@@ -14593,6 +14977,10 @@
             "zho": {
                 "official": "\u572d\u4e9a\u90a3\u5171\u548c\u56fd",
                 "common": "\u572d\u4e9a\u90a3"
+            },
+            "swe": {
+                "official": "Kooperativa republiken Guyana",
+                "common": "Guyana"
             }
         },
         "latlng": [
@@ -14739,6 +15127,10 @@
             "urd": {
                 "official": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 \u06a9\u0627 \u062e\u0635\u0648\u0635\u06cc \u0627\u0646\u062a\u0638\u0627\u0645\u06cc \u0639\u0644\u0627\u0642\u06c1",
                 "common": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af"
+            },
+            "swe": {
+                "official": "Hongkong",
+                "common": "Hongkong"
             }
         },
         "latlng": [
@@ -14878,6 +15270,10 @@
             "zho": {
                 "official": "\u8d6b\u5fb7\u5c9b\u548c\u9ea6\u5f53\u52b3\u7fa4\u5c9b",
                 "common": "\u8d6b\u5fb7\u5c9b\u548c\u9ea6\u5f53\u52b3\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Heard- och McDonald\u00f6arna",
+                "common": "Heard- och McDonald\u00f6arna"
             }
         },
         "latlng": [
@@ -15020,6 +15416,10 @@
             "zho": {
                 "official": "\u6d2a\u90fd\u62c9\u65af\u5171\u548c\u56fd",
                 "common": "\u6d2a\u90fd\u62c9\u65af"
+            },
+            "swe": {
+                "official": "Republiken Honduras",
+                "common": "Honduras"
             }
         },
         "latlng": [
@@ -15171,6 +15571,10 @@
             "zho": {
                 "official": "\u514b\u7f57\u5730\u4e9a\u5171\u548c\u56fd",
                 "common": "\u514b\u7f57\u5730\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Kroatien",
+                "common": "Kroatien"
             }
         },
         "latlng": [
@@ -15325,6 +15729,10 @@
             "zho": {
                 "official": "\u6d77\u5730\u5171\u548c\u56fd",
                 "common": "\u6d77\u5730"
+            },
+            "swe": {
+                "official": "Republiken Haiti",
+                "common": "Haiti"
             }
         },
         "latlng": [
@@ -15467,6 +15875,10 @@
             "zho": {
                 "official": "\u5308\u7259\u5229",
                 "common": "\u5308\u7259\u5229"
+            },
+            "swe": {
+                "official": "Ungern",
+                "common": "Ungern"
             }
         },
         "latlng": [
@@ -15617,6 +16029,10 @@
             "zho": {
                 "official": "\u5370\u5ea6\u5c3c\u897f\u4e9a\u5171\u548c\u56fd",
                 "common": "\u5370\u5ea6\u5c3c\u897f\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Indonesien",
+                "common": "Indonesien"
             }
         },
         "latlng": [
@@ -15773,6 +16189,10 @@
             "zho": {
                 "official": "\u9a6c\u6069\u5c9b",
                 "common": "\u9a6c\u6069\u5c9b"
+            },
+            "swe": {
+                "official": "Isle of Man",
+                "common": "Isle of Man"
             }
         },
         "latlng": [
@@ -15927,6 +16347,10 @@
             "zho": {
                 "official": "\u5370\u5ea6\u5171\u548c\u56fd",
                 "common": "\u5370\u5ea6"
+            },
+            "swe": {
+                "official": "Republiken Indien",
+                "common": "Indien"
             }
         },
         "latlng": [
@@ -16078,6 +16502,10 @@
             "zho": {
                 "official": "\u82f1\u5c5e\u5370\u5ea6\u6d0b\u9886\u5730",
                 "common": "\u82f1\u5c5e\u5370\u5ea6\u6d0b\u9886\u5730"
+            },
+            "swe": {
+                "official": "Brittiska territoriet i Indiska Oceanen",
+                "common": "Brittiska territoriet i Indiska Oceanen"
             }
         },
         "latlng": [
@@ -16226,6 +16654,10 @@
             "zho": {
                 "official": "\u7231\u5c14\u5170\u5171\u548c\u56fd",
                 "common": "\u7231\u5c14\u5170"
+            },
+            "swe": {
+                "official": "Irland",
+                "common": "Irland"
             }
         },
         "latlng": [
@@ -16368,6 +16800,10 @@
             "zho": {
                 "official": "\u4f0a\u6717\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u4f0a\u6717"
+            },
+            "swe": {
+                "official": "Islamiska republiken Iran",
+                "common": "Iran"
             }
         },
         "latlng": [
@@ -16528,6 +16964,10 @@
             "zho": {
                 "official": "\u4f0a\u62c9\u514b\u5171\u548c\u56fd",
                 "common": "\u4f0a\u62c9\u514b"
+            },
+            "swe": {
+                "official": "Republiken Irak",
+                "common": "Irak"
             }
         },
         "latlng": [
@@ -16678,6 +17118,10 @@
             "zho": {
                 "official": "\u51b0\u5c9b",
                 "common": "\u51b0\u5c9b"
+            },
+            "swe": {
+                "official": "Island",
+                "common": "Island"
             }
         },
         "latlng": [
@@ -16825,6 +17269,10 @@
             "zho": {
                 "official": "\u4ee5\u8272\u5217\u56fd",
                 "common": "\u4ee5\u8272\u5217"
+            },
+            "swe": {
+                "official": "Staten Israel",
+                "common": "Israel"
             }
         },
         "latlng": [
@@ -16973,6 +17421,10 @@
             "zho": {
                 "official": "\u610f\u5927\u5229\u5171\u548c\u56fd",
                 "common": "\u610f\u5927\u5229"
+            },
+            "swe": {
+                "official": "Republiken Italien",
+                "common": "Italien"
             }
         },
         "latlng": [
@@ -17125,6 +17577,10 @@
             "zho": {
                 "official": "\u7259\u4e70\u52a0",
                 "common": "\u7259\u4e70\u52a0"
+            },
+            "swe": {
+                "official": "Jamaica",
+                "common": "Jamaica"
             }
         },
         "latlng": [
@@ -17282,6 +17738,10 @@
             "zho": {
                 "official": "\u6cfd\u897f\u5c9b",
                 "common": "\u6cfd\u897f\u5c9b"
+            },
+            "swe": {
+                "official": "Jersey",
+                "common": "Jersey"
             }
         },
         "latlng": [
@@ -17425,6 +17885,10 @@
             "zho": {
                 "official": "\u7ea6\u65e6\u54c8\u5e0c\u59c6\u738b\u56fd",
                 "common": "\u7ea6\u65e6"
+            },
+            "swe": {
+                "official": "Hashimitiska kungad\u00f6met Jordanien",
+                "common": "Jordanien"
             }
         },
         "latlng": [
@@ -17574,6 +18038,10 @@
             "zho": {
                 "official": "\u65e5\u672c\u56fd",
                 "common": "\u65e5\u672c"
+            },
+            "swe": {
+                "official": "Japan",
+                "common": "Japan"
             }
         },
         "latlng": [
@@ -17728,6 +18196,10 @@
             "zho": {
                 "official": "\u54c8\u8428\u514b\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u54c8\u8428\u514b\u65af\u5766"
+            },
+            "swe": {
+                "official": "Republiken Kazakstan",
+                "common": "Kazakstan"
             }
         },
         "latlng": [
@@ -17881,6 +18353,10 @@
             "zho": {
                 "official": "\u80af\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u80af\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Kenya",
+                "common": "Kenya"
             }
         },
         "latlng": [
@@ -18036,6 +18512,10 @@
             "zho": {
                 "official": "\u5409\u5c14\u5409\u65af\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u5409\u5c14\u5409\u65af\u65af\u5766"
+            },
+            "swe": {
+                "official": "Republiken Kirgizistan",
+                "common": "Kirgizistan"
             }
         },
         "latlng": [
@@ -18190,6 +18670,10 @@
             "zho": {
                 "official": "\u67ec\u57d4\u5be8\u738b\u56fd",
                 "common": "\u67ec\u57d4\u5be8"
+            },
+            "swe": {
+                "official": "Konungariket Kambodja",
+                "common": "Kambodja"
             }
         },
         "latlng": [
@@ -18345,6 +18829,10 @@
             "zho": {
                 "official": "\u57fa\u91cc\u5df4\u65af\u5171\u548c\u56fd",
                 "common": "\u57fa\u91cc\u5df4\u65af"
+            },
+            "swe": {
+                "official": "Republiken Kiribati",
+                "common": "Kiribati"
             }
         },
         "latlng": [
@@ -18486,6 +18974,10 @@
             "zho": {
                 "official": "\u5723\u514b\u91cc\u65af\u6258\u5f17\u548c\u5c3c\u7ef4\u65af\u8054\u90a6",
                 "common": "\u5723\u57fa\u8328\u548c\u5c3c\u7ef4\u65af"
+            },
+            "swe": {
+                "official": "Federationen Saint Kitts och Nevis",
+                "common": "Saint Kitts och Nevis"
             }
         },
         "latlng": [
@@ -18631,6 +19123,10 @@
             "zho": {
                 "official": "\u5927\u97e9\u6c11\u56fd",
                 "common": "\u97e9\u56fd"
+            },
+            "swe": {
+                "official": "Republiken Korea",
+                "common": "Sydkorea"
             }
         },
         "latlng": [
@@ -18773,6 +19269,10 @@
             "zho": {
                 "official": "\u79d1\u7d22\u6c83\u5171\u548c\u56fd",
                 "common": "\u79d1\u7d22\u6c83"
+            },
+            "swe": {
+                "official": "Republiken Kosovo",
+                "common": "Kosovo"
             }
         },
         "latlng": [
@@ -18920,6 +19420,10 @@
             "zho": {
                 "official": "\u79d1\u5a01\u7279\u56fd",
                 "common": "\u79d1\u5a01\u7279"
+            },
+            "swe": {
+                "official": "Staten Kuwait",
+                "common": "Kuwait"
             }
         },
         "latlng": [
@@ -19066,6 +19570,10 @@
             "zho": {
                 "official": "\u8001\u631d\u4eba\u6c11\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u8001\u631d"
+            },
+            "swe": {
+                "official": "Demokratiska folkrepubliken Laos",
+                "common": "Laos"
             }
         },
         "latlng": [
@@ -19219,6 +19727,10 @@
             "zho": {
                 "official": "\u9ece\u5df4\u5ae9\u5171\u548c\u56fd",
                 "common": "\u9ece\u5df4\u5ae9"
+            },
+            "swe": {
+                "official": "Republiken Libanon",
+                "common": "Libanon"
             }
         },
         "latlng": [
@@ -19363,6 +19875,10 @@
             "zho": {
                 "official": "\u5229\u6bd4\u91cc\u4e9a\u5171\u548c\u56fd",
                 "common": "\u5229\u6bd4\u91cc\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Liberia",
+                "common": "Liberia"
             }
         },
         "latlng": [
@@ -19509,6 +20025,10 @@
             "zho": {
                 "official": "\u5229\u6bd4\u4e9a\u56fd",
                 "common": "\u5229\u6bd4\u4e9a"
+            },
+            "swe": {
+                "official": "Staten Libyen",
+                "common": "Libyen"
             }
         },
         "latlng": [
@@ -19656,6 +20176,10 @@
             "zho": {
                 "official": "\u5723\u5362\u897f\u4e9a",
                 "common": "\u5723\u5362\u897f\u4e9a"
+            },
+            "swe": {
+                "official": "Saint Lucia",
+                "common": "Saint Lucia"
             }
         },
         "latlng": [
@@ -19798,6 +20322,10 @@
             "zho": {
                 "official": "\u5217\u652f\u6566\u58eb\u767b\u516c\u56fd",
                 "common": "\u5217\u652f\u6566\u58eb\u767b"
+            },
+            "swe": {
+                "official": "Furstend\u00f6met Liechtenstein",
+                "common": "Liechtenstein"
             }
         },
         "latlng": [
@@ -19950,6 +20478,10 @@
             "zho": {
                 "official": "\u65af\u91cc\u5170\u5361\u6c11\u4e3b\u793e\u4f1a\u4e3b\u4e49\u5171\u548c\u56fd",
                 "common": "\u65af\u91cc\u5170\u5361"
+            },
+            "swe": {
+                "official": "Demokratiska socialistiska republiken Sri Lanka",
+                "common": "Sri Lanka"
             }
         },
         "latlng": [
@@ -20103,6 +20635,10 @@
             "zho": {
                 "official": "\u83b1\u7d22\u6258\u738b\u56fd",
                 "common": "\u83b1\u7d22\u6258"
+            },
+            "swe": {
+                "official": "Konungariket Lesotho",
+                "common": "Lesotho"
             }
         },
         "latlng": [
@@ -20247,6 +20783,10 @@
             "zho": {
                 "official": "\u7acb\u9676\u5b9b\u5171\u548c\u56fd",
                 "common": "\u7acb\u9676\u5b9b"
+            },
+            "swe": {
+                "official": "Republiken Litauen",
+                "common": "Litauen"
             }
         },
         "latlng": [
@@ -20406,6 +20946,10 @@
             "zho": {
                 "official": "\u5362\u68ee\u5821\u5927\u516c\u56fd",
                 "common": "\u5362\u68ee\u5821"
+            },
+            "swe": {
+                "official": "Storhertigd\u00f6met Luxemburg",
+                "common": "Luxemburg"
             }
         },
         "latlng": [
@@ -20552,6 +21096,10 @@
             "zho": {
                 "official": "\u62c9\u8131\u7ef4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u62c9\u8131\u7ef4\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Lettland",
+                "common": "Lettland"
             }
         },
         "latlng": [
@@ -20703,6 +21251,10 @@
             "urd": {
                 "official": "\u0645\u06a9\u0627\u0624 \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 \u06a9\u0627 \u062e\u0635\u0648\u0635\u06cc \u0627\u0646\u062a\u0638\u0627\u0645\u06cc \u0639\u0644\u0627\u0642\u06c1",
                 "common": "\u0645\u06a9\u0627\u0624"
+            },
+            "swe": {
+                "official": "Macao",
+                "common": "Macao"
             }
         },
         "latlng": [
@@ -20849,6 +21401,10 @@
             "zho": {
                 "official": "\u5723\u9a6c\u4e01",
                 "common": "\u5723\u9a6c\u4e01"
+            },
+            "swe": {
+                "official": "F\u00f6rvaltningsomr\u00e5det Saint-Martin",
+                "common": "Saint-Martin"
             }
         },
         "latlng": [
@@ -20999,6 +21555,10 @@
             "zho": {
                 "official": "\u6469\u6d1b\u54e5\u738b\u56fd",
                 "common": "\u6469\u6d1b\u54e5"
+            },
+            "swe": {
+                "official": "Konungariket Marocko",
+                "common": "Marocko"
             }
         },
         "latlng": [
@@ -21145,6 +21705,10 @@
             "zho": {
                 "official": "\u6469\u7eb3\u54e5\u516c\u56fd",
                 "common": "\u6469\u7eb3\u54e5"
+            },
+            "swe": {
+                "official": "Furstend\u00f6met Monaco",
+                "common": "Monaco"
             }
         },
         "latlng": [
@@ -21290,6 +21854,10 @@
             "zho": {
                 "official": "\u6469\u5c14\u591a\u74e6\u5171\u548c\u56fd",
                 "common": "\u6469\u5c14\u591a\u74e6"
+            },
+            "swe": {
+                "official": "Republiken Moldavien",
+                "common": "Moldavien"
             }
         },
         "latlng": [
@@ -21441,6 +22009,10 @@
             "zho": {
                 "official": "\u9a6c\u8fbe\u52a0\u65af\u52a0\u5171\u548c\u56fd",
                 "common": "\u9a6c\u8fbe\u52a0\u65af\u52a0"
+            },
+            "swe": {
+                "official": "Republiken Madagaskar",
+                "common": "Madagaskar"
             }
         },
         "latlng": [
@@ -21584,6 +22156,10 @@
             "zho": {
                 "official": "\u9a6c\u5c14\u4ee3\u592b\u5171\u548c\u56fd",
                 "common": "\u9a6c\u5c14\u4ee3\u592b"
+            },
+            "swe": {
+                "official": "Republiken Maldiverna",
+                "common": "Maldiverna"
             }
         },
         "latlng": [
@@ -21727,6 +22303,10 @@
             "zho": {
                 "official": "\u58a8\u897f\u54e5\u5408\u4f17\u56fd",
                 "common": "\u58a8\u897f\u54e5"
+            },
+            "swe": {
+                "official": "Mexikos f\u00f6renta stater",
+                "common": "Mexiko"
             }
         },
         "latlng": [
@@ -21878,6 +22458,10 @@
             "zho": {
                 "official": "\u9a6c\u7ecd\u5c14\u7fa4\u5c9b\u5171\u548c\u56fd",
                 "common": "\u9a6c\u7ecd\u5c14\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Republiken Marshall\u00f6arna",
+                "common": "Marshall\u00f6arna"
             }
         },
         "latlng": [
@@ -22022,6 +22606,10 @@
             "zho": {
                 "official": "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b",
                 "common": "\u5317\u99ac\u5176\u9813"
+            },
+            "swe": {
+                "official": "Republiken Nordmakedonien",
+                "common": "Nordmakedonien"
             }
         },
         "latlng": [
@@ -22170,6 +22758,10 @@
             "zho": {
                 "official": "\u9a6c\u91cc\u5171\u548c\u56fd",
                 "common": "\u9a6c\u91cc"
+            },
+            "swe": {
+                "official": "Republiken Mali",
+                "common": "Mali"
             }
         },
         "latlng": [
@@ -22325,6 +22917,10 @@
             "zho": {
                 "official": "\u9a6c\u8033\u4ed6\u5171\u548c\u56fd",
                 "common": "\u9a6c\u8033\u4ed6"
+            },
+            "swe": {
+                "official": "Republiken Malta",
+                "common": "Malta"
             }
         },
         "latlng": [
@@ -22468,6 +23064,10 @@
             "zho": {
                 "official": "\u7f05\u7538\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u7f05\u7538"
+            },
+            "swe": {
+                "official": "Republiken Unionen Myanmar",
+                "common": "Myanmar"
             }
         },
         "latlng": [
@@ -22615,6 +23215,10 @@
             "zho": {
                 "official": "\u9ed1\u5c71",
                 "common": "\u9ed1\u5c71"
+            },
+            "swe": {
+                "official": "Montenegro",
+                "common": "Montenegro"
             }
         },
         "latlng": [
@@ -22761,6 +23365,10 @@
             "zho": {
                 "official": "\u8499\u53e4",
                 "common": "\u8499\u53e4"
+            },
+            "swe": {
+                "official": "Mongoliet",
+                "common": "Mongoliet"
             }
         },
         "latlng": [
@@ -22916,6 +23524,10 @@
             "zho": {
                 "official": "\u5317\u9a6c\u91cc\u4e9a\u7eb3\u7fa4\u5c9b",
                 "common": "\u5317\u9a6c\u91cc\u4e9a\u7eb3\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Nordmarianerna",
+                "common": "Nordmarianerna"
             }
         },
         "latlng": [
@@ -23058,6 +23670,10 @@
             "zho": {
                 "official": "\u83ab\u6851\u6bd4\u514b\u5171\u548c\u56fd",
                 "common": "\u83ab\u6851\u6bd4\u514b"
+            },
+            "swe": {
+                "official": "Republiken Moçambique",
+                "common": "Moçambique"
             }
         },
         "latlng": [
@@ -23207,6 +23823,10 @@
             "zho": {
                 "official": "\u6bdb\u91cc\u5854\u5c3c\u4e9a\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u6bdb\u91cc\u5854\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Islamiska republiken Mauretanien",
+                "common": "Mauretanien"
             }
         },
         "latlng": [
@@ -23352,6 +23972,10 @@
             "zho": {
                 "official": "\u8499\u7279\u585e\u62c9\u7279",
                 "common": "\u8499\u7279\u585e\u62c9\u7279"
+            },
+            "swe": {
+                "official": "Montserrat",
+                "common": "Montserrat"
             }
         },
         "latlng": [
@@ -23492,6 +24116,10 @@
             "zho": {
                 "official": "\u9a6c\u63d0\u5c3c\u514b",
                 "common": "\u9a6c\u63d0\u5c3c\u514b"
+            },
+            "swe": {
+                "official": "Martinique",
+                "common": "Martinique"
             }
         },
         "latlng": [
@@ -23644,6 +24272,10 @@
             "zho": {
                 "official": "\u6bdb\u91cc\u6c42\u65af\u5171\u548c\u56fd",
                 "common": "\u6bdb\u91cc\u6c42\u65af"
+            },
+            "swe": {
+                "official": "Republiken Mauritius",
+                "common": "Mauritius"
             }
         },
         "latlng": [
@@ -23790,6 +24422,10 @@
             "zho": {
                 "official": "\u9a6c\u62c9\u7ef4\u5171\u548c\u56fd",
                 "common": "\u9a6c\u62c9\u7ef4"
+            },
+            "swe": {
+                "official": "Republiken Malawi",
+                "common": "Malawi"
             }
         },
         "latlng": [
@@ -23939,6 +24575,10 @@
             "zho": {
                 "official": "\u9a6c\u6765\u897f\u4e9a",
                 "common": "\u9a6c\u6765\u897f\u4e9a"
+            },
+            "swe": {
+                "official": "Malaysia",
+                "common": "Malaysia"
             }
         },
         "latlng": [
@@ -24085,6 +24725,10 @@
             "zho": {
                 "official": "\u9a6c\u7ea6\u7279",
                 "common": "\u9a6c\u7ea6\u7279"
+            },
+            "swe": {
+                "official": "Departementsomr\u00e5det Mayotte",
+                "common": "Mayotte"
             }
         },
         "latlng": [
@@ -24271,6 +24915,10 @@
             "zho": {
                 "official": "\u7eb3\u7c73\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u7eb3\u7c73\u6bd4\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Namibia",
+                "common": "Namibia"
             }
         },
         "latlng": [
@@ -24416,6 +25064,10 @@
             "zho": {
                 "official": "\u65b0\u5580\u91cc\u591a\u5c3c\u4e9a",
                 "common": "\u65b0\u5580\u91cc\u591a\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Nya Kaledonien",
+                "common": "Nya Kaledonien"
             }
         },
         "latlng": [
@@ -24557,6 +25209,10 @@
             "zho": {
                 "official": "\u5c3c\u65e5\u5c14\u5171\u548c\u56fd",
                 "common": "\u5c3c\u65e5\u5c14"
+            },
+            "swe": {
+                "official": "Republiken Niger",
+                "common": "Niger"
             }
         },
         "latlng": [
@@ -24712,6 +25368,10 @@
             "zho": {
                 "official": "\u8bfa\u798f\u514b\u5c9b",
                 "common": "\u8bfa\u798f\u514b\u5c9b"
+            },
+            "swe": {
+                "official": "Norfolk\u00f6n",
+                "common": "Norfolk\u00f6n"
             }
         },
         "latlng": [
@@ -24855,6 +25515,10 @@
             "zho": {
                 "official": "\u5c3c\u65e5\u5229\u4e9a\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u5c3c\u65e5\u5229\u4e9a"
+            },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Nigeria",
+                "common": "Nigeria"
             }
         },
         "latlng": [
@@ -25002,6 +25666,10 @@
             "zho": {
                 "official": "\u5c3c\u52a0\u62c9\u74dc\u5171\u548c\u56fd",
                 "common": "\u5c3c\u52a0\u62c9\u74dc"
+            },
+            "swe": {
+                "official": "Republiken Nicaragua",
+                "common": "Nicaragua"
             }
         },
         "latlng": [
@@ -25150,6 +25818,10 @@
             "zho": {
                 "official": "\u7ebd\u57c3",
                 "common": "\u7ebd\u57c3"
+            },
+            "swe": {
+                "official": "Niue",
+                "common": "Niue"
             }
         },
         "latlng": [
@@ -25293,6 +25965,10 @@
             "zho": {
                 "official": "\u8377\u5170",
                 "common": "\u8377\u5170"
+            },
+            "swe": {
+                "official": "Nederl\u00e4nderna",
+                "common": "Nederl\u00e4nderna"
             }
         },
         "latlng": [
@@ -25451,6 +26127,10 @@
             "zho": {
                 "official": "\u632a\u5a01\u738b\u56fd",
                 "common": "\u632a\u5a01"
+            },
+            "swe": {
+                "official": "Konungariket Norge",
+                "common": "Norge"
             }
         },
         "latlng": [
@@ -25597,6 +26277,10 @@
             "zho": {
                 "official": "\u5c3c\u6cca\u5c14\u8054\u90a6\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u5c3c\u6cca\u5c14"
+            },
+            "swe": {
+                "official": "Demokratiska f\u00f6rbundsrepubliken Nepal",
+                "common": "Nepal"
             }
         },
         "latlng": [
@@ -25749,6 +26433,10 @@
             "zho": {
                 "official": "\u7459\u9c81\u5171\u548c\u56fd",
                 "common": "\u7459\u9c81"
+            },
+            "swe": {
+                "official": "Republiken Nauru",
+                "common": "Nauru"
             }
         },
         "latlng": [
@@ -25900,6 +26588,10 @@
             "zho": {
                 "official": "\u65b0\u897f\u5170",
                 "common": "\u65b0\u897f\u5170"
+            },
+            "swe": {
+                "official": "Nya Zeeland",
+                "common": "Nya Zeeland"
             }
         },
         "latlng": [
@@ -26042,6 +26734,10 @@
             "zho": {
                 "official": "\u963f\u66fc\u82cf\u4e39\u56fd",
                 "common": "\u963f\u66fc"
+            },
+            "swe": {
+                "official": "Sultanatet Oman",
+                "common": "Oman"
             }
         },
         "latlng": [
@@ -26194,6 +26890,10 @@
             "zho": {
                 "official": "\u5df4\u57fa\u65af\u5766\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u5df4\u57fa\u65af\u5766"
+            },
+            "swe": {
+                "official": "Islamiska republiken Pakistan",
+                "common": "Pakistan"
             }
         },
         "latlng": [
@@ -26345,6 +27045,10 @@
             "zho": {
                 "official": "\u5df4\u62ff\u9a6c\u5171\u548c\u56fd",
                 "common": "\u5df4\u62ff\u9a6c"
+            },
+            "swe": {
+                "official": "Republiken Panama",
+                "common": "Panama"
             }
         },
         "latlng": [
@@ -26490,6 +27194,10 @@
             "zho": {
                 "official": "\u76ae\u7279\u51ef\u6069\u7fa4\u5c9b",
                 "common": "\u76ae\u7279\u51ef\u6069\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Pitcairn\u00f6arna",
+                "common": "Pitcairn\u00f6arna"
             }
         },
         "latlng": [
@@ -26642,6 +27350,10 @@
             "zho": {
                 "official": "\u79d8\u9c81\u5171\u548c\u56fd",
                 "common": "\u79d8\u9c81"
+            },
+            "swe": {
+                "official": "Republiken Peru",
+                "common": "Peru"
             }
         },
         "latlng": [
@@ -26795,6 +27507,10 @@
             "zho": {
                 "official": "\u83f2\u5f8b\u5bbe\u5171\u548c\u56fd",
                 "common": "\u83f2\u5f8b\u5bbe"
+            },
+            "swe": {
+                "official": "Republiken Filippinerna",
+                "common": "Filippinerna"
             }
         },
         "latlng": [
@@ -26942,6 +27658,10 @@
             "zho": {
                 "official": "\u5e15\u52b3\u5171\u548c\u56fd",
                 "common": "\u5e15\u52b3"
+            },
+            "swe": {
+                "official": "Republiken Palau",
+                "common": "Palau"
             }
         },
         "latlng": [
@@ -27094,6 +27814,10 @@
             "zho": {
                 "official": "\u5df4\u5e03\u4e9a\u65b0\u51e0\u5185\u4e9a",
                 "common": "\u5df4\u5e03\u4e9a\u65b0\u51e0\u5185\u4e9a"
+            },
+            "swe": {
+                "official": "Den oberoende staten Papua Nya Guinea",
+                "common": "Papua Nya Guinea"
             }
         },
         "latlng": [
@@ -27238,6 +27962,10 @@
             "zho": {
                 "official": "\u6ce2\u5170\u5171\u548c\u56fd",
                 "common": "\u6ce2\u5170"
+            },
+            "swe": {
+                "official": "Republiken Polen",
+                "common": "Polen"
             }
         },
         "latlng": [
@@ -27394,6 +28122,10 @@
             "zho": {
                 "official": "\u6ce2\u591a\u9ece\u5404\u8054\u90a6",
                 "common": "\u6ce2\u591a\u9ece\u5404"
+            },
+            "swe": {
+                "official": "Puerto Rico",
+                "common": "Puerto Rico"
             }
         },
         "latlng": [
@@ -27541,6 +28273,10 @@
             "zho": {
                 "official": "\u671d\u9c9c\u4eba\u6c11\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u671d\u9c9c"
+            },
+            "swe": {
+                "official": "Demokratiska Folkrepubliken Korea",
+                "common": "Nordkorea"
             }
         },
         "latlng": [
@@ -27688,6 +28424,10 @@
             "zho": {
                 "official": "\u8461\u8404\u7259\u5171\u548c\u56fd",
                 "common": "\u8461\u8404\u7259"
+            },
+            "swe": {
+                "official": "Republiken Portugal",
+                "common": "Portugal"
             }
         },
         "latlng": [
@@ -27838,6 +28578,10 @@
             "zho": {
                 "official": "\u5df4\u62c9\u572d\u5171\u548c\u56fd",
                 "common": "\u5df4\u62c9\u572d"
+            },
+            "swe": {
+                "official": "Republiken Paraguay",
+                "common": "Paraguay"
             }
         },
         "latlng": [
@@ -27994,6 +28738,10 @@
             "zho": {
                 "official": "\u5df4\u52d2\u65af\u5766\u56fd",
                 "common": "\u5df4\u52d2\u65af\u5766"
+            },
+            "swe": {
+                "official": "Palestina",
+                "common": "Palestina"
             }
         },
         "latlng": [
@@ -28141,6 +28889,10 @@
             "zho": {
                 "official": "\u6cd5\u5c5e\u6ce2\u5229\u5c3c\u897f\u4e9a",
                 "common": "\u6cd5\u5c5e\u6ce2\u5229\u5c3c\u897f\u4e9a"
+            },
+            "swe": {
+                "official": "Franska Polynesien",
+                "common": "Franska Polynesien"
             }
         },
         "latlng": [
@@ -28284,6 +29036,10 @@
             "zho": {
                 "official": "\u5361\u5854\u5c14\u56fd",
                 "common": "\u5361\u5854\u5c14"
+            },
+            "swe": {
+                "official": "Staten Qatar",
+                "common": "Qatar"
             }
         },
         "latlng": [
@@ -28427,6 +29183,10 @@
             "zho": {
                 "official": "\u7559\u5c3c\u65fa\u5c9b",
                 "common": "\u7559\u5c3c\u65fa\u5c9b"
+            },
+            "swe": {
+                "official": "R\u00e9union",
+                "common": "R\u00e9union"
             }
         },
         "latlng": [
@@ -28570,6 +29330,10 @@
             "zho": {
                 "official": "\u7f57\u9a6c\u5c3c\u4e9a",
                 "common": "\u7f57\u9a6c\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Rum\u00e4nien",
+                "common": "Rum\u00e4nien"
             }
         },
         "latlng": [
@@ -28724,6 +29488,10 @@
             "zho": {
                 "official": "\u4fc4\u7f57\u65af\u8054\u90a6",
                 "common": "\u4fc4\u7f57\u65af"
+            },
+            "swe": {
+                "official": "Ryska federationen",
+                "common": "Ryssland"
             }
         },
         "latlng": [
@@ -28892,6 +29660,10 @@
             "zho": {
                 "official": "\u5362\u65fa\u8fbe\u5171\u548c\u56fd",
                 "common": "\u5362\u65fa\u8fbe"
+            },
+            "swe": {
+                "official": "Republiken Rwanda",
+                "common": "Rwanda"
             }
         },
         "latlng": [
@@ -29041,6 +29813,10 @@
             "zho": {
                 "official": "\u6c99\u7279\u963f\u62c9\u4f2f\u738b\u56fd",
                 "common": "\u6c99\u7279\u963f\u62c9\u4f2f"
+            },
+            "swe": {
+                "official": "Kungad\u00f6met Saudiarabien",
+                "common": "Saudiarabien"
             }
         },
         "latlng": [
@@ -29196,6 +29972,10 @@
             "zho": {
                 "official": "\u82cf\u4e39\u5171\u548c\u56fd",
                 "common": "\u82cf\u4e39"
+            },
+            "swe": {
+                "official": "Republiken Sudan",
+                "common": "Sudan"
             }
         },
         "latlng": [
@@ -29346,6 +30126,10 @@
             "zho": {
                 "official": "\u585e\u5185\u52a0\u5c14\u5171\u548c\u56fd",
                 "common": "\u585e\u5185\u52a0\u5c14"
+            },
+            "swe": {
+                "official": "Republiken Senegal",
+                "common": "Senegal"
             }
         },
         "latlng": [
@@ -29508,6 +30292,10 @@
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0646\u06af\u0627\u067e\u0648\u0631",
                 "common": "\u0633\u0646\u06af\u0627\u067e\u0648\u0631"
+            },
+            "swe": {
+                "official": "Republiken Singapore",
+                "common": "Singapore"
             }
         },
         "latlng": [
@@ -29649,6 +30437,10 @@
             "zho": {
                 "official": "\u5357\u4e54\u6cbb\u4e9a\u5c9b\u548c\u5357\u6851\u5a01\u5947\u7fa4\u5c9b",
                 "common": "\u5357\u4e54\u6cbb\u4e9a"
+            },
+            "swe": {
+                "official": "Sydgeorgien",
+                "common": "Sydgeorgien"
             }
         },
         "latlng": [
@@ -29790,6 +30582,10 @@
             "zho": {
                 "official": "\u65af\u74e6\u5c14\u5df4\u7279",
                 "common": "\u65af\u74e6\u5c14\u5df4\u7279"
+            },
+            "swe": {
+                "official": "Svalbard och Jan Mayen",
+                "common": "Svalbard och Jan Mayen"
             }
         },
         "latlng": [
@@ -29930,6 +30726,10 @@
             "zho": {
                 "official": "\u6240\u7f57\u95e8\u7fa4\u5c9b",
                 "common": "\u6240\u7f57\u95e8\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Salomon\u00f6arna",
+                "common": "Salomon\u00f6arna"
             }
         },
         "latlng": [
@@ -30071,6 +30871,10 @@
             "zho": {
                 "official": "\u585e\u62c9\u5229\u6602\u5171\u548c\u56fd",
                 "common": "\u585e\u62c9\u5229\u6602"
+            },
+            "swe": {
+                "official": "Republiken Sierra Leone",
+                "common": "Sierra Leone"
             }
         },
         "latlng": [
@@ -30220,6 +31024,10 @@
             "zho": {
                 "official": "\u8428\u5c14\u74e6\u591a\u5171\u548c\u56fd",
                 "common": "\u8428\u5c14\u74e6\u591a"
+            },
+            "swe": {
+                "official": "Republiken El Salvador",
+                "common": "El Salvador"
             }
         },
         "latlng": [
@@ -30365,6 +31173,10 @@
             "zho": {
                 "official": "\u5723\u9a6c\u529b\u8bfa\u5171\u548c\u56fd",
                 "common": "\u5723\u9a6c\u529b\u8bfa"
+            },
+            "swe": {
+                "official": "Republiken San Marino",
+                "common": "San Marino"
             }
         },
         "latlng": [
@@ -30516,6 +31328,10 @@
             "zho": {
                 "official": "\u7d22\u9a6c\u91cc\u5171\u548c\u56fd",
                 "common": "\u7d22\u9a6c\u91cc"
+            },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Somalia",
+                "common": "Somalia"
             }
         },
         "latlng": [
@@ -30661,6 +31477,10 @@
             "zho": {
                 "official": "\u5723\u76ae\u57c3\u5c14\u548c\u5bc6\u514b\u9686",
                 "common": "\u5723\u76ae\u57c3\u5c14\u548c\u5bc6\u514b\u9686"
+            },
+            "swe": {
+                "official": "Saint-Pierre och Miquelon",
+                "common": "Saint-Pierre och Miquelon"
             }
         },
         "latlng": [
@@ -30806,6 +31626,10 @@
             "zho": {
                 "official": "\u585e\u5c14\u7ef4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u585e\u5c14\u7ef4\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Serbien",
+                "common": "Serbien"
             }
         },
         "latlng": [
@@ -30955,6 +31779,10 @@
             "zho": {
                 "official": "\u5357\u82cf\u4e39\u5171\u548c\u56fd",
                 "common": "\u5357\u82cf\u4e39"
+            },
+            "swe": {
+                "official": "Republiken Sydsudan",
+                "common": "Sydsudan"
             }
         },
         "latlng": [
@@ -31105,6 +31933,10 @@
             "zho": {
                 "official": "\u5723\u591a\u7f8e\u548c\u666e\u6797\u897f\u6bd4\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u5723\u591a\u7f8e\u548c\u666e\u6797\u897f\u6bd4"
+            },
+            "swe": {
+                "official": "Demokratiska republiken S\u00e3o Tom\u00e9 och Pr\u00edncipe",
+                "common": "S\u00e3o Tom\u00e9 och Pr\u00edncipe"
             }
         },
         "latlng": [
@@ -31249,6 +32081,10 @@
             "zho": {
                 "official": "\u82cf\u91cc\u5357\u5171\u548c\u56fd",
                 "common": "\u82cf\u91cc\u5357"
+            },
+            "swe": {
+                "official": "Republiken Surinam",
+                "common": "Surinam"
             }
         },
         "latlng": [
@@ -31395,6 +32231,10 @@
             "zho": {
                 "official": "\u65af\u6d1b\u4f10\u514b\u5171\u548c\u56fd",
                 "common": "\u65af\u6d1b\u4f10\u514b"
+            },
+            "swe": {
+                "official": "Republiken Slovakien",
+                "common": "Slovakien"
             }
         },
         "latlng": [
@@ -31543,6 +32383,10 @@
             "zho": {
                 "official": "\u65af\u6d1b\u6587\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u65af\u6d1b\u6587\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Slovenien",
+                "common": "Slovenien"
             }
         },
         "latlng": [
@@ -31690,6 +32534,10 @@
             "zho": {
                 "official": "\u745e\u5178\u738b\u56fd",
                 "common": "\u745e\u5178"
+            },
+            "swe": {
+                "official": "Konungariket Sverige",
+                "common": "Sverige"
             }
         },
         "latlng": [
@@ -31848,6 +32696,10 @@
             "zho": {
                 "official": "\u65af\u5a01\u58eb\u5170\u738b\u56fd",
                 "common": "\u65af\u5a01\u58eb\u5170"
+            },
+            "swe": {
+                "official": "Konungariket Eswatini",
+                "common": "Swaziland"
             }
         },
         "latlng": [
@@ -32002,6 +32854,10 @@
             "zho": {
                 "official": "\u5723\u9a6c\u4e01\u5c9b",
                 "common": "\u5723\u9a6c\u4e01\u5c9b"
+            },
+            "swe": {
+                "official": "Sint Maarten",
+                "common": "Sint Maarten"
             }
         },
         "latlng": [
@@ -32157,6 +33013,10 @@
             "zho": {
                 "official": "\u585e\u820c\u5c14\u5171\u548c\u56fd",
                 "common": "\u585e\u820c\u5c14"
+            },
+            "swe": {
+                "official": "Republiken Seychellerna",
+                "common": "Seychellerna"
             }
         },
         "latlng": [
@@ -32300,6 +33160,10 @@
             "zho": {
                 "official": "\u53d9\u5229\u4e9a\u963f\u62c9\u4f2f\u5171\u548c\u56fd",
                 "common": "\u53d9\u5229\u4e9a"
+            },
+            "swe": {
+                "official": "Syriska arabiska republiken",
+                "common": "Syrien"
             }
         },
         "latlng": [
@@ -32446,6 +33310,10 @@
             "zho": {
                 "official": "\u7279\u514b\u65af\u548c\u51ef\u79d1\u65af\u7fa4\u5c9b",
                 "common": "\u7279\u514b\u65af\u548c\u51ef\u79d1\u65af\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Turks- och Caicos\u00f6arna",
+                "common": "Turks- och Caicos\u00f6arna"
             }
         },
         "latlng": [
@@ -32598,6 +33466,10 @@
             "zho": {
                 "official": "\u4e4d\u5f97\u5171\u548c\u56fd",
                 "common": "\u4e4d\u5f97"
+            },
+            "swe": {
+                "official": "Republiken Tchad",
+                "common": "Tchad"
             }
         },
         "latlng": [
@@ -32748,6 +33620,10 @@
             "zho": {
                 "official": "\u591a\u54e5\u5171\u548c\u56fd",
                 "common": "\u591a\u54e5"
+            },
+            "swe": {
+                "official": "Republiken Togo",
+                "common": "Togo"
             }
         },
         "latlng": [
@@ -32898,6 +33774,10 @@
             "zho": {
                 "official": "\u6cf0\u738b\u56fd",
                 "common": "\u6cf0\u56fd"
+            },
+            "swe": {
+                "official": "Konungariket Thailand",
+                "common": "Thailand"
             }
         },
         "latlng": [
@@ -33052,6 +33932,10 @@
             "zho": {
                 "official": "\u5854\u5409\u514b\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u5854\u5409\u514b\u65af\u5766"
+            },
+            "swe": {
+                "official": "Republiken Tadzjikistan",
+                "common": "Tadzjikistan"
             }
         },
         "latlng": [
@@ -33207,6 +34091,10 @@
             "zho": {
                 "official": "\u6258\u514b\u52b3",
                 "common": "\u6258\u514b\u52b3"
+            },
+            "swe": {
+                "official": "Tokelau\u00f6arna",
+                "common": "Tokelau\u00f6arna"
             }
         },
         "latlng": [
@@ -33352,6 +34240,10 @@
             "zho": {
                 "official": "\u571f\u5e93\u66fc\u65af\u5766",
                 "common": "\u571f\u5e93\u66fc\u65af\u5766"
+            },
+            "swe": {
+                "official": "Turkmenistan",
+                "common": "Turkmenistan"
             }
         },
         "latlng": [
@@ -33508,6 +34400,10 @@
             "zho": {
                 "official": "\u4e1c\u5e1d\u6c76\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u4e1c\u5e1d\u6c76"
+            },
+            "swe": {
+                "official": "Demokratiska republiken \u00d6sttimor",
+                "common": "\u00d6sttimor a.k.a. Timor-Leste"
             }
         },
         "latlng": [
@@ -33655,6 +34551,10 @@
             "zho": {
                 "official": "\u6c64\u52a0\u738b\u56fd",
                 "common": "\u6c64\u52a0"
+            },
+            "swe": {
+                "official": "Konungariket Tonga",
+                "common": "Tonga"
             }
         },
         "latlng": [
@@ -33796,6 +34696,10 @@
             "zho": {
                 "official": "\u7279\u7acb\u5c3c\u8fbe\u548c\u591a\u5df4\u54e5\u5171\u548c\u56fd",
                 "common": "\u7279\u7acb\u5c3c\u8fbe\u548c\u591a\u5df4\u54e5"
+            },
+            "swe": {
+                "official": "Republiken Trinidad och Tobago",
+                "common": "Trinidad och Tobago"
             }
         },
         "latlng": [
@@ -33938,6 +34842,10 @@
             "zho": {
                 "official": "\u7a81\u5c3c\u65af\u5171\u548c\u56fd",
                 "common": "\u7a81\u5c3c\u65af"
+            },
+            "swe": {
+                "official": "Republiken Tunisien",
+                "common": "Tunisien"
             }
         },
         "latlng": [
@@ -34084,6 +34992,10 @@
             "zho": {
                 "official": "\u571f\u8033\u5176\u5171\u548c\u56fd",
                 "common": "\u571f\u8033\u5176"
+            },
+            "swe": {
+                "official": "Republiken Turkiet",
+                "common": "Turkiet"
             }
         },
         "latlng": [
@@ -34242,6 +35154,10 @@
             "zho": {
                 "official": "\u56fe\u74e6\u5362",
                 "common": "\u56fe\u74e6\u5362"
+            },
+            "swe": {
+                "official": "Tuvalu",
+                "common": "Tuvalu"
             }
         },
         "latlng": [
@@ -34385,6 +35301,10 @@
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 (\u062a\u0627\u0626\u06cc\u0648\u0627\u0646)",
                 "common": "\u062a\u0627\u0626\u06cc\u0648\u0627\u0646"
+            },
+            "swe": {
+                "official": "Republiken Kina",
+                "common": "Taiwan"
             }
         },
         "latlng": [
@@ -34533,6 +35453,10 @@
             "zho": {
                 "official": "\u5766\u6851\u5c3c\u4e9a\u8054\u5408\u5171\u548c\u56fd",
                 "common": "\u5766\u6851\u5c3c\u4e9a"
+            },
+            "swe": {
+                "official": "F\u00f6renade republiken Tanzania",
+                "common": "Tanzania"
             }
         },
         "latlng": [
@@ -34689,6 +35613,10 @@
             "zho": {
                 "official": "\u4e4c\u5e72\u8fbe\u5171\u548c\u56fd",
                 "common": "\u4e4c\u5e72\u8fbe"
+            },
+            "swe": {
+                "official": "Republiken Uganda",
+                "common": "Uganda"
             }
         },
         "latlng": [
@@ -34837,6 +35765,10 @@
             "zho": {
                 "official": "\u4e4c\u514b\u5170",
                 "common": "\u4e4c\u514b\u5170"
+            },
+            "swe": {
+                "official": "Ukraina",
+                "common": "Ukraina"
             }
         },
         "latlng": [
@@ -34985,6 +35917,10 @@
             "zho": {
                 "official": "\u7f8e\u56fd\u672c\u571f\u5916\u5c0f\u5c9b\u5c7f",
                 "common": "\u7f8e\u56fd\u672c\u571f\u5916\u5c0f\u5c9b\u5c7f"
+            },
+            "swe": {
+                "official": "F\u00f6renta staternas mindre \u00f6ar i Oceanien och V\u00e4stindien",
+                "common": "F\u00f6renta staternas mindre \u00f6ar i Oceanien och V\u00e4stindien"
             }
         },
         "latlng": [
@@ -35127,6 +36063,10 @@
             "zho": {
                 "official": "\u4e4c\u62c9\u572d\u4e1c\u5cb8\u5171\u548c\u56fd",
                 "common": "\u4e4c\u62c9\u572d"
+            },
+            "swe": {
+                "official": "Republiken Uruguay",
+                "common": "Uruguay"
             }
         },
         "latlng": [
@@ -35588,6 +36528,10 @@
             "zho": {
                 "official": "\u7f8e\u5229\u575a\u5408\u4f17\u56fd",
                 "common": "\u7f8e\u56fd"
+            },
+            "swe": {
+                "official": "Amerikas f\u00f6renta stater",
+                "common": "USA"
             }
         },
         "latlng": [
@@ -35739,6 +36683,10 @@
             "zho": {
                 "official": "\u4e4c\u5179\u522b\u514b\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u4e4c\u5179\u522b\u514b\u65af\u5766"
+            },
+            "swe": {
+                "official": "Republiken Uzbekistan",
+                "common": "Uzbekistan"
             }
         },
         "latlng": [
@@ -35894,6 +36842,10 @@
             "zho": {
                 "official": "\u68b5\u8482\u5188\u57ce\u56fd",
                 "common": "\u68b5\u8482\u5188"
+            },
+            "swe": {
+                "official": "Vatikanstaten",
+                "common": "Vatikanstaten"
             }
         },
         "latlng": [
@@ -36036,6 +36988,10 @@
             "zho": {
                 "official": "\u5723\u6587\u68ee\u7279\u548c\u683c\u6797\u7eb3\u4e01\u65af",
                 "common": "\u5723\u6587\u68ee\u7279\u548c\u683c\u6797\u7eb3\u4e01\u65af"
+            },
+            "swe": {
+                "official": "Saint Vincent och Grenadinerna",
+                "common": "Saint Vincent och Grenadinerna"
             }
         },
         "latlng": [
@@ -36179,6 +37135,10 @@
             "zho": {
                 "official": "\u59d4\u5185\u745e\u62c9\u73bb\u5229\u74e6\u5c14\u5171\u548c\u56fd",
                 "common": "\u59d4\u5185\u745e\u62c9"
+            },
+            "swe": {
+                "official": "Bolivarianska republiken Venezuela",
+                "common": "Venezuela"
             }
         },
         "latlng": [
@@ -36324,6 +37284,10 @@
             "zho": {
                 "official": "\u82f1\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b",
                 "common": "\u82f1\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Brittiska Jungfru\u00f6arna",
+                "common": "Brittiska Jungfru\u00f6arna"
             }
         },
         "latlng": [
@@ -36465,6 +37429,10 @@
             "zho": {
                 "official": "\u7f8e\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b",
                 "common": "\u7f8e\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Amerikanska Jungfru\u00f6arna",
+                "common": "Amerikanska Jungfru\u00f6arna"
             }
         },
         "latlng": [
@@ -36608,6 +37576,10 @@
             "zho": {
                 "official": "\u8d8a\u5357\u793e\u4f1a\u4e3b\u4e49\u5171\u548c\u56fd",
                 "common": "\u8d8a\u5357"
+            },
+            "swe": {
+                "official": "Socialistiska republiken Vietnam",
+                "common": "Vietnam"
             }
         },
         "latlng": [
@@ -36765,6 +37737,10 @@
             "zho": {
                 "official": "\u74e6\u52aa\u963f\u56fe\u5171\u548c\u56fd",
                 "common": "\u74e6\u52aa\u963f\u56fe"
+            },
+            "swe": {
+                "official": "Republiken Vanuatu",
+                "common": "Vanuatu"
             }
         },
         "latlng": [
@@ -36907,6 +37883,10 @@
             "zho": {
                 "official": "\u74e6\u5229\u65af\u548c\u5bcc\u56fe\u7eb3\u7fa4\u5c9b",
                 "common": "\u74e6\u5229\u65af\u548c\u5bcc\u56fe\u7eb3\u7fa4\u5c9b"
+            },
+            "swe": {
+                "official": "Territoriet Wallis- och Futuna\u00f6arna",
+                "common": "Wallis- och Futuna\u00f6arna"
             }
         },
         "latlng": [
@@ -37054,6 +38034,10 @@
             "zho": {
                 "official": "\u8428\u6469\u4e9a\u72ec\u7acb\u56fd",
                 "common": "\u8428\u6469\u4e9a"
+            },
+            "swe": {
+                "official": "Sj\u00e4lvst\u00e4ndiga staten Samoa",
+                "common": "Samoa"
             }
         },
         "latlng": [
@@ -37196,6 +38180,10 @@
             "zho": {
                 "official": "\u4e5f\u95e8\u5171\u548c\u56fd",
                 "common": "\u4e5f\u95e8"
+            },
+            "swe": {
+                "official": "Republiken Jemen",
+                "common": "Jemen"
             }
         },
         "latlng": [
@@ -37394,6 +38382,10 @@
             "zho": {
                 "official": "\u5357\u975e\u5171\u548c\u56fd",
                 "common": "\u5357\u975e"
+            },
+            "swe": {
+                "official": "Republiken Sydafrika",
+                "common": "Sydafrika"
             }
         },
         "latlng": [
@@ -37542,6 +38534,10 @@
             "zho": {
                 "official": "\u8d5e\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u8d5e\u6bd4\u4e9a"
+            },
+            "swe": {
+                "official": "Republiken Zambia",
+                "common": "Zambia"
             }
         },
         "latlng": [
@@ -37794,6 +38790,10 @@
             "zho": {
                 "official": "\u6d25\u5df4\u5e03\u97e6\u5171\u548c\u56fd",
                 "common": "\u6d25\u5df4\u5e03\u97e6"
+            },
+            "swe": {
+                "official": "Republiken Zimbabwe",
+                "common": "Zimbabwe"
             }
         },
         "latlng": [

--- a/countries.json
+++ b/countries.json
@@ -116,6 +116,10 @@
                 "official": "Aruba",
                 "common": "Aruba"
             },
+            "swe": {
+                "official": "Aruba",
+                "common": "Aruba"
+            },
             "urd": {
                 "official": "\u0627\u0631\u0648\u0628\u0627",
                 "common": "\u0627\u0631\u0648\u0628\u0627"
@@ -123,10 +127,6 @@
             "zho": {
                 "official": "\u963f\u9c81\u5df4",
                 "common": "\u963f\u9c81\u5df4"
-            },
-            "swe": {
-                "official": "Aruba",
-                "common": "Aruba"
             }
         },
         "latlng": [
@@ -275,6 +275,10 @@
                 "official": "Rep\u00fablica Isl\u00e1mica de Afganist\u00e1n",
                 "common": "Afganist\u00e1n"
             },
+            "swe": {
+                "official": "Islamiska republiken Afghanistan",
+                "common": "Afghanistan"
+            },
             "urd": {
                 "official": "\u0627\u0633\u0644\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0641\u063a\u0627\u0646\u0633\u062a\u0627\u0646",
                 "common": "\u0627\u0641\u063a\u0627\u0646\u0633\u062a\u0627\u0646"
@@ -282,10 +286,6 @@
             "zho": {
                 "official": "\u963f\u5bcc\u6c57\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u963f\u5bcc\u6c57"
-            },
-            "swe": {
-                "official": "Islamiska republiken Afghanistan",
-                "common": "Afghanistan"
             }
         },
         "latlng": [
@@ -432,6 +432,10 @@
                 "official": "Rep\u00fablica de Angola",
                 "common": "Angola"
             },
+            "swe": {
+                "official": "Republiken Angola",
+                "common": "Angola"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0646\u06af\u0648\u0644\u06c1",
                 "common": "\u0627\u0646\u06af\u0648\u0644\u06c1"
@@ -439,10 +443,6 @@
             "zho": {
                 "official": "\u5b89\u54e5\u62c9\u5171\u548c\u56fd",
                 "common": "\u5b89\u54e5\u62c9"
-            },
-            "swe": {
-                "official": "Republiken Angola",
-                "common": "Angola"
             }
         },
         "latlng": [
@@ -581,6 +581,10 @@
                 "official": "Anguila",
                 "common": "Anguilla"
             },
+            "swe": {
+                "official": "Anguilla",
+                "common": "Anguilla"
+            },
             "urd": {
                 "official": "\u0627\u06cc\u0646\u06af\u0648\u06cc\u0644\u0627",
                 "common": "\u0627\u06cc\u0646\u06af\u0648\u06cc\u0644\u0627"
@@ -588,10 +592,6 @@
             "zho": {
                 "official": "\u5b89\u572d\u62c9",
                 "common": "\u5b89\u572d\u62c9"
-            },
-            "swe": {
-                "official": "Anguilla",
-                "common": "Anguilla"
             }
         },
         "latlng": [
@@ -728,6 +728,10 @@
                 "official": "Islas \u00c5land",
                 "common": "Alandia"
             },
+            "swe": {
+                "official": "\u00c5land",
+                "common": "\u00c5land"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 \u0627\u0648\u0644\u0646\u062f",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u0627\u0648\u0644\u0646\u062f"
@@ -735,10 +739,6 @@
             "zho": {
                 "official": "\u5965\u5170\u7fa4\u5c9b",
                 "common": "\u5965\u5170\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "\u00c5land",
-                "common": "\u00c5land"
             }
         },
         "latlng": [
@@ -879,6 +879,10 @@
                 "official": "Rep\u00fablica de Albania",
                 "common": "Albania"
             },
+            "swe": {
+                "official": "Republiken Albanien",
+                "common": "Albanien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0644\u0628\u0627\u0646\u06cc\u0627",
                 "common": "\u0627\u0644\u0628\u0627\u0646\u06cc\u0627"
@@ -886,10 +890,6 @@
             "zho": {
                 "official": "\u963f\u5c14\u5df4\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u963f\u5c14\u5df4\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Albanien",
-                "common": "Albanien"
             }
         },
         "latlng": [
@@ -1034,6 +1034,10 @@
                 "official": "Principado de Andorra",
                 "common": "Andorra"
             },
+            "swe": {
+                "official": "Furstend\u00f6met Andorra",
+                "common": "Andorra"
+            },
             "urd": {
                 "official": "\u0627\u0645\u0627\u0631\u0627\u062a\u0650 \u0627\u0646\u0688\u0648\u0631\u0627",
                 "common": "\u0627\u0646\u0688\u0648\u0631\u0627"
@@ -1041,10 +1045,6 @@
             "zho": {
                 "official": "\u5b89\u9053\u5c14\u516c\u56fd",
                 "common": "\u5b89\u9053\u5c14"
-            },
-            "swe": {
-                "official": "Furstend\u00f6met Andorra",
-                "common": "Andorra"
             }
         },
         "latlng": [
@@ -1184,6 +1184,10 @@
                 "official": "Emiratos \u00c1rabes Unidos",
                 "common": "Emiratos \u00c1rabes Unidos"
             },
+            "swe": {
+                "official": "F\u00f6renade Arabemiraten",
+                "common": "F\u00f6renade Arabemiraten"
+            },
             "urd": {
                 "official": "\u0645\u062a\u062d\u062f\u06c1 \u0639\u0631\u0628 \u0627\u0645\u0627\u0631\u0627\u062a",
                 "common": "\u0645\u062a\u062d\u062f\u06c1 \u0639\u0631\u0628 \u0627\u0645\u0627\u0631\u0627\u062a"
@@ -1191,10 +1195,6 @@
             "zho": {
                 "official": "\u963f\u62c9\u4f2f\u8054\u5408\u914b\u957f\u56fd",
                 "common": "\u963f\u62c9\u4f2f\u8054\u5408\u914b\u957f\u56fd"
-            },
-            "swe": {
-                "official": "F\u00f6renade Arabemiraten",
-                "common": "F\u00f6renade Arabemiraten"
             }
         },
         "latlng": [
@@ -1342,6 +1342,10 @@
                 "official": "Rep\u00fablica Argentina",
                 "common": "Argentina"
             },
+            "swe": {
+                "official": "Republiken Argentina",
+                "common": "Argentina"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0631\u062c\u0646\u0679\u0627\u0626\u0646",
                 "common": "\u0627\u0631\u062c\u0646\u0679\u0627\u0626\u0646"
@@ -1349,10 +1353,6 @@
             "zho": {
                 "official": "\u963f\u6839\u5ef7\u5171\u548c\u56fd",
                 "common": "\u963f\u6839\u5ef7"
-            },
-            "swe": {
-                "official": "Republiken Argentina",
-                "common": "Argentina"
             }
         },
         "latlng": [
@@ -1499,6 +1499,10 @@
                 "official": "Rep\u00fablica de Armenia",
                 "common": "Armenia"
             },
+            "swe": {
+                "official": "Republiken Armenien",
+                "common": "Armenien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0622\u0631\u0645\u06cc\u0646\u06cc\u0627",
                 "common": "\u0622\u0631\u0645\u06cc\u0646\u06cc\u0627"
@@ -1506,10 +1510,6 @@
             "zho": {
                 "official": "\u4e9a\u7f8e\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u4e9a\u7f8e\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Armenien",
-                "common": "Armenien"
             }
         },
         "latlng": [
@@ -1656,6 +1656,10 @@
                 "official": "Samoa Americana",
                 "common": "Samoa Americana"
             },
+            "swe": {
+                "official": "Amerikanska Samoa",
+                "common": "Amerikanska Samoa"
+            },
             "urd": {
                 "official": "\u0627\u0645\u0631\u06cc\u06a9\u06cc \u0633\u0645\u0648\u0648\u0627",
                 "common": "\u0627\u0645\u0631\u06cc\u06a9\u06cc \u0633\u0645\u0648\u0648\u0627"
@@ -1663,10 +1667,6 @@
             "zho": {
                 "official": "\u7f8e\u5c5e\u8428\u6469\u4e9a",
                 "common": "\u7f8e\u5c5e\u8428\u6469\u4e9a"
-            },
-            "swe": {
-                "official": "Amerikanska Samoa",
-                "common": "Amerikanska Samoa"
             }
         },
         "latlng": [
@@ -1790,6 +1790,10 @@
                 "official": "Ant\u00e1rtida",
                 "common": "Ant\u00e1rtida"
             },
+            "swe": {
+                "official": "Antarktis",
+                "common": "Antarktis"
+            },
             "urd": {
                 "official": "\u0627\u0646\u0679\u0627\u0631\u06a9\u0679\u06a9\u0627",
                 "common": "\u0627\u0646\u0679\u0627\u0631\u06a9\u0679\u06a9\u0627"
@@ -1797,10 +1801,6 @@
             "zho": {
                 "official": "\u5357\u6781\u6d32",
                 "common": "\u5357\u6781\u6d32"
-            },
-            "swe": {
-                "official": "Antarktis",
-                "common": "Antarktis"
             }
         },
         "latlng": [
@@ -1935,6 +1935,10 @@
                 "official": "Territorio del Franc\u00e9s Tierras australes y ant\u00e1rticas",
                 "common": "Tierras Australes y Ant\u00e1rticas Francesas"
             },
+            "swe": {
+                "official": "Franska syd- och Antarktisterritorierna",
+                "common": "Franska s\u00f6dra territorierna"
+            },
             "urd": {
                 "official": "\u0633\u0631\u0632\u0645\u06cc\u0646\u0650 \u062c\u0646\u0648\u0628\u06cc \u0641\u0631\u0627\u0646\u0633\u06cc\u0633\u06cc\u06c1 \u0648 \u0627\u0646\u0679\u0627\u0631\u06a9\u0679\u06cc\u06a9\u06c1",
                 "common": "\u0633\u0631\u0632\u0645\u06cc\u0646 \u062c\u0646\u0648\u0628\u06cc \u0641\u0631\u0627\u0646\u0633\u06cc\u0633\u06cc\u06c1 \u0648 \u0627\u0646\u0679\u0627\u0631\u06a9\u0679\u06cc\u06a9\u0627"
@@ -1942,10 +1946,6 @@
             "zho": {
                 "official": "\u6cd5\u56fd\u5357\u90e8\u548c\u5357\u6781\u571f\u5730",
                 "common": "\u6cd5\u56fd\u5357\u90e8\u548c\u5357\u6781\u571f\u5730"
-            },
-            "swe": {
-                "official": "Franska syd- och Antarktisterritorierna",
-                "common": "Franska s\u00f6dra territorierna"
             }
         },
         "latlng": [
@@ -2083,6 +2083,10 @@
                 "official": "Antigua y Barbuda",
                 "common": "Antigua y Barbuda"
             },
+            "swe": {
+                "official": "Antigua och Barbuda",
+                "common": "Antigua och Barbuda"
+            },
             "urd": {
                 "official": "\u0627\u06cc\u0646\u0679\u06cc\u06af\u0648\u0627 \u0648 \u0628\u0627\u0631\u0628\u0648\u0688\u0627",
                 "common": "\u0627\u06cc\u0646\u0679\u06cc\u06af\u0648\u0627 \u0648 \u0628\u0627\u0631\u0628\u0648\u0688\u0627"
@@ -2090,10 +2094,6 @@
             "zho": {
                 "official": "\u5b89\u63d0\u74dc\u548c\u5df4\u5e03\u8fbe",
                 "common": "\u5b89\u63d0\u74dc\u548c\u5df4\u5e03\u8fbe"
-            },
-            "swe": {
-                "official": "Antigua och Barbuda",
-                "common": "Antigua och Barbuda"
             }
         },
         "latlng": [
@@ -2231,6 +2231,10 @@
                 "official": "Mancomunidad de Australia",
                 "common": "Australia"
             },
+            "swe": {
+                "official": "Australiska statsf\u00f6rbundet",
+                "common": "Australien"
+            },
             "urd": {
                 "official": "\u062f\u0648\u0644\u062a\u0650 \u0645\u0634\u062a\u0631\u06a9\u06c1 \u0622\u0633\u0679\u0631\u06cc\u0644\u06cc\u0627",
                 "common": "\u0622\u0633\u0679\u0631\u06cc\u0644\u06cc\u0627"
@@ -2238,10 +2242,6 @@
             "zho": {
                 "official": "\u6fb3\u5927\u5229\u4e9a\u8054\u90a6",
                 "common": "\u6fb3\u5927\u5229\u4e9a"
-            },
-            "swe": {
-                "official": "Australiska statsf\u00f6rbundet",
-                "common": "Australien"
             }
         },
         "latlng": [
@@ -2381,6 +2381,10 @@
                 "official": "Rep\u00fablica de Austria",
                 "common": "Austria"
             },
+            "swe": {
+                "official": "Republiken \u00d6sterrike",
+                "common": "\u00d6sterrike"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0622\u0633\u0679\u0631\u06cc\u0627",
                 "common": "\u0622\u0633\u0679\u0631\u06cc\u0627"
@@ -2388,10 +2392,6 @@
             "zho": {
                 "official": "\u5965\u5730\u5229\u5171\u548c\u56fd",
                 "common": "\u5965\u5730\u5229"
-            },
-            "swe": {
-                "official": "Republiken \u00d6sterrike",
-                "common": "\u00d6sterrike"
             }
         },
         "latlng": [
@@ -2545,6 +2545,10 @@
                 "official": "Rep\u00fablica de Azerbaiy\u00e1n",
                 "common": "Azerbaiy\u00e1n"
             },
+            "swe": {
+                "official": "Republiken Azerbajdzjan",
+                "common": "Azerbajdzjan"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0622\u0630\u0631\u0628\u0627\u0626\u06cc\u062c\u0627\u0646",
                 "common": "\u0622\u0630\u0631\u0628\u0627\u0626\u06cc\u062c\u0627\u0646"
@@ -2552,10 +2556,6 @@
             "zho": {
                 "official": "\u963f\u585e\u62dc\u7586\u5171\u548c\u56fd",
                 "common": "\u963f\u585e\u62dc\u7586"
-            },
-            "swe": {
-                "official": "Republiken Azerbajdzjan",
-                "common": "Azerbajdzjan"
             }
         },
         "latlng": [
@@ -2707,6 +2707,10 @@
                 "official": "Rep\u00fablica de Burundi",
                 "common": "Burundi"
             },
+            "swe": {
+                "official": "Republiken Burundi",
+                "common": "Burundi"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u0631\u0648\u0646\u0688\u06cc",
                 "common": "\u0628\u0631\u0648\u0646\u0688\u06cc"
@@ -2714,10 +2718,6 @@
             "zho": {
                 "official": "\u5e03\u9686\u8fea\u5171\u548c\u56fd",
                 "common": "\u5e03\u9686\u8fea"
-            },
-            "swe": {
-                "official": "Republiken Burundi",
-                "common": "Burundi"
             }
         },
         "latlng": [
@@ -2877,6 +2877,10 @@
                 "official": "Reino de B\u00e9lgica",
                 "common": "B\u00e9lgica"
             },
+            "swe": {
+                "official": "Konungariket Belgien",
+                "common": "Belgien"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0628\u0644\u062c\u0626\u06cc\u0645",
                 "common": "\u0628\u0644\u062c\u0626\u06cc\u0645"
@@ -2884,10 +2888,6 @@
             "zho": {
                 "official": "\u6bd4\u5229\u65f6\u738b\u56fd",
                 "common": "\u6bd4\u5229\u65f6"
-            },
-            "swe": {
-                "official": "Konungariket Belgien",
-                "common": "Belgien"
             }
         },
         "latlng": [
@@ -3032,6 +3032,10 @@
                 "official": "Rep\u00fablica de Benin",
                 "common": "Ben\u00edn"
             },
+            "swe": {
+                "official": "Republiken Benin",
+                "common": "Benin"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u06cc\u0646\u0646",
                 "common": "\u0628\u06cc\u0646\u0646"
@@ -3039,10 +3043,6 @@
             "zho": {
                 "official": "\u8d1d\u5b81\u5171\u548c\u56fd",
                 "common": "\u8d1d\u5b81"
-            },
-            "swe": {
-                "official": "Republiken Benin",
-                "common": "Benin"
             }
         },
         "latlng": [
@@ -3185,6 +3185,10 @@
                 "official": "Burkina Faso",
                 "common": "Burkina Faso"
             },
+            "swe": {
+                "official": "Burkina Faso",
+                "common": "Burkina Faso"
+            },
             "urd": {
                 "official": "\u0628\u0631\u06a9\u06cc\u0646\u0627 \u0641\u0627\u0633\u0648",
                 "common": "\u0628\u0631\u06a9\u06cc\u0646\u0627 \u0641\u0627\u0633\u0648"
@@ -3192,10 +3196,6 @@
             "zho": {
                 "official": "\u5e03\u57fa\u7eb3\u6cd5\u7d22",
                 "common": "\u5e03\u57fa\u7eb3\u6cd5\u7d22"
-            },
-            "swe": {
-                "official": "Burkina Faso",
-                "common": "Burkina Faso"
             }
         },
         "latlng": [
@@ -3342,6 +3342,10 @@
                 "official": "Rep\u00fablica Popular de Bangladesh",
                 "common": "Bangladesh"
             },
+            "swe": {
+                "official": "Folkrepubliken Bangladesh",
+                "common": "Bangladesh"
+            },
             "urd": {
                 "official": "\u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u0646\u06af\u0644\u06c1 \u062f\u06cc\u0634",
                 "common": "\u0628\u0646\u06af\u0644\u06c1 \u062f\u06cc\u0634"
@@ -3349,10 +3353,6 @@
             "zho": {
                 "official": "\u5b5f\u52a0\u62c9\u4eba\u6c11\u5171\u548c\u56fd",
                 "common": "\u5b5f\u52a0\u62c9\u56fd"
-            },
-            "swe": {
-                "official": "Folkrepubliken Bangladesh",
-                "common": "Bangladesh"
             }
         },
         "latlng": [
@@ -3495,6 +3495,10 @@
                 "official": "Rep\u00fablica de Bulgaria",
                 "common": "Bulgaria"
             },
+            "swe": {
+                "official": "Republiken Bulgarien",
+                "common": "Bulgarien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u0644\u063a\u0627\u0631\u06cc\u06c1",
                 "common": "\u0628\u0644\u063a\u0627\u0631\u06cc\u06c1"
@@ -3502,10 +3506,6 @@
             "zho": {
                 "official": "\u4fdd\u52a0\u5229\u4e9a\u5171\u548c\u56fd",
                 "common": "\u4fdd\u52a0\u5229\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Bulgarien",
-                "common": "Bulgarien"
             }
         },
         "latlng": [
@@ -3651,6 +3651,10 @@
                 "official": "Reino de Bahrein",
                 "common": "Bahrein"
             },
+            "swe": {
+                "official": "Konungariket Bahrain",
+                "common": "Bahrain"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0628\u062d\u0631\u06cc\u0646",
                 "common": "\u0628\u062d\u0631\u06cc\u0646"
@@ -3658,10 +3662,6 @@
             "zho": {
                 "official": "\u5df4\u6797\u738b\u56fd",
                 "common": "\u5df4\u6797"
-            },
-            "swe": {
-                "official": "Konungariket Bahrain",
-                "common": "Bahrain"
             }
         },
         "latlng": [
@@ -3804,6 +3804,10 @@
                 "official": "Commonwealth de las Bahamas",
                 "common": "Bahamas"
             },
+            "swe": {
+                "official": "Samv\u00e4ldet Bahamas",
+                "common": "Bahamas"
+            },
             "urd": {
                 "official": "\u062f\u0648\u0644\u062a\u0650 \u0645\u0634\u062a\u0631\u06a9\u06c1 \u0628\u06c1\u0627\u0645\u0627\u0633",
                 "common": "\u0628\u06c1\u0627\u0645\u0627\u0633"
@@ -3811,10 +3815,6 @@
             "zho": {
                 "official": "\u5df4\u54c8\u9a6c\u8054\u90a6",
                 "common": "\u5df4\u54c8\u9a6c"
-            },
-            "swe": {
-                "official": "Samv\u00e4ldet Bahamas",
-                "common": "Bahamas"
             }
         },
         "latlng": [
@@ -3964,6 +3964,10 @@
                 "official": "Bosnia y Herzegovina",
                 "common": "Bosnia y Herzegovina"
             },
+            "swe": {
+                "official": "Bosnien och Hercegovina",
+                "common": "Bosnien och Hercegovina"
+            },
             "urd": {
                 "official": "\u0628\u0648\u0633\u0646\u06cc\u0627 \u0648 \u06c1\u0631\u0632\u06cc\u06af\u0648\u0648\u06cc\u0646\u0627",
                 "common": "\u0628\u0648\u0633\u0646\u06cc\u0627 \u0648 \u06c1\u0631\u0632\u06cc\u06af\u0648\u0648\u06cc\u0646\u0627"
@@ -3971,10 +3975,6 @@
             "zho": {
                 "official": "\u6ce2\u65af\u5c3c\u4e9a\u548c\u9ed1\u585e\u54e5\u7ef4\u90a3",
                 "common": "\u6ce2\u65af\u5c3c\u4e9a\u548c\u9ed1\u585e\u54e5\u7ef4\u90a3"
-            },
-            "swe": {
-                "official": "Bosnien och Hercegovina",
-                "common": "Bosnien och Hercegovina"
             }
         },
         "latlng": [
@@ -4115,6 +4115,10 @@
                 "official": "Colectividad de San Barth\u00e9lemy",
                 "common": "San Bartolom\u00e9"
             },
+            "swe": {
+                "official": "Saint-Barth\u00e9lemy",
+                "common": "Saint-Barth\u00e9lemy"
+            },
             "urd": {
                 "official": "\u0633\u06cc\u0646\u0679 \u0628\u0627\u0631\u062a\u06be\u06cc\u0645\u0644\u06d2",
                 "common": "\u0633\u06cc\u0646\u0679 \u0628\u0627\u0631\u062a\u06be\u06cc\u0645\u0644\u06d2"
@@ -4122,10 +4126,6 @@
             "zho": {
                 "official": "\u5723\u5df4\u6cf0\u52d2\u7c73\u96c6\u4f53",
                 "common": "\u5723\u5df4\u6cf0\u52d2\u7c73"
-            },
-            "swe": {
-                "official": "Saint-Barth\u00e9lemy",
-                "common": "Saint-Barth\u00e9lemy"
             }
         },
         "latlng": [
@@ -4266,6 +4266,10 @@
                 "official": "Santa Elena, Ascensi\u00f3n y Trist\u00e1n de Acu\u00f1a",
                 "common": "Santa Elena, Ascensi\u00f3n y Trist\u00e1n de Acu\u00f1a"
             },
+            "swe": {
+                "official": "Sankta Helena",
+                "common": "Sankta Helena"
+            },
             "urd": {
                 "official": "\u0633\u06cc\u0646\u0679 \u06c1\u0644\u06cc\u0646\u0627\u060c \u0627\u0633\u06cc\u0646\u0634\u0646 \u0648 \u062a\u0631\u0633\u0679\u0627\u0646 \u062f\u0627 \u06a9\u0648\u0646\u06cc\u0627",
                 "common": "\u0633\u06cc\u0646\u0679 \u06c1\u0644\u06cc\u0646\u0627\u060c \u0627\u0633\u06cc\u0646\u0634\u0646 \u0648 \u062a\u0631\u0633\u0679\u0627\u0646 \u062f\u0627 \u06a9\u0648\u0646\u06cc\u0627"
@@ -4273,10 +4277,6 @@
             "zho": {
                 "official": "\u5723\u8d6b\u52d2\u62ff\u3001\u963f\u68ee\u677e\u548c\u7279\u91cc\u65af\u5766-\u8fbe\u5e93\u5c3c\u4e9a",
                 "common": "\u5723\u8d6b\u52d2\u62ff\u3001\u963f\u68ee\u677e\u548c\u7279\u91cc\u65af\u5766-\u8fbe\u5e93\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Sankta Helena",
-                "common": "Sankta Helena"
             }
         },
         "latlng": [
@@ -4423,6 +4423,10 @@
                 "official": "Rep\u00fablica de Belar\u00fas",
                 "common": "Bielorrusia"
             },
+            "swe": {
+                "official": "Republiken Vitryssland",
+                "common": "Belarus"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u06cc\u0644\u0627\u0631\u0648\u0633",
                 "common": "\u0628\u06cc\u0644\u0627\u0631\u0648\u0633"
@@ -4430,10 +4434,6 @@
             "zho": {
                 "official": "\u767d\u4fc4\u7f57\u65af\u5171\u548c\u56fd",
                 "common": "\u767d\u4fc4\u7f57\u65af"
-            },
-            "swe": {
-                "official": "Republiken Vitryssland",
-                "common": "Belarus"
             }
         },
         "latlng": [
@@ -4587,6 +4587,10 @@
                 "official": "Belice",
                 "common": "Belice"
             },
+            "swe": {
+                "official": "Belize",
+                "common": "Belize"
+            },
             "urd": {
                 "official": "\u0628\u06cc\u0644\u06cc\u0632",
                 "common": "\u0628\u06cc\u0644\u06cc\u0632"
@@ -4594,10 +4598,6 @@
             "zho": {
                 "official": "\u4f2f\u5229\u5179",
                 "common": "\u4f2f\u5229\u5179"
-            },
-            "swe": {
-                "official": "Belize",
-                "common": "Belize"
             }
         },
         "latlng": [
@@ -4741,6 +4741,10 @@
                 "official": "Bermuda",
                 "common": "Bermudas"
             },
+            "swe": {
+                "official": "Bermuda",
+                "common": "Bermuda"
+            },
             "urd": {
                 "official": "\u0628\u0631\u0645\u0648\u062f\u0627",
                 "common": "\u0628\u0631\u0645\u0648\u062f\u0627"
@@ -4748,10 +4752,6 @@
             "zho": {
                 "official": "\u767e\u6155\u5927",
                 "common": "\u767e\u6155\u5927"
-            },
-            "swe": {
-                "official": "Bermuda",
-                "common": "Bermuda"
             }
         },
         "latlng": [
@@ -4912,6 +4912,10 @@
                 "official": "Estado Plurinacional de Bolivia",
                 "common": "Bolivia"
             },
+            "swe": {
+                "official": "M\u00e5ngnationella staten Bolivia",
+                "common": "Bolivia"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u0648\u0644\u06cc\u0648\u06cc\u0627",
                 "common": "\u0628\u0648\u0644\u06cc\u0648\u06cc\u0627"
@@ -4919,10 +4923,6 @@
             "zho": {
                 "official": "\u591a\u6c11\u65cf\u73bb\u5229\u7ef4\u4e9a\u56fd",
                 "common": "\u73bb\u5229\u7ef4\u4e9a"
-            },
-            "swe": {
-                "official": "M\u00e5ngnationella staten Bolivia",
-                "common": "Bolivia"
             }
         },
         "latlng": [
@@ -5067,6 +5067,10 @@
                 "official": "Bonaire, San Eustaquio y Saba",
                 "common": "Caribe Neerland\u00e9s"
             },
+            "swe": {
+                "official": "Bonaire, Sint Eustatius and Saba",
+                "common": "Karibiska Nederl\u00e4nderna"
+            },
             "urd": {
                 "official": "\u0628\u0648\u0646\u0627\u06cc\u0631\u060c \u0633\u06cc\u0646\u0679 \u0627\u06cc\u0648\u0633\u0679\u0627\u0626\u06cc\u0633 \u0627\u0648\u0631 \u0633\u0627\u0628\u0627",
                 "common": "\u06a9\u06cc\u0631\u06cc\u0628\u06cc\u0646 \u0646\u06cc\u062f\u0631\u0644\u06cc\u0646\u0688\u0632"
@@ -5074,10 +5078,6 @@
             "zho": {
                 "official": "\u8377\u862d\u52a0\u52d2\u6bd4\u5340",
                 "common": "\u8377\u862d\u52a0\u52d2\u6bd4\u5340"
-            },
-            "swe": {
-                "official": "Bonaire, Sint Eustatius and Saba",
-                "common": "Karibiska Nederl\u00e4nderna"
             }
         },
         "latlng": [
@@ -5218,6 +5218,10 @@
                 "official": "Rep\u00fablica Federativa del Brasil",
                 "common": "Brasil"
             },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Brasilien",
+                "common": "Brasilien"
+            },
             "urd": {
                 "official": "\u0648\u0641\u0627\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u0631\u0627\u0632\u06cc\u0644",
                 "common": "\u0628\u0631\u0627\u0632\u06cc\u0644"
@@ -5225,10 +5229,6 @@
             "zho": {
                 "official": "\u5df4\u897f\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u5df4\u897f"
-            },
-            "swe": {
-                "official": "F\u00f6rbundsrepubliken Brasilien",
-                "common": "Brasilien"
             }
         },
         "latlng": [
@@ -5377,6 +5377,10 @@
                 "official": "Barbados",
                 "common": "Barbados"
             },
+            "swe": {
+                "official": "Barbados",
+                "common": "Barbados"
+            },
             "urd": {
                 "official": "\u0628\u0627\u0631\u0628\u0627\u0688\u0648\u0633",
                 "common": "\u0628\u0627\u0631\u0628\u0627\u0688\u0648\u0633"
@@ -5384,10 +5388,6 @@
             "zho": {
                 "official": "\u5df4\u5df4\u591a\u65af",
                 "common": "\u5df4\u5df4\u591a\u65af"
-            },
-            "swe": {
-                "official": "Barbados",
-                "common": "Barbados"
             }
         },
         "latlng": [
@@ -5532,6 +5532,10 @@
                 "official": "Naci\u00f3n de Brunei, Morada de la Paz",
                 "common": "Brunei"
             },
+            "swe": {
+                "official": "Brunei Darussalam",
+                "common": "Brunei"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u0650 \u0628\u0631\u0648\u0646\u0627\u0626\u06cc \u062f\u0627\u0631\u0627\u0644\u0633\u0644\u0627\u0645",
                 "common": "\u0628\u0631\u0648\u0646\u0627\u0626\u06cc"
@@ -5539,10 +5543,6 @@
             "zho": {
                 "official": "\u6587\u83b1\u548c\u5e73\u4e4b\u56fd",
                 "common": "\u6587\u83b1"
-            },
-            "swe": {
-                "official": "Brunei Darussalam",
-                "common": "Brunei"
             }
         },
         "latlng": [
@@ -5687,6 +5687,10 @@
                 "official": "Reino de But\u00e1n",
                 "common": "But\u00e1n"
             },
+            "swe": {
+                "official": "Konungariket Bhutan",
+                "common": "Bhutan"
+            },
             "urd": {
                 "official": "\u0633\u0644\u0637\u0646\u062a \u0628\u06be\u0648\u0679\u0627\u0646",
                 "common": "\u0628\u06be\u0648\u0679\u0627\u0646"
@@ -5694,10 +5698,6 @@
             "zho": {
                 "official": "\u4e0d\u4e39\u738b\u56fd",
                 "common": "\u4e0d\u4e39"
-            },
-            "swe": {
-                "official": "Konungariket Bhutan",
-                "common": "Bhutan"
             }
         },
         "latlng": [
@@ -5831,6 +5831,10 @@
                 "official": "Isla Bouvet",
                 "common": "Isla Bouvet"
             },
+            "swe": {
+                "official": "Bouvet\u00f6n",
+                "common": "Bouvet\u00f6n"
+            },
             "urd": {
                 "official": "\u062c\u0632\u06cc\u0631\u06c1 \u0628\u0648\u0648\u06c1",
                 "common": "\u062c\u0632\u06cc\u0631\u06c1 \u0628\u0648\u0648\u06c1"
@@ -5838,10 +5842,6 @@
             "zho": {
                 "official": "\u5e03\u7ef4\u5c9b",
                 "common": "\u5e03\u7ef4\u5c9b"
-            },
-            "swe": {
-                "official": "Bouvet\u00f6n",
-                "common": "Bouvet\u00f6n"
             }
         },
         "latlng": [
@@ -5982,6 +5982,10 @@
                 "official": "Rep\u00fablica de Botswana",
                 "common": "Botswana"
             },
+            "swe": {
+                "official": "Republiken Botswana",
+                "common": "Botswana"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u0648\u0679\u0633\u0648\u0627\u0646\u0627",
                 "common": "\u0628\u0648\u0679\u0633\u0648\u0627\u0646\u0627"
@@ -5989,10 +5993,6 @@
             "zho": {
                 "official": "\u535a\u8328\u74e6\u7eb3\u5171\u548c\u56fd",
                 "common": "\u535a\u8328\u74e6\u7eb3"
-            },
-            "swe": {
-                "official": "Republiken Botswana",
-                "common": "Botswana"
             }
         },
         "latlng": [
@@ -6142,6 +6142,10 @@
                 "official": "Rep\u00fablica Centroafricana",
                 "common": "Rep\u00fablica Centroafricana"
             },
+            "swe": {
+                "official": "Centralafrikanska republiken",
+                "common": "Centralafrikanska republiken"
+            },
             "urd": {
                 "official": "\u0648\u0633\u0637\u06cc \u0627\u0641\u0631\u06cc\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1",
                 "common": "\u0648\u0633\u0637\u06cc \u0627\u0641\u0631\u06cc\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1"
@@ -6149,10 +6153,6 @@
             "zho": {
                 "official": "\u4e2d\u975e\u5171\u548c\u56fd",
                 "common": "\u4e2d\u975e\u5171\u548c\u56fd"
-            },
-            "swe": {
-                "official": "Centralafrikanska republiken",
-                "common": "Centralafrikanska republiken"
             }
         },
         "latlng": [
@@ -6302,6 +6302,10 @@
                 "official": "Canad\u00e1",
                 "common": "Canad\u00e1"
             },
+            "swe": {
+                "official": "Kanada",
+                "common": "Kanada"
+            },
             "urd": {
                 "official": "\u06a9\u06cc\u0646\u06cc\u0688\u0627",
                 "common": "\u06a9\u06cc\u0646\u06cc\u0688\u0627"
@@ -6309,10 +6313,6 @@
             "zho": {
                 "official": "\u52a0\u62ff\u5927",
                 "common": "\u52a0\u62ff\u5927"
-            },
-            "swe": {
-                "official": "Kanada",
-                "common": "Kanada"
             }
         },
         "latlng": [
@@ -6454,6 +6454,10 @@
                 "official": "Territorio de los (Keeling) Islas Cocos",
                 "common": "Islas Cocos o Islas Keeling"
             },
+            "swe": {
+                "official": "Kokos\u00f6arna",
+                "common": "Kokos\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 (\u06a9\u06cc\u0644\u0646\u06af) \u06a9\u0648\u06a9\u0648\u0633",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u06a9\u0648\u06a9\u0648\u0633"
@@ -6461,10 +6465,6 @@
             "zho": {
                 "official": "\u79d1\u79d1\u65af",
                 "common": "\u79d1\u79d1\u65af"
-            },
-            "swe": {
-                "official": "Kokos\u00f6arna",
-                "common": "Kokos\u00f6arna"
             }
         },
         "latlng": [
@@ -6618,6 +6618,10 @@
                 "official": "Confederaci\u00f3n Suiza",
                 "common": "Suiza"
             },
+            "swe": {
+                "official": "Schweiziska edsf\u00f6rbundet",
+                "common": "Schweiz"
+            },
             "urd": {
                 "official": "\u0633\u0648\u0626\u06cc\u0633  \u0645\u062a\u062d\u062f\u06c1",
                 "common": "\u0633\u0648\u06cc\u0679\u0630\u0631\u0644\u06cc\u0646\u0688"
@@ -6625,10 +6629,6 @@
             "zho": {
                 "official": "\u745e\u58eb\u8054\u90a6",
                 "common": "\u745e\u58eb"
-            },
-            "swe": {
-                "official": "Schweiziska edsf\u00f6rbundet",
-                "common": "Schweiz"
             }
         },
         "latlng": [
@@ -6774,6 +6774,10 @@
                 "official": "Rep\u00fablica de Chile",
                 "common": "Chile"
             },
+            "swe": {
+                "official": "Republiken Chile",
+                "common": "Chile"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u0644\u06cc",
                 "common": "\u0686\u0644\u06cc"
@@ -6781,10 +6785,6 @@
             "zho": {
                 "official": "\u667a\u5229\u5171\u548c\u56fd",
                 "common": "\u667a\u5229"
-            },
-            "swe": {
-                "official": "Republiken Chile",
-                "common": "Chile"
             }
         },
         "latlng": [
@@ -6936,13 +6936,13 @@
                 "official": "Rep\u00fablica Popular de China",
                 "common": "China"
             },
-            "urd": {
-                "official": "\u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646",
-                "common": "\u0686\u06cc\u0646"
-            },
             "swe": {
                 "official": "Folkrepubliken Kina",
                 "common": "Kina"
+            },
+            "urd": {
+                "official": "\u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646",
+                "common": "\u0686\u06cc\u0646"
             }
         },
         "latlng": [
@@ -7097,6 +7097,10 @@
                 "official": "Rep\u00fablica de C\u00f4te d'Ivoire",
                 "common": "Costa de Marfil"
             },
+            "swe": {
+                "official": "Republiken Elfenbenskusten",
+                "common": "Elfenbenskusten"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0648\u062a \u062f\u06cc\u0648\u0627\u063a",
                 "common": "\u0622\u0626\u06cc\u0648\u0631\u06cc \u06a9\u0648\u0633\u0679"
@@ -7104,10 +7108,6 @@
             "zho": {
                 "official": "\u79d1\u7279\u8fea\u74e6\u5171\u548c\u56fd",
                 "common": "\u79d1\u7279\u8fea\u74e6"
-            },
-            "swe": {
-                "official": "Republiken Elfenbenskusten",
-                "common": "Elfenbenskusten"
             }
         },
         "latlng": [
@@ -7258,6 +7258,10 @@
                 "official": "Rep\u00fablica de Camer\u00fan",
                 "common": "Camer\u00fan"
             },
+            "swe": {
+                "official": "Republiken Kamerun",
+                "common": "Kamerun"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u06cc\u0645\u0631\u0648\u0646",
                 "common": "\u06a9\u06cc\u0645\u0631\u0648\u0646"
@@ -7265,10 +7269,6 @@
             "zho": {
                 "official": "\u5580\u9ea6\u9686\u5171\u548c\u56fd",
                 "common": "\u5580\u9ea6\u9686"
-            },
-            "swe": {
-                "official": "Republiken Kamerun",
-                "common": "Kamerun"
             }
         },
         "latlng": [
@@ -7437,6 +7437,10 @@
                 "official": "Rep\u00fablica Democr\u00e1tica del Congo",
                 "common": "Congo (Rep. Dem.)"
             },
+            "swe": {
+                "official": "Demokratiska republiken Kongo",
+                "common": "Kongo-Kinshasa"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0627\u0646\u06af\u0648",
                 "common": "\n\u06a9\u0627\u0646\u06af\u0648"
@@ -7444,10 +7448,6 @@
             "zho": {
                 "official": "\u521a\u679c\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u6c11\u4e3b\u521a\u679c"
-            },
-            "swe": {
-                "official": "Demokratiska republiken Kongo",
-                "common": "Kongo-Kinshasa"
             }
         },
         "latlng": [
@@ -7607,6 +7607,10 @@
                 "official": "Rep\u00fablica del Congo",
                 "common": "Congo"
             },
+            "swe": {
+                "official": "Republiken Kongo",
+                "common": "Kongo-Brazzaville"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0627\u0646\u06af\u0648",
                 "common": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0627\u0646\u06af\u0648"
@@ -7614,10 +7618,6 @@
             "zho": {
                 "official": "\u521a\u679c\u5171\u548c\u56fd",
                 "common": "\u521a\u679c"
-            },
-            "swe": {
-                "official": "Republiken Kongo",
-                "common": "Kongo-Brazzaville"
             }
         },
         "latlng": [
@@ -7771,6 +7771,10 @@
                 "official": "Islas Cook",
                 "common": "Islas Cook"
             },
+            "swe": {
+                "official": "Cook\u00f6arna",
+                "common": "Cook\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 \u06a9\u06a9",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u06a9\u06a9"
@@ -7778,10 +7782,6 @@
             "zho": {
                 "official": "\u5e93\u514b\u7fa4\u5c9b",
                 "common": "\u5e93\u514b\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Cook\u00f6arna",
-                "common": "Cook\u00f6arna"
             }
         },
         "latlng": [
@@ -7921,6 +7921,10 @@
                 "official": "Rep\u00fablica de Colombia",
                 "common": "Colombia"
             },
+            "swe": {
+                "official": "Republiken Colombia",
+                "common": "Colombia"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0648\u0644\u0645\u0628\u06cc\u0627",
                 "common": "\u06a9\u0648\u0644\u0645\u0628\u06cc\u0627"
@@ -7928,10 +7932,6 @@
             "zho": {
                 "official": "\u54e5\u4f26\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u54e5\u4f26\u6bd4\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Colombia",
-                "common": "Colombia"
             }
         },
         "latlng": [
@@ -8089,6 +8089,10 @@
                 "official": "Uni\u00f3n de las Comoras",
                 "common": "Comoras"
             },
+            "swe": {
+                "official": "Unionen Komorerna",
+                "common": "Komorerna"
+            },
             "urd": {
                 "official": "\u0627\u062a\u062d\u0627\u062f \u0627\u0644\u0642\u0645\u0631\u06cc",
                 "common": "\u0627\u0644\u0642\u0645\u0631\u06cc"
@@ -8096,10 +8100,6 @@
             "zho": {
                 "official": "\u79d1\u6469\u7f57\u8054\u76df",
                 "common": "\u79d1\u6469\u7f57"
-            },
-            "swe": {
-                "official": "Unionen Komorerna",
-                "common": "Komorerna"
             }
         },
         "latlng": [
@@ -8239,6 +8239,10 @@
                 "official": "Rep\u00fablica de Cabo Verde",
                 "common": "Cabo Verde"
             },
+            "swe": {
+                "official": "Republiken Kap Verde",
+                "common": "Kap Verde"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u06cc\u067e \u0648\u0631\u0688\u06cc",
                 "common": "\u06a9\u06cc\u067e \u0648\u0631\u0688\u06cc"
@@ -8246,10 +8250,6 @@
             "zho": {
                 "official": "\u4f5b\u5f97\u89d2\u5171\u548c\u56fd",
                 "common": "\u4f5b\u5f97\u89d2"
-            },
-            "swe": {
-                "official": "Republiken Kap Verde",
-                "common": "Kap Verde"
             }
         },
         "latlng": [
@@ -8389,6 +8389,10 @@
                 "official": "Rep\u00fablica de Costa Rica",
                 "common": "Costa Rica"
             },
+            "swe": {
+                "official": "Republiken Costa Rica",
+                "common": "Costa Rica"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0648\u0633\u0679\u0627\u0631\u06cc\u06a9\u0627",
                 "common": "\u06a9\u0648\u0633\u0679\u0627\u0631\u06cc\u06a9\u0627"
@@ -8396,10 +8400,6 @@
             "zho": {
                 "official": "\u54e5\u65af\u8fbe\u9ece\u52a0\u5171\u548c\u56fd",
                 "common": "\u54e5\u65af\u8fbe\u9ece\u52a0"
-            },
-            "swe": {
-                "official": "Republiken Costa Rica",
-                "common": "Costa Rica"
             }
         },
         "latlng": [
@@ -8546,6 +8546,10 @@
                 "official": "Rep\u00fablica de Cuba",
                 "common": "Cuba"
             },
+            "swe": {
+                "official": "Republiken Kuba",
+                "common": "Kuba"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u06cc\u0648\u0628\u0627",
                 "common": "\u06a9\u06cc\u0648\u0628\u0627"
@@ -8553,10 +8557,6 @@
             "zho": {
                 "official": "\u53e4\u5df4\u5171\u548c\u56fd",
                 "common": "\u53e4\u5df4"
-            },
-            "swe": {
-                "official": "Republiken Kuba",
-                "common": "Kuba"
             }
         },
         "latlng": [
@@ -8697,6 +8697,10 @@
                 "official": "Pa\u00eds de Curazao",
                 "common": "Curazao"
             },
+            "swe": {
+                "official": "Cura\u00e7ao",
+                "common": "Cura\u00e7ao"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u06a9\u06cc\u0648\u0631\u0627\u0633\u0627\u0624",
                 "common": "\u06a9\u06cc\u0648\u0631\u0627\u0633\u0627\u0624"
@@ -8704,10 +8708,6 @@
             "zho": {
                 "official": "\u5e93\u62c9\u7d22",
                 "common": "\u5e93\u62c9\u7d22"
-            },
-            "swe": {
-                "official": "Cura\u00e7ao",
-                "common": "Cura\u00e7ao"
             }
         },
         "latlng": [
@@ -8846,6 +8846,10 @@
                 "official": "Territorio de la Isla de Navidad",
                 "common": "Isla de Navidad"
             },
+            "swe": {
+                "official": "Jul\u00f6n",
+                "common": "Jul\u00f6n"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u0650 \u062c\u0632\u06cc\u0631\u06c1 \u06a9\u0631\u0633\u0645\u0633",
                 "common": "\u062c\u0632\u06cc\u0631\u06c1 \u06a9\u0631\u0633\u0645\u0633"
@@ -8853,10 +8857,6 @@
             "zho": {
                 "official": "\u5723\u8bde\u5c9b",
                 "common": "\u5723\u8bde\u5c9b"
-            },
-            "swe": {
-                "official": "Jul\u00f6n",
-                "common": "Jul\u00f6n"
             }
         },
         "latlng": [
@@ -8994,6 +8994,10 @@
                 "official": "Islas Caim\u00e1n",
                 "common": "Islas Caim\u00e1n"
             },
+            "swe": {
+                "official": "Cayman\u00f6arna",
+                "common": "Cayman\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 \u06a9\u06cc\u0645\u06cc\u0646",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u06a9\u06cc\u0645\u06cc\u0646"
@@ -9001,10 +9005,6 @@
             "zho": {
                 "official": "\u5f00\u66fc\u7fa4\u5c9b",
                 "common": "\u5f00\u66fc\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Cayman\u00f6arna",
-                "common": "Cayman\u00f6arna"
             }
         },
         "latlng": [
@@ -9152,6 +9152,10 @@
                 "official": "Rep\u00fablica de Chipre",
                 "common": "Chipre"
             },
+            "swe": {
+                "official": "Republiken Cypern",
+                "common": "Cypern"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0642\u0628\u0631\u0635",
                 "common": "\u0642\u0628\u0631\u0635"
@@ -9159,10 +9163,6 @@
             "zho": {
                 "official": "\u585e\u6d66\u8def\u65af\u5171\u548c\u56fd",
                 "common": "\u585e\u6d66\u8def\u65af"
-            },
-            "swe": {
-                "official": "Republiken Cypern",
-                "common": "Cypern"
             }
         },
         "latlng": [
@@ -9307,6 +9307,10 @@
                 "official": "Rep\u00fablica Checa",
                 "common": "Chequia"
             },
+            "swe": {
+                "official": "Republiken Tjeckien",
+                "common": "Tjeckien"
+            },
             "urd": {
                 "official": "\u0686\u064a\u06a9 \u062c\u0645\u06c1\u0648\u0631\u064a\u06c1",
                 "common": "\u0686\u064a\u06a9"
@@ -9314,10 +9318,6 @@
             "zho": {
                 "official": "\u6377\u514b\u5171\u548c\u56fd",
                 "common": "\u6377\u514b"
-            },
-            "swe": {
-                "official": "Republiken Tjeckien",
-                "common": "Tjeckien"
             }
         },
         "latlng": [
@@ -9458,6 +9458,10 @@
                 "official": "Rep\u00fablica Federal de Alemania",
                 "common": "Alemania"
             },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Tyskland",
+                "common": "Tyskland"
+            },
             "urd": {
                 "official": "\u0648\u0641\u0627\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062c\u0631\u0645\u0646\u06cc",
                 "common": "\u062c\u0631\u0645\u0646\u06cc"
@@ -9465,10 +9469,6 @@
             "zho": {
                 "official": "\u5fb7\u610f\u5fd7\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u5fb7\u56fd"
-            },
-            "swe": {
-                "official": "F\u00f6rbundsrepubliken Tyskland",
-                "common": "Tyskland"
             }
         },
         "latlng": [
@@ -9627,6 +9627,10 @@
                 "official": "Rep\u00fablica de Djibouti",
                 "common": "Djibouti"
             },
+            "swe": {
+                "official": "Republiken Djibouti",
+                "common": "Djibouti"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062c\u0628\u0648\u062a\u06cc",
                 "common": "\u062c\u0628\u0648\u062a\u06cc"
@@ -9634,10 +9638,6 @@
             "zho": {
                 "official": "\u5409\u5e03\u63d0\u5171\u548c\u56fd",
                 "common": "\u5409\u5e03\u63d0"
-            },
-            "swe": {
-                "official": "Republiken Djibouti",
-                "common": "Djibouti"
             }
         },
         "latlng": [
@@ -9782,6 +9782,10 @@
                 "official": "Mancomunidad de Dominica",
                 "common": "Dominica"
             },
+            "swe": {
+                "official": "Samv\u00e4ldet Dominica",
+                "common": "Dominica"
+            },
             "urd": {
                 "official": "\u062f\u0648\u0644\u062a\u0650 \u0645\u0634\u062a\u0631\u06a9\u06c1 \u0688\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0627",
                 "common": "\u0688\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0627"
@@ -9789,10 +9793,6 @@
             "zho": {
                 "official": "\u591a\u7c73\u5c3c\u52a0\u5171\u548c\u56fd",
                 "common": "\u591a\u7c73\u5c3c\u52a0"
-            },
-            "swe": {
-                "official": "Samv\u00e4ldet Dominica",
-                "common": "Dominica"
             }
         },
         "latlng": [
@@ -9933,6 +9933,10 @@
                 "official": "Reino de Dinamarca",
                 "common": "Dinamarca"
             },
+            "swe": {
+                "official": "Konungariket Danmark",
+                "common": "Danmark"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0688\u0646\u0645\u0627\u0631\u06a9",
                 "common": "\u0688\u0646\u0645\u0627\u0631\u06a9"
@@ -9940,10 +9944,6 @@
             "zho": {
                 "official": "\u4e39\u9ea6\u738b\u56fd",
                 "common": "\u4e39\u9ea6"
-            },
-            "swe": {
-                "official": "Konungariket Danmark",
-                "common": "Danmark"
             }
         },
         "latlng": [
@@ -10085,6 +10085,10 @@
                 "official": "Rep\u00fablica Dominicana",
                 "common": "Rep\u00fablica Dominicana"
             },
+            "swe": {
+                "official": "Dominikanska republiken",
+                "common": "Dominikanska republiken"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0688\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0646",
                 "common": "\u0688\u0648\u0645\u06cc\u0646\u06cc\u06a9\u0646"
@@ -10092,10 +10096,6 @@
             "zho": {
                 "official": "\u591a\u660e\u5c3c\u52a0\u5171\u548c\u56fd",
                 "common": "\u591a\u660e\u5c3c\u52a0"
-            },
-            "swe": {
-                "official": "Dominikanska republiken",
-                "common": "Dominikanska republiken"
             }
         },
         "latlng": [
@@ -10238,6 +10238,10 @@
                 "official": "Rep\u00fablica Argelina Democr\u00e1tica y Popular",
                 "common": "Argelia"
             },
+            "swe": {
+                "official": "Demokratiska folkrepubliken Algeriet",
+                "common": "Algeriet"
+            },
             "urd": {
                 "official": "\u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0644\u062c\u0632\u0627\u0626\u0631",
                 "common": "\u0627\u0644\u062c\u0632\u0627\u0626\u0631"
@@ -10245,10 +10249,6 @@
             "zho": {
                 "official": "\u963f\u5c14\u53ca\u5229\u4e9a\u4eba\u6c11\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u963f\u5c14\u53ca\u5229\u4e9a"
-            },
-            "swe": {
-                "official": "Demokratiska folkrepubliken Algeriet",
-                "common": "Algeriet"
             }
         },
         "latlng": [
@@ -10396,6 +10396,10 @@
                 "official": "Rep\u00fablica del Ecuador",
                 "common": "Ecuador"
             },
+            "swe": {
+                "official": "Republiken Ecuador",
+                "common": "Ecuador"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u06cc\u06a9\u0648\u0688\u0648\u0631",
                 "common": "\u0627\u06cc\u06a9\u0648\u0627\u0688\u0648\u0631"
@@ -10403,10 +10407,6 @@
             "zho": {
                 "official": "\u5384\u74dc\u591a\u5c14\u5171\u548c\u56fd",
                 "common": "\u5384\u74dc\u591a\u5c14"
-            },
-            "swe": {
-                "official": "Republiken Ecuador",
-                "common": "Ecuador"
             }
         },
         "latlng": [
@@ -10549,6 +10549,10 @@
                 "official": "Rep\u00fablica \u00c1rabe de Egipto",
                 "common": "Egipto"
             },
+            "swe": {
+                "official": "Arabrepubliken Egypten",
+                "common": "Egypten"
+            },
             "urd": {
                 "official": "\u0645\u0635\u0631\u06cc \u0639\u0631\u0628 \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1",
                 "common": "\u0645\u0635\u0631"
@@ -10556,10 +10560,6 @@
             "zho": {
                 "official": "\u963f\u62c9\u4f2f\u57c3\u53ca\u5171\u548c\u56fd",
                 "common": "\u57c3\u53ca"
-            },
-            "swe": {
-                "official": "Arabrepubliken Egypten",
-                "common": "Egypten"
             }
         },
         "latlng": [
@@ -10717,6 +10717,10 @@
                 "official": "Estado de Eritrea",
                 "common": "Eritrea"
             },
+            "swe": {
+                "official": "Staten Eritrea",
+                "common": "Eritrea"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u0650 \u0627\u0631\u062a\u0631\u06cc\u0627",
                 "common": "\u0627\u0631\u062a\u0631\u06cc\u0627"
@@ -10724,10 +10728,6 @@
             "zho": {
                 "official": "\u5384\u7acb\u7279\u91cc\u4e9a",
                 "common": "\u5384\u7acb\u7279\u91cc\u4e9a"
-            },
-            "swe": {
-                "official": "Staten Eritrea",
-                "common": "Eritrea"
             }
         },
         "latlng": [
@@ -10885,6 +10885,10 @@
                 "official": "Rep\u00fablica \u00c1rabe Saharaui Democr\u00e1tica",
                 "common": "Sahara Occidental"
             },
+            "swe": {
+                "official": "V\u00e4stsahara",
+                "common": "V\u00e4stsahara"
+            },
             "urd": {
                 "official": "\u0635\u062d\u0631\u0627\u0648\u06cc \u0639\u0631\u0628 \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1",
                 "common": "\u0645\u063a\u0631\u0628\u06cc \u0635\u062d\u0627\u0631\u0627"
@@ -10892,10 +10896,6 @@
             "zho": {
                 "official": "\u963f\u62c9\u4f2f\u6492\u54c8\u62c9\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u897f\u6492\u54c8\u62c9"
-            },
-            "swe": {
-                "official": "V\u00e4stsahara",
-                "common": "V\u00e4stsahara"
             }
         },
         "latlng": [
@@ -11035,6 +11035,10 @@
                 "official": "Reino de Espa\u00f1a",
                 "common": "Espa\u00f1a"
             },
+            "swe": {
+                "official": "Konungariket Spanien",
+                "common": "Spanien"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u06c1\u0633\u067e\u0627\u0646\u06cc\u06c1",
                 "common": "\u06c1\u0633\u067e\u0627\u0646\u06cc\u06c1"
@@ -11042,10 +11046,6 @@
             "zho": {
                 "official": "\u897f\u73ed\u7259\u738b\u56fd",
                 "common": "\u897f\u73ed\u7259"
-            },
-            "swe": {
-                "official": "Konungariket Spanien",
-                "common": "Spanien"
             }
         },
         "latlng": [
@@ -11192,6 +11192,10 @@
                 "official": "Rep\u00fablica de Estonia",
                 "common": "Estonia"
             },
+            "swe": {
+                "official": "Republiken Estland",
+                "common": "Estland"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0633\u0679\u0648\u0646\u06cc\u0627",
                 "common": "\u0627\u0633\u0679\u0648\u0646\u06cc\u0627"
@@ -11199,10 +11203,6 @@
             "zho": {
                 "official": "\u7231\u6c99\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u7231\u6c99\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Estland",
-                "common": "Estland"
             }
         },
         "latlng": [
@@ -11346,6 +11346,10 @@
                 "official": "Rep\u00fablica Democr\u00e1tica Federal de Etiop\u00eda",
                 "common": "Etiop\u00eda"
             },
+            "swe": {
+                "official": "Demokratiska f\u00f6rbundsrepubliken Etiopien",
+                "common": "Etiopien"
+            },
             "urd": {
                 "official": "\u0648\u0641\u0627\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u06cc\u062a\u06be\u0648\u067e\u06cc\u0627",
                 "common": "\u0627\u06cc\u062a\u06be\u0648\u067e\u06cc\u0627"
@@ -11353,10 +11357,6 @@
             "zho": {
                 "official": "\u57c3\u585e\u4fc4\u6bd4\u4e9a\u8054\u90a6\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u57c3\u585e\u4fc4\u6bd4\u4e9a"
-            },
-            "swe": {
-                "official": "Demokratiska f\u00f6rbundsrepubliken Etiopien",
-                "common": "Etiopien"
             }
         },
         "latlng": [
@@ -11506,6 +11506,10 @@
                 "official": "Rep\u00fablica de Finlandia",
                 "common": "Finlandia"
             },
+            "swe": {
+                "official": "Republiken Finland",
+                "common": "Finland"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0641\u0646 \u0644\u06cc\u0646\u0688",
                 "common": "\u0641\u0646 \u0644\u06cc\u0646\u0688"
@@ -11513,10 +11517,6 @@
             "zho": {
                 "official": "\u82ac\u5170\u5171\u548c\u56fd",
                 "common": "\u82ac\u5170"
-            },
-            "swe": {
-                "official": "Republiken Finland",
-                "common": "Finland"
             }
         },
         "latlng": [
@@ -11668,6 +11668,10 @@
                 "official": "Rep\u00fablica de Fiji",
                 "common": "Fiyi"
             },
+            "swe": {
+                "official": "Republiken Fiji",
+                "common": "Fiji"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0641\u062c\u06cc",
                 "common": "\u0641\u062c\u06cc"
@@ -11675,10 +11679,6 @@
             "zho": {
                 "official": "\u6590\u6d4e\u5171\u548c\u56fd",
                 "common": "\u6590\u6d4e"
-            },
-            "swe": {
-                "official": "Republiken Fiji",
-                "common": "Fiji"
             }
         },
         "latlng": [
@@ -11814,6 +11814,10 @@
                 "official": "islas Malvinas",
                 "common": "Islas Malvinas"
             },
+            "swe": {
+                "official": "Falklands\u00f6arna",
+                "common": "Falklands\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 \u0641\u0627\u06a9\u0644\u06cc\u0646\u0688",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u0641\u0627\u06a9\u0644\u06cc\u0646\u0688"
@@ -11821,10 +11825,6 @@
             "zho": {
                 "official": "\u798f\u514b\u5170\u7fa4\u5c9b",
                 "common": "\u798f\u514b\u5170\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Falklands\u00f6arna",
-                "common": "Falklands\u00f6arna"
             }
         },
         "latlng": [
@@ -11960,6 +11960,10 @@
                 "official": "Rep\u00fablica franc\u00e9s",
                 "common": "Francia"
             },
+            "swe": {
+                "official": "Republiken Frankrike",
+                "common": "Frankrike"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0641\u0631\u0627\u0646\u0633",
                 "common": "\u0641\u0631\u0627\u0646\u0633"
@@ -11967,10 +11971,6 @@
             "zho": {
                 "official": "\u6cd5\u5170\u897f\u5171\u548c\u56fd",
                 "common": "\u6cd5\u56fd"
-            },
-            "swe": {
-                "official": "Republiken Frankrike",
-                "common": "Frankrike"
             }
         },
         "latlng": [
@@ -12124,6 +12124,10 @@
                 "official": "Islas Feroe",
                 "common": "Islas Faroe"
             },
+            "swe": {
+                "official": "F\u00e4r\u00f6arna",
+                "common": "F\u00e4r\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 \u0641\u0627\u0631\u0648",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u0641\u0627\u0631\u0648"
@@ -12131,10 +12135,6 @@
             "zho": {
                 "official": "\u6cd5\u7f57\u7fa4\u5c9b",
                 "common": "\u6cd5\u7f57\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "F\u00e4r\u00f6arna",
-                "common": "F\u00e4r\u00f6arna"
             }
         },
         "latlng": [
@@ -12265,6 +12265,10 @@
                 "official": "Estados Federados de Micronesia",
                 "common": "Micronesia"
             },
+            "swe": {
+                "official": "Mikronesiska federationen",
+                "common": "Mikronesiska federationen"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u06c1\u0627\u0626\u06d2 \u0648\u0641\u0627\u0642\u06cc\u06c1 \u0645\u0627\u0626\u06a9\u0631\u0648\u0646\u06cc\u0634\u06cc\u0627",
                 "common": "\u0645\u0627\u0626\u06a9\u0631\u0648\u0646\u06cc\u0634\u06cc\u0627"
@@ -12272,10 +12276,6 @@
             "zho": {
                 "official": "\u5bc6\u514b\u7f57\u5c3c\u897f\u4e9a\u8054\u90a6",
                 "common": "\u5bc6\u514b\u7f57\u5c3c\u897f\u4e9a"
-            },
-            "swe": {
-                "official": "Mikronesiska federationen",
-                "common": "Mikronesiska federationen"
             }
         },
         "latlng": [
@@ -12411,6 +12411,10 @@
                 "official": "Rep\u00fablica de Gab\u00f3n",
                 "common": "Gab\u00f3n"
             },
+            "swe": {
+                "official": "Republiken Gabon",
+                "common": "Gabon"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06af\u06cc\u0628\u0648\u0646",
                 "common": "\u06af\u06cc\u0628\u0648\u0646"
@@ -12418,10 +12422,6 @@
             "zho": {
                 "official": "\u52a0\u84ec\u5171\u548c\u56fd",
                 "common": "\u52a0\u84ec"
-            },
-            "swe": {
-                "official": "Republiken Gabon",
-                "common": "Gabon"
             }
         },
         "latlng": [
@@ -12561,6 +12561,10 @@
                 "official": "Reino Unido de Gran Breta\u00f1a e Irlanda del Norte",
                 "common": "Reino Unido"
             },
+            "swe": {
+                "official": "F\u00f6renade konungariket Storbritannien och Nordirland",
+                "common": "Storbritannien"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0645\u062a\u062d\u062f\u06c1 \u0628\u0631\u0637\u0627\u0646\u06cc\u06c1 \u0639\u0638\u0645\u06cc \u0648 \u0634\u0645\u0627\u0644\u06cc \u0622\u0626\u0631\u0644\u06cc\u0646\u0688",
                 "common": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0645\u062a\u062d\u062f\u06c1"
@@ -12568,10 +12572,6 @@
             "zho": {
                 "official": "\u5927\u4e0d\u5217\u98a0\u53ca\u5317\u7231\u5c14\u5170\u8054\u5408\u738b\u56fd",
                 "common": "\u82f1\u56fd"
-            },
-            "swe": {
-                "official": "F\u00f6renade konungariket Storbritannien och Nordirland",
-                "common": "Storbritannien"
             }
         },
         "latlng": [
@@ -12708,6 +12708,10 @@
                 "official": "Georgia",
                 "common": "Georgia"
             },
+            "swe": {
+                "official": "Georgien",
+                "common": "Georgien"
+            },
             "urd": {
                 "official": "\u062c\u0627\u0631\u062c\u06cc\u0627",
                 "common": "\u062c\u0627\u0631\u062c\u06cc\u0627"
@@ -12715,10 +12719,6 @@
             "zho": {
                 "official": "\u683c\u9c81\u5409\u4e9a",
                 "common": "\u683c\u9c81\u5409\u4e9a"
-            },
-            "swe": {
-                "official": "Georgien",
-                "common": "Georgien"
             }
         },
         "latlng": [
@@ -12873,6 +12873,10 @@
                 "official": "Bail\u00eda de Guernsey",
                 "common": "Guernsey"
             },
+            "swe": {
+                "official": "Guernsey",
+                "common": "Guernsey"
+            },
             "urd": {
                 "official": "\u06af\u0631\u0646\u0632\u06cc \u0631\u0648\u062f\u0628\u0627\u0631",
                 "common": "\u06af\u0631\u0646\u0632\u06cc"
@@ -12880,10 +12884,6 @@
             "zho": {
                 "official": "\u6839\u897f\u5c9b",
                 "common": "\u6839\u897f\u5c9b"
-            },
-            "swe": {
-                "official": "Guernsey",
-                "common": "Guernsey"
             }
         },
         "latlng": [
@@ -13017,6 +13017,10 @@
                 "official": "Rep\u00fablica de Ghana",
                 "common": "Ghana"
             },
+            "swe": {
+                "official": "Republiken Ghana",
+                "common": "Ghana"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06af\u06be\u0627\u0646\u0627",
                 "common": "\u06af\u06be\u0627\u0646\u0627"
@@ -13024,10 +13028,6 @@
             "zho": {
                 "official": "\u52a0\u7eb3\u5171\u548c\u56fd",
                 "common": "\u52a0\u7eb3"
-            },
-            "swe": {
-                "official": "Republiken Ghana",
-                "common": "Ghana"
             }
         },
         "latlng": [
@@ -13165,6 +13165,10 @@
                 "official": "Gibraltar",
                 "common": "Gibraltar"
             },
+            "swe": {
+                "official": "Gibraltar",
+                "common": "Gibraltar"
+            },
             "urd": {
                 "official": "\u062c\u0628\u0644 \u0627\u0644\u0637\u0627\u0631\u0642",
                 "common": "\u062c\u0628\u0644 \u0627\u0644\u0637\u0627\u0631\u0642"
@@ -13172,10 +13176,6 @@
             "zho": {
                 "official": "\u76f4\u5e03\u7f57\u9640",
                 "common": "\u76f4\u5e03\u7f57\u9640"
-            },
-            "swe": {
-                "official": "Gibraltar",
-                "common": "Gibraltar"
             }
         },
         "latlng": [
@@ -13313,6 +13313,10 @@
                 "official": "Rep\u00fablica de Guinea",
                 "common": "Guinea"
             },
+            "swe": {
+                "official": "Republiken Guinea",
+                "common": "Guinea"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06af\u0646\u06cc",
                 "common": "\u06af\u0646\u06cc"
@@ -13320,10 +13324,6 @@
             "zho": {
                 "official": "\u51e0\u5185\u4e9a\u5171\u548c\u56fd",
                 "common": "\u51e0\u5185\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Guinea",
-                "common": "Guinea"
             }
         },
         "latlng": [
@@ -13465,6 +13465,10 @@
                 "official": "Guadalupe",
                 "common": "Guadalupe"
             },
+            "swe": {
+                "official": "Guadeloupe",
+                "common": "Guadeloupe"
+            },
             "urd": {
                 "official": "\u06af\u0648\u0627\u0688\u06cc\u0644\u0648\u067e",
                 "common": "\u06af\u0648\u0627\u0688\u06cc\u0644\u0648\u067e"
@@ -13472,10 +13476,6 @@
             "zho": {
                 "official": "\u74dc\u5fb7\u7f57\u666e\u5c9b",
                 "common": "\u74dc\u5fb7\u7f57\u666e\u5c9b"
-            },
-            "swe": {
-                "official": "Guadeloupe",
-                "common": "Guadeloupe"
             }
         },
         "latlng": [
@@ -13610,6 +13610,10 @@
                 "official": "Rep\u00fablica de Gambia",
                 "common": "Gambia"
             },
+            "swe": {
+                "official": "Republiken Gambia",
+                "common": "Gambia"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06af\u06cc\u0645\u0628\u06cc\u0627",
                 "common": "\u06af\u06cc\u0645\u0628\u06cc\u0627"
@@ -13617,10 +13621,6 @@
             "zho": {
                 "official": "\u5188\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u5188\u6bd4\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Gambia",
-                "common": "Gambia"
             }
         },
         "latlng": [
@@ -13763,6 +13763,10 @@
                 "official": "Rep\u00fablica de Guinea-Bissau",
                 "common": "Guinea-Bis\u00e1u"
             },
+            "swe": {
+                "official": "Republiken Guinea-Bissau",
+                "common": "Guinea-Bissau"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06af\u0646\u06cc \u0628\u0633\u0627\u0624",
                 "common": "\u06af\u0646\u06cc \u0628\u0633\u0627\u0624"
@@ -13770,10 +13774,6 @@
             "zho": {
                 "official": "\u51e0\u5185\u4e9a\u6bd4\u7ecd\u5171\u548c\u56fd",
                 "common": "\u51e0\u5185\u4e9a\u6bd4\u7ecd"
-            },
-            "swe": {
-                "official": "Republiken Guinea-Bissau",
-                "common": "Guinea-Bissau"
             }
         },
         "latlng": [
@@ -13928,6 +13928,10 @@
                 "official": "Rep\u00fablica de Guinea Ecuatorial",
                 "common": "Guinea Ecuatorial"
             },
+            "swe": {
+                "official": "Republiken Ekvatorialguinea",
+                "common": "Ekvatorialguinea"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0633\u062a\u0648\u0627\u0626\u06cc \u06af\u0646\u06cc",
                 "common": "\u0627\u0633\u062a\u0648\u0627\u0626\u06cc \u06af\u0646\u06cc"
@@ -13935,10 +13939,6 @@
             "zho": {
                 "official": "\u8d64\u9053\u51e0\u5185\u4e9a\u5171\u548c\u56fd",
                 "common": "\u8d64\u9053\u51e0\u5185\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Ekvatorialguinea",
-                "common": "Ekvatorialguinea"
             }
         },
         "latlng": [
@@ -14078,6 +14078,10 @@
                 "official": "Rep\u00fablica Hel\u00e9nica",
                 "common": "Grecia"
             },
+            "swe": {
+                "official": "Republiken Grekland",
+                "common": "Grekland"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06c1\u06cc\u0644\u06cc\u0646\u06cc\u06c1",
                 "common": "\u06cc\u0648\u0646\u0627\u0646"
@@ -14085,10 +14089,6 @@
             "zho": {
                 "official": "\u5e0c\u814a\u5171\u548c\u56fd",
                 "common": "\u5e0c\u814a"
-            },
-            "swe": {
-                "official": "Republiken Grekland",
-                "common": "Grekland"
             }
         },
         "latlng": [
@@ -14227,6 +14227,10 @@
                 "official": "Granada",
                 "common": "Grenada"
             },
+            "swe": {
+                "official": "Grenada",
+                "common": "Grenada"
+            },
             "urd": {
                 "official": "\u06af\u0631\u06cc\u0646\u0627\u0688\u0627",
                 "common": "\u06af\u0631\u06cc\u0646\u0627\u0688\u0627"
@@ -14234,10 +14238,6 @@
             "zho": {
                 "official": "\u683c\u6797\u7eb3\u8fbe",
                 "common": "\u683c\u6797\u7eb3\u8fbe"
-            },
-            "swe": {
-                "official": "Grenada",
-                "common": "Grenada"
             }
         },
         "latlng": [
@@ -14372,6 +14372,10 @@
                 "official": "Groenlandia",
                 "common": "Groenlandia"
             },
+            "swe": {
+                "official": "Gr\u00f6nland",
+                "common": "Gr\u00f6nland"
+            },
             "urd": {
                 "official": "\u06af\u0631\u06cc\u0646 \u0644\u06cc\u0646\u0688",
                 "common": "\u06af\u0631\u06cc\u0646 \u0644\u06cc\u0646\u0688"
@@ -14379,10 +14383,6 @@
             "zho": {
                 "official": "\u683c\u9675\u5170",
                 "common": "\u683c\u9675\u5170"
-            },
-            "swe": {
-                "official": "Gr\u00f6nland",
-                "common": "Gr\u00f6nland"
             }
         },
         "latlng": [
@@ -14516,6 +14516,10 @@
                 "official": "Rep\u00fablica de Guatemala",
                 "common": "Guatemala"
             },
+            "swe": {
+                "official": "Republiken Guatemala",
+                "common": "Guatemala"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06af\u0648\u0627\u062a\u06cc\u0645\u0627\u0644\u0627",
                 "common": "\u06af\u0648\u0627\u062a\u06cc\u0645\u0627\u0644\u0627"
@@ -14523,10 +14527,6 @@
             "zho": {
                 "official": "\u5371\u5730\u9a6c\u62c9\u5171\u548c\u56fd",
                 "common": "\u5371\u5730\u9a6c\u62c9"
-            },
-            "swe": {
-                "official": "Republiken Guatemala",
-                "common": "Guatemala"
             }
         },
         "latlng": [
@@ -14667,6 +14667,10 @@
                 "official": "Guayana",
                 "common": "Guayana Francesa"
             },
+            "swe": {
+                "official": "Franska Guyana",
+                "common": "Franska Guyana"
+            },
             "urd": {
                 "official": "\u06af\u06cc\u0627\u0646\u0627",
                 "common": "\u0641\u0631\u0627\u0646\u0633\u06cc\u0633\u06cc \u06af\u06cc\u0627\u0646\u0627"
@@ -14674,10 +14678,6 @@
             "zho": {
                 "official": "\u6cd5\u5c5e\u572d\u4e9a\u90a3",
                 "common": "\u6cd5\u5c5e\u572d\u4e9a\u90a3"
-            },
-            "swe": {
-                "official": "Franska Guyana",
-                "common": "Franska Guyana"
             }
         },
         "latlng": [
@@ -14825,6 +14825,10 @@
                 "official": "Guam",
                 "common": "Guam"
             },
+            "swe": {
+                "official": "Guam",
+                "common": "Guam"
+            },
             "urd": {
                 "official": "\u06af\u0648\u0627\u0645",
                 "common": "\u06af\u0648\u0627\u0645"
@@ -14832,10 +14836,6 @@
             "zho": {
                 "official": "\u5173\u5c9b",
                 "common": "\u5173\u5c9b"
-            },
-            "swe": {
-                "official": "Guam",
-                "common": "Guam"
             }
         },
         "latlng": [
@@ -14970,6 +14970,10 @@
                 "official": "Rep\u00fablica Cooperativa de Guyana",
                 "common": "Guyana"
             },
+            "swe": {
+                "official": "Kooperativa republiken Guyana",
+                "common": "Guyana"
+            },
             "urd": {
                 "official": "\u062a\u0639\u0627\u0648\u0646\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06af\u06cc\u0627\u0646\u0627",
                 "common": "\u06af\u06cc\u0627\u0646\u0627"
@@ -14977,10 +14981,6 @@
             "zho": {
                 "official": "\u572d\u4e9a\u90a3\u5171\u548c\u56fd",
                 "common": "\u572d\u4e9a\u90a3"
-            },
-            "swe": {
-                "official": "Kooperativa republiken Guyana",
-                "common": "Guyana"
             }
         },
         "latlng": [
@@ -15124,13 +15124,13 @@
                 "official": "Hong Kong Regi\u00f3n Administrativa Especial de la Rep\u00fablica Popular China",
                 "common": "Hong Kong"
             },
-            "urd": {
-                "official": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 \u06a9\u0627 \u062e\u0635\u0648\u0635\u06cc \u0627\u0646\u062a\u0638\u0627\u0645\u06cc \u0639\u0644\u0627\u0642\u06c1",
-                "common": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af"
-            },
             "swe": {
                 "official": "Hongkong",
                 "common": "Hongkong"
+            },
+            "urd": {
+                "official": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 \u06a9\u0627 \u062e\u0635\u0648\u0635\u06cc \u0627\u0646\u062a\u0638\u0627\u0645\u06cc \u0639\u0644\u0627\u0642\u06c1",
+                "common": "\u06c1\u0627\u0646\u06af \u06a9\u0627\u0646\u06af"
             }
         },
         "latlng": [
@@ -15263,6 +15263,10 @@
                 "official": "Islas Heard y McDonald",
                 "common": "Islas Heard y McDonald"
             },
+            "swe": {
+                "official": "Heard- och McDonald\u00f6arna",
+                "common": "Heard- och McDonald\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u06cc\u0631\u06c1 \u06c1\u0631\u0688 \u0648 \u062c\u0632\u0627\u0626\u0631 \u0645\u06a9\u0688\u0648\u0646\u0644\u0688",
                 "common": "\u062c\u0632\u06cc\u0631\u06c1 \u06c1\u0631\u0688 \u0648 \u062c\u0632\u0627\u0626\u0631 \u0645\u06a9\u0688\u0648\u0646\u0644\u0688"
@@ -15270,10 +15274,6 @@
             "zho": {
                 "official": "\u8d6b\u5fb7\u5c9b\u548c\u9ea6\u5f53\u52b3\u7fa4\u5c9b",
                 "common": "\u8d6b\u5fb7\u5c9b\u548c\u9ea6\u5f53\u52b3\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Heard- och McDonald\u00f6arna",
-                "common": "Heard- och McDonald\u00f6arna"
             }
         },
         "latlng": [
@@ -15409,6 +15409,10 @@
                 "official": "Rep\u00fablica de Honduras",
                 "common": "Honduras"
             },
+            "swe": {
+                "official": "Republiken Honduras",
+                "common": "Honduras"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06c1\u0648\u0646\u0688\u0648\u0631\u0627\u0633",
                 "common": "\u06c1\u0648\u0646\u0688\u0648\u0631\u0627\u0633"
@@ -15416,10 +15420,6 @@
             "zho": {
                 "official": "\u6d2a\u90fd\u62c9\u65af\u5171\u548c\u56fd",
                 "common": "\u6d2a\u90fd\u62c9\u65af"
-            },
-            "swe": {
-                "official": "Republiken Honduras",
-                "common": "Honduras"
             }
         },
         "latlng": [
@@ -15564,6 +15564,10 @@
                 "official": "Rep\u00fablica de Croacia",
                 "common": "Croacia"
             },
+            "swe": {
+                "official": "Republiken Kroatien",
+                "common": "Kroatien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0631\u0648\u06cc\u0626\u0634\u0627",
                 "common": "\u06a9\u0631\u0648\u06cc\u0626\u0634\u0627"
@@ -15571,10 +15575,6 @@
             "zho": {
                 "official": "\u514b\u7f57\u5730\u4e9a\u5171\u548c\u56fd",
                 "common": "\u514b\u7f57\u5730\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Kroatien",
-                "common": "Kroatien"
             }
         },
         "latlng": [
@@ -15722,6 +15722,10 @@
                 "official": "Rep\u00fablica de Hait\u00ed",
                 "common": "Hait\u00ed"
             },
+            "swe": {
+                "official": "Republiken Haiti",
+                "common": "Haiti"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06c1\u06cc\u0679\u06cc",
                 "common": "\u06c1\u06cc\u0679\u06cc"
@@ -15729,10 +15733,6 @@
             "zho": {
                 "official": "\u6d77\u5730\u5171\u548c\u56fd",
                 "common": "\u6d77\u5730"
-            },
-            "swe": {
-                "official": "Republiken Haiti",
-                "common": "Haiti"
             }
         },
         "latlng": [
@@ -15868,6 +15868,10 @@
                 "official": "Hungr\u00eda",
                 "common": "Hungr\u00eda"
             },
+            "swe": {
+                "official": "Ungern",
+                "common": "Ungern"
+            },
             "urd": {
                 "official": "\u0645\u062c\u0627\u0631\u0633\u062a\u0627\u0646",
                 "common": "\u0645\u062c\u0627\u0631\u0633\u062a\u0627\u0646"
@@ -15875,10 +15879,6 @@
             "zho": {
                 "official": "\u5308\u7259\u5229",
                 "common": "\u5308\u7259\u5229"
-            },
-            "swe": {
-                "official": "Ungern",
-                "common": "Ungern"
             }
         },
         "latlng": [
@@ -16022,6 +16022,10 @@
                 "official": "Rep\u00fablica de Indonesia",
                 "common": "Indonesia"
             },
+            "swe": {
+                "official": "Republiken Indonesien",
+                "common": "Indonesien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0646\u0688\u0648\u0646\u06cc\u0634\u06cc\u0627",
                 "common": "\u0627\u0646\u0688\u0648\u0646\u06cc\u0634\u06cc\u0627"
@@ -16029,10 +16033,6 @@
             "zho": {
                 "official": "\u5370\u5ea6\u5c3c\u897f\u4e9a\u5171\u548c\u56fd",
                 "common": "\u5370\u5ea6\u5c3c\u897f\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Indonesien",
-                "common": "Indonesien"
             }
         },
         "latlng": [
@@ -16182,6 +16182,10 @@
                 "official": "Isla de Man",
                 "common": "Isla de Man"
             },
+            "swe": {
+                "official": "Isle of Man",
+                "common": "Isle of Man"
+            },
             "urd": {
                 "official": "\u0622\u0626\u0644 \u0622\u0641 \u0645\u06cc\u0646",
                 "common": "\u0622\u0626\u0644 \u0622\u0641 \u0645\u06cc\u0646"
@@ -16189,10 +16193,6 @@
             "zho": {
                 "official": "\u9a6c\u6069\u5c9b",
                 "common": "\u9a6c\u6069\u5c9b"
-            },
-            "swe": {
-                "official": "Isle of Man",
-                "common": "Isle of Man"
             }
         },
         "latlng": [
@@ -16340,6 +16340,10 @@
                 "official": "Rep\u00fablica de la India",
                 "common": "India"
             },
+            "swe": {
+                "official": "Republiken Indien",
+                "common": "Indien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0628\u06be\u0627\u0631\u062a",
                 "common": "\u0628\u06be\u0627\u0631\u062a"
@@ -16347,10 +16351,6 @@
             "zho": {
                 "official": "\u5370\u5ea6\u5171\u548c\u56fd",
                 "common": "\u5370\u5ea6"
-            },
-            "swe": {
-                "official": "Republiken Indien",
-                "common": "Indien"
             }
         },
         "latlng": [
@@ -16495,6 +16495,10 @@
                 "official": "Territorio Brit\u00e1nico del Oc\u00e9ano \u00cdndico",
                 "common": "Territorio Brit\u00e1nico del Oc\u00e9ano \u00cdndico"
             },
+            "swe": {
+                "official": "Brittiska territoriet i Indiska Oceanen",
+                "common": "Brittiska territoriet i Indiska Oceanen"
+            },
             "urd": {
                 "official": "\u0628\u0631\u0637\u0627\u0646\u0648\u06cc \u0628\u062d\u0631\u06c1\u0646\u062f \u062e\u0637\u06c1",
                 "common": "\u0628\u0631\u0637\u0627\u0646\u0648\u06cc \u0628\u062d\u0631\u06c1\u0646\u062f \u062e\u0637\u06c1"
@@ -16502,10 +16506,6 @@
             "zho": {
                 "official": "\u82f1\u5c5e\u5370\u5ea6\u6d0b\u9886\u5730",
                 "common": "\u82f1\u5c5e\u5370\u5ea6\u6d0b\u9886\u5730"
-            },
-            "swe": {
-                "official": "Brittiska territoriet i Indiska Oceanen",
-                "common": "Brittiska territoriet i Indiska Oceanen"
             }
         },
         "latlng": [
@@ -16647,6 +16647,10 @@
                 "official": "Rep\u00fablica de Irlanda",
                 "common": "Irlanda"
             },
+            "swe": {
+                "official": "Irland",
+                "common": "Irland"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062c\u0632\u06cc\u0631\u06c1 \u0622\u0626\u0631\u0644\u06cc\u0646\u0688",
                 "common": "\u062c\u0632\u06cc\u0631\u06c1 \u0622\u0626\u0631\u0644\u06cc\u0646\u0688"
@@ -16654,10 +16658,6 @@
             "zho": {
                 "official": "\u7231\u5c14\u5170\u5171\u548c\u56fd",
                 "common": "\u7231\u5c14\u5170"
-            },
-            "swe": {
-                "official": "Irland",
-                "common": "Irland"
             }
         },
         "latlng": [
@@ -16793,6 +16793,10 @@
                 "official": "Rep\u00fablica Isl\u00e1mica de Ir\u00e1n",
                 "common": "Iran"
             },
+            "swe": {
+                "official": "Islamiska republiken Iran",
+                "common": "Iran"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u06cc\u0631\u0627\u0646",
                 "common": "\u0627\u06cc\u0631\u0627\u0646"
@@ -16800,10 +16804,6 @@
             "zho": {
                 "official": "\u4f0a\u6717\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u4f0a\u6717"
-            },
-            "swe": {
-                "official": "Islamiska republiken Iran",
-                "common": "Iran"
             }
         },
         "latlng": [
@@ -16957,6 +16957,10 @@
                 "official": "Rep\u00fablica de Irak",
                 "common": "Irak"
             },
+            "swe": {
+                "official": "Republiken Irak",
+                "common": "Irak"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0639\u0631\u0627\u0642",
                 "common": "\u0639\u0631\u0627\u0642"
@@ -16964,10 +16968,6 @@
             "zho": {
                 "official": "\u4f0a\u62c9\u514b\u5171\u548c\u56fd",
                 "common": "\u4f0a\u62c9\u514b"
-            },
-            "swe": {
-                "official": "Republiken Irak",
-                "common": "Irak"
             }
         },
         "latlng": [
@@ -17111,6 +17111,10 @@
                 "official": "Islandia",
                 "common": "Islandia"
             },
+            "swe": {
+                "official": "Island",
+                "common": "Island"
+            },
             "urd": {
                 "official": "\u0622\u0626\u0633 \u0644\u06cc\u0646\u0688",
                 "common": "\u0622\u0626\u0633 \u0644\u06cc\u0646\u0688"
@@ -17118,10 +17122,6 @@
             "zho": {
                 "official": "\u51b0\u5c9b",
                 "common": "\u51b0\u5c9b"
-            },
-            "swe": {
-                "official": "Island",
-                "common": "Island"
             }
         },
         "latlng": [
@@ -17262,6 +17262,10 @@
                 "official": "Estado de Israel",
                 "common": "Israel"
             },
+            "swe": {
+                "official": "Staten Israel",
+                "common": "Israel"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u0650 \u0627\u0633\u0631\u0627\u0626\u06cc\u0644",
                 "common": "\u0627\u0633\u0631\u0627\u0626\u06cc\u0644"
@@ -17269,10 +17273,6 @@
             "zho": {
                 "official": "\u4ee5\u8272\u5217\u56fd",
                 "common": "\u4ee5\u8272\u5217"
-            },
-            "swe": {
-                "official": "Staten Israel",
-                "common": "Israel"
             }
         },
         "latlng": [
@@ -17414,6 +17414,10 @@
                 "official": "Rep\u00fablica Italiana",
                 "common": "Italia"
             },
+            "swe": {
+                "official": "Republiken Italien",
+                "common": "Italien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0637\u0627\u0644\u06cc\u06c1",
                 "common": "\u0627\u0637\u0627\u0644\u06cc\u06c1"
@@ -17421,10 +17425,6 @@
             "zho": {
                 "official": "\u610f\u5927\u5229\u5171\u548c\u56fd",
                 "common": "\u610f\u5927\u5229"
-            },
-            "swe": {
-                "official": "Republiken Italien",
-                "common": "Italien"
             }
         },
         "latlng": [
@@ -17570,6 +17570,10 @@
                 "official": "Jamaica",
                 "common": "Jamaica"
             },
+            "swe": {
+                "official": "Jamaica",
+                "common": "Jamaica"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06cc\u06a9\u0627",
                 "common": "\u062c\u0645\u06cc\u06a9\u0627"
@@ -17577,10 +17581,6 @@
             "zho": {
                 "official": "\u7259\u4e70\u52a0",
                 "common": "\u7259\u4e70\u52a0"
-            },
-            "swe": {
-                "official": "Jamaica",
-                "common": "Jamaica"
             }
         },
         "latlng": [
@@ -17731,6 +17731,10 @@
                 "official": "Bail\u00eda de Jersey",
                 "common": "Jersey"
             },
+            "swe": {
+                "official": "Jersey",
+                "common": "Jersey"
+            },
             "urd": {
                 "official": "\u062c\u0631\u0632\u06cc",
                 "common": "\u062c\u0631\u0632\u06cc"
@@ -17738,10 +17742,6 @@
             "zho": {
                 "official": "\u6cfd\u897f\u5c9b",
                 "common": "\u6cfd\u897f\u5c9b"
-            },
-            "swe": {
-                "official": "Jersey",
-                "common": "Jersey"
             }
         },
         "latlng": [
@@ -17878,6 +17878,10 @@
                 "official": "Reino Hachemita de Jordania",
                 "common": "Jordania"
             },
+            "swe": {
+                "official": "Hashimitiska kungad\u00f6met Jordanien",
+                "common": "Jordanien"
+            },
             "urd": {
                 "official": "\u06be\u0627\u0634\u0645\u06cc \u0645\u0645\u0644\u06a9\u062a\u0650 \u0627\u0631\u062f\u0646",
                 "common": "\u0627\u0631\u062f\u0646"
@@ -17885,10 +17889,6 @@
             "zho": {
                 "official": "\u7ea6\u65e6\u54c8\u5e0c\u59c6\u738b\u56fd",
                 "common": "\u7ea6\u65e6"
-            },
-            "swe": {
-                "official": "Hashimitiska kungad\u00f6met Jordanien",
-                "common": "Jordanien"
             }
         },
         "latlng": [
@@ -18031,6 +18031,10 @@
                 "official": "Jap\u00f3n",
                 "common": "Jap\u00f3n"
             },
+            "swe": {
+                "official": "Japan",
+                "common": "Japan"
+            },
             "urd": {
                 "official": "\u062c\u0627\u067e\u0627\u0646",
                 "common": "\u062c\u0627\u067e\u0627\u0646"
@@ -18038,10 +18042,6 @@
             "zho": {
                 "official": "\u65e5\u672c\u56fd",
                 "common": "\u65e5\u672c"
-            },
-            "swe": {
-                "official": "Japan",
-                "common": "Japan"
             }
         },
         "latlng": [
@@ -18189,6 +18189,10 @@
                 "official": "Rep\u00fablica de Kazajst\u00e1n",
                 "common": "Kazajist\u00e1n"
             },
+            "swe": {
+                "official": "Republiken Kazakstan",
+                "common": "Kazakstan"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0642\u0627\u0632\u0642\u0633\u062a\u0627\u0646",
                 "common": "\u0642\u0627\u0632\u0642\u0633\u062a\u0627\u0646"
@@ -18196,10 +18200,6 @@
             "zho": {
                 "official": "\u54c8\u8428\u514b\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u54c8\u8428\u514b\u65af\u5766"
-            },
-            "swe": {
-                "official": "Republiken Kazakstan",
-                "common": "Kazakstan"
             }
         },
         "latlng": [
@@ -18346,6 +18346,10 @@
                 "official": "Rep\u00fablica de Kenya",
                 "common": "Kenia"
             },
+            "swe": {
+                "official": "Republiken Kenya",
+                "common": "Kenya"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u06cc\u0646\u06cc\u0627",
                 "common": "\u06a9\u06cc\u0646\u06cc\u0627"
@@ -18353,10 +18357,6 @@
             "zho": {
                 "official": "\u80af\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u80af\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Kenya",
-                "common": "Kenya"
             }
         },
         "latlng": [
@@ -18505,6 +18505,10 @@
                 "official": "Rep\u00fablica Kirguisa",
                 "common": "Kirguizist\u00e1n"
             },
+            "swe": {
+                "official": "Republiken Kirgizistan",
+                "common": "Kirgizistan"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0631\u063a\u06cc\u0632\u0633\u062a\u0627\u0646",
                 "common": "\u06a9\u0631\u063a\u06cc\u0632\u0633\u062a\u0627\u0646"
@@ -18512,10 +18516,6 @@
             "zho": {
                 "official": "\u5409\u5c14\u5409\u65af\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u5409\u5c14\u5409\u65af\u65af\u5766"
-            },
-            "swe": {
-                "official": "Republiken Kirgizistan",
-                "common": "Kirgizistan"
             }
         },
         "latlng": [
@@ -18663,6 +18663,10 @@
                 "official": "Reino de Camboya",
                 "common": "Camboya"
             },
+            "swe": {
+                "official": "Konungariket Kambodja",
+                "common": "Kambodja"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u06a9\u0645\u0628\u0648\u0688\u06cc\u0627",
                 "common": "\u06a9\u0645\u0628\u0648\u0688\u06cc\u0627"
@@ -18670,10 +18674,6 @@
             "zho": {
                 "official": "\u67ec\u57d4\u5be8\u738b\u56fd",
                 "common": "\u67ec\u57d4\u5be8"
-            },
-            "swe": {
-                "official": "Konungariket Kambodja",
-                "common": "Kambodja"
             }
         },
         "latlng": [
@@ -18822,6 +18822,10 @@
                 "official": "Rep\u00fablica Independiente y Soberano de Kiribati",
                 "common": "Kiribati"
             },
+            "swe": {
+                "official": "Republiken Kiribati",
+                "common": "Kiribati"
+            },
             "urd": {
                 "official": "\u0633\u0644\u0637\u0646\u062a \u0622\u0632\u0627\u062f \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc",
                 "common": "\u06a9\u06cc\u0631\u06cc\u0628\u0627\u062a\u06cc"
@@ -18829,10 +18833,6 @@
             "zho": {
                 "official": "\u57fa\u91cc\u5df4\u65af\u5171\u548c\u56fd",
                 "common": "\u57fa\u91cc\u5df4\u65af"
-            },
-            "swe": {
-                "official": "Republiken Kiribati",
-                "common": "Kiribati"
             }
         },
         "latlng": [
@@ -18967,6 +18967,10 @@
                 "official": "Federaci\u00f3n de San Crist\u00f3bal y Nevis",
                 "common": "San Crist\u00f3bal y Nieves"
             },
+            "swe": {
+                "official": "Federationen Saint Kitts och Nevis",
+                "common": "Saint Kitts och Nevis"
+            },
             "urd": {
                 "official": "\u0648\u0641\u0627\u0642\u0650 \u0633\u06cc\u0646\u0679 \u06a9\u06cc\u0679\u0632 \u0648 \u0646\u0627\u0648\u06cc\u0633",
                 "common": "\u0633\u06cc\u0646\u0679 \u06a9\u06cc\u0679\u0632 \u0648 \u0646\u0627\u0648\u06cc\u0633"
@@ -18974,10 +18978,6 @@
             "zho": {
                 "official": "\u5723\u514b\u91cc\u65af\u6258\u5f17\u548c\u5c3c\u7ef4\u65af\u8054\u90a6",
                 "common": "\u5723\u57fa\u8328\u548c\u5c3c\u7ef4\u65af"
-            },
-            "swe": {
-                "official": "Federationen Saint Kitts och Nevis",
-                "common": "Saint Kitts och Nevis"
             }
         },
         "latlng": [
@@ -19116,6 +19116,10 @@
                 "official": "Rep\u00fablica de Corea",
                 "common": "Corea del Sur"
             },
+            "swe": {
+                "official": "Republiken Korea",
+                "common": "Sydkorea"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0648\u0631\u06cc\u0627 ",
                 "common": "\u062c\u0646\u0648\u0628\u06cc \u06a9\u0648\u0631\u06cc\u0627"
@@ -19123,10 +19127,6 @@
             "zho": {
                 "official": "\u5927\u97e9\u6c11\u56fd",
                 "common": "\u97e9\u56fd"
-            },
-            "swe": {
-                "official": "Republiken Korea",
-                "common": "Sydkorea"
             }
         },
         "latlng": [
@@ -19262,6 +19262,10 @@
                 "official": "Rep\u00fablica de Kosovo",
                 "common": "Kosovo"
             },
+            "swe": {
+                "official": "Republiken Kosovo",
+                "common": "Kosovo"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0648\u0633\u0648\u0648\u06c1",
                 "common": "\u06a9\u0648\u0633\u0648\u0648\u06c1"
@@ -19269,10 +19273,6 @@
             "zho": {
                 "official": "\u79d1\u7d22\u6c83\u5171\u548c\u56fd",
                 "common": "\u79d1\u7d22\u6c83"
-            },
-            "swe": {
-                "official": "Republiken Kosovo",
-                "common": "Kosovo"
             }
         },
         "latlng": [
@@ -19413,6 +19413,10 @@
                 "official": "Estado de Kuwait",
                 "common": "Kuwait"
             },
+            "swe": {
+                "official": "Staten Kuwait",
+                "common": "Kuwait"
+            },
             "urd": {
                 "official": "\u062f\u0648\u0644\u062a\u0650 \u06a9\u0648\u06cc\u062a",
                 "common": "\u06a9\u0648\u06cc\u062a"
@@ -19420,10 +19424,6 @@
             "zho": {
                 "official": "\u79d1\u5a01\u7279\u56fd",
                 "common": "\u79d1\u5a01\u7279"
-            },
-            "swe": {
-                "official": "Staten Kuwait",
-                "common": "Kuwait"
             }
         },
         "latlng": [
@@ -19563,6 +19563,10 @@
                 "official": "Rep\u00fablica Democr\u00e1tica Popular Lao",
                 "common": "Laos"
             },
+            "swe": {
+                "official": "Demokratiska folkrepubliken Laos",
+                "common": "Laos"
+            },
             "urd": {
                 "official": "\u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0644\u0627\u0624",
                 "common": "\u0644\u0627\u0624\u0633"
@@ -19570,10 +19574,6 @@
             "zho": {
                 "official": "\u8001\u631d\u4eba\u6c11\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u8001\u631d"
-            },
-            "swe": {
-                "official": "Demokratiska folkrepubliken Laos",
-                "common": "Laos"
             }
         },
         "latlng": [
@@ -19720,6 +19720,10 @@
                 "official": "Rep\u00fablica Libanesa",
                 "common": "L\u00edbano"
             },
+            "swe": {
+                "official": "Republiken Libanon",
+                "common": "Libanon"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0644\u0628\u0646\u0627\u0646",
                 "common": "\u0644\u0628\u0646\u0627\u0646"
@@ -19727,10 +19731,6 @@
             "zho": {
                 "official": "\u9ece\u5df4\u5ae9\u5171\u548c\u56fd",
                 "common": "\u9ece\u5df4\u5ae9"
-            },
-            "swe": {
-                "official": "Republiken Libanon",
-                "common": "Libanon"
             }
         },
         "latlng": [
@@ -19868,6 +19868,10 @@
                 "official": "Rep\u00fablica de Liberia",
                 "common": "Liberia"
             },
+            "swe": {
+                "official": "Republiken Liberia",
+                "common": "Liberia"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0644\u0627\u0626\u0628\u06cc\u0631\u06cc\u0627",
                 "common": "\u0644\u0627\u0626\u0628\u06cc\u0631\u06cc\u0627"
@@ -19875,10 +19879,6 @@
             "zho": {
                 "official": "\u5229\u6bd4\u91cc\u4e9a\u5171\u548c\u56fd",
                 "common": "\u5229\u6bd4\u91cc\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Liberia",
-                "common": "Liberia"
             }
         },
         "latlng": [
@@ -20018,6 +20018,10 @@
                 "official": "Estado de Libia",
                 "common": "Libia"
             },
+            "swe": {
+                "official": "Staten Libyen",
+                "common": "Libyen"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u0650 \u0644\u06cc\u0628\u06cc\u0627",
                 "common": "\u0644\u06cc\u0628\u06cc\u0627"
@@ -20025,10 +20029,6 @@
             "zho": {
                 "official": "\u5229\u6bd4\u4e9a\u56fd",
                 "common": "\u5229\u6bd4\u4e9a"
-            },
-            "swe": {
-                "official": "Staten Libyen",
-                "common": "Libyen"
             }
         },
         "latlng": [
@@ -20169,6 +20169,10 @@
                 "official": "Santa Luc\u00eda",
                 "common": "Santa Luc\u00eda"
             },
+            "swe": {
+                "official": "Saint Lucia",
+                "common": "Saint Lucia"
+            },
             "urd": {
                 "official": "\u0633\u06cc\u0646\u0679 \u0644\u0648\u0633\u06cc\u0627",
                 "common": "\u0633\u06cc\u0646\u0679 \u0644\u0648\u0633\u06cc\u0627"
@@ -20176,10 +20180,6 @@
             "zho": {
                 "official": "\u5723\u5362\u897f\u4e9a",
                 "common": "\u5723\u5362\u897f\u4e9a"
-            },
-            "swe": {
-                "official": "Saint Lucia",
-                "common": "Saint Lucia"
             }
         },
         "latlng": [
@@ -20315,6 +20315,10 @@
                 "official": "Principado de Liechtenstein",
                 "common": "Liechtenstein"
             },
+            "swe": {
+                "official": "Furstend\u00f6met Liechtenstein",
+                "common": "Liechtenstein"
+            },
             "urd": {
                 "official": "\u0627\u0645\u0627\u0631\u0627\u062a \u0644\u06cc\u062e\u062a\u06cc\u0646\u0633\u062a\u0627\u0626\u0646",
                 "common": "\u0644\u06cc\u062e\u062a\u06cc\u0646\u0633\u062a\u0627\u0626\u0646"
@@ -20322,10 +20326,6 @@
             "zho": {
                 "official": "\u5217\u652f\u6566\u58eb\u767b\u516c\u56fd",
                 "common": "\u5217\u652f\u6566\u58eb\u767b"
-            },
-            "swe": {
-                "official": "Furstend\u00f6met Liechtenstein",
-                "common": "Liechtenstein"
             }
         },
         "latlng": [
@@ -20471,6 +20471,10 @@
                 "official": "Rep\u00fablica Democr\u00e1tica Socialista de Sri Lanka",
                 "common": "Sri Lanka"
             },
+            "swe": {
+                "official": "Demokratiska socialistiska republiken Sri Lanka",
+                "common": "Sri Lanka"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc \u0648 \u0627\u0634\u062a\u0631\u0627\u06a9\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0631\u06cc \u0644\u0646\u06a9\u0627",
                 "common": "\u0633\u0631\u06cc \u0644\u0646\u06a9\u0627"
@@ -20478,10 +20482,6 @@
             "zho": {
                 "official": "\u65af\u91cc\u5170\u5361\u6c11\u4e3b\u793e\u4f1a\u4e3b\u4e49\u5171\u548c\u56fd",
                 "common": "\u65af\u91cc\u5170\u5361"
-            },
-            "swe": {
-                "official": "Demokratiska socialistiska republiken Sri Lanka",
-                "common": "Sri Lanka"
             }
         },
         "latlng": [
@@ -20628,6 +20628,10 @@
                 "official": "Reino de Lesotho",
                 "common": "Lesotho"
             },
+            "swe": {
+                "official": "Konungariket Lesotho",
+                "common": "Lesotho"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0644\u06cc\u0633\u0648\u062a\u06be\u0648",
                 "common": "\u0644\u06cc\u0633\u0648\u062a\u06be\u0648"
@@ -20635,10 +20639,6 @@
             "zho": {
                 "official": "\u83b1\u7d22\u6258\u738b\u56fd",
                 "common": "\u83b1\u7d22\u6258"
-            },
-            "swe": {
-                "official": "Konungariket Lesotho",
-                "common": "Lesotho"
             }
         },
         "latlng": [
@@ -20776,6 +20776,10 @@
                 "official": "Rep\u00fablica de Lituania",
                 "common": "Lituania"
             },
+            "swe": {
+                "official": "Republiken Litauen",
+                "common": "Litauen"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0644\u062a\u06be\u0648\u0648\u06cc\u0646\u06cc\u0627",
                 "common": "\u0644\u062a\u06be\u0648\u0648\u06cc\u0646\u06cc\u0627"
@@ -20783,10 +20787,6 @@
             "zho": {
                 "official": "\u7acb\u9676\u5b9b\u5171\u548c\u56fd",
                 "common": "\u7acb\u9676\u5b9b"
-            },
-            "swe": {
-                "official": "Republiken Litauen",
-                "common": "Litauen"
             }
         },
         "latlng": [
@@ -20939,6 +20939,10 @@
                 "official": "Gran Ducado de Luxemburgo",
                 "common": "Luxemburgo"
             },
+            "swe": {
+                "official": "Storhertigd\u00f6met Luxemburg",
+                "common": "Luxemburg"
+            },
             "urd": {
                 "official": "\u062f\u0648\u0642\u06cc\u06c1 \u06a9\u0628\u06cc\u0631\u0644\u06a9\u0633\u0645\u0628\u0631\u06af",
                 "common": "\u0644\u06a9\u0633\u0645\u0628\u0631\u06af"
@@ -20946,10 +20950,6 @@
             "zho": {
                 "official": "\u5362\u68ee\u5821\u5927\u516c\u56fd",
                 "common": "\u5362\u68ee\u5821"
-            },
-            "swe": {
-                "official": "Storhertigd\u00f6met Luxemburg",
-                "common": "Luxemburg"
             }
         },
         "latlng": [
@@ -21089,6 +21089,10 @@
                 "official": "Rep\u00fablica de Letonia",
                 "common": "Letonia"
             },
+            "swe": {
+                "official": "Republiken Lettland",
+                "common": "Lettland"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0644\u0679\u0648\u06cc\u0627",
                 "common": "\u0644\u0679\u0648\u06cc\u0627"
@@ -21096,10 +21100,6 @@
             "zho": {
                 "official": "\u62c9\u8131\u7ef4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u62c9\u8131\u7ef4\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Lettland",
-                "common": "Lettland"
             }
         },
         "latlng": [
@@ -21248,13 +21248,13 @@
                 "official": "Macao, Regi\u00f3n Administrativa Especial de la Rep\u00fablica Popular China",
                 "common": "Macao"
             },
-            "urd": {
-                "official": "\u0645\u06a9\u0627\u0624 \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 \u06a9\u0627 \u062e\u0635\u0648\u0635\u06cc \u0627\u0646\u062a\u0638\u0627\u0645\u06cc \u0639\u0644\u0627\u0642\u06c1",
-                "common": "\u0645\u06a9\u0627\u0624"
-            },
             "swe": {
                 "official": "Macao",
                 "common": "Macao"
+            },
+            "urd": {
+                "official": "\u0645\u06a9\u0627\u0624 \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 \u06a9\u0627 \u062e\u0635\u0648\u0635\u06cc \u0627\u0646\u062a\u0638\u0627\u0645\u06cc \u0639\u0644\u0627\u0642\u06c1",
+                "common": "\u0645\u06a9\u0627\u0624"
             }
         },
         "latlng": [
@@ -21394,6 +21394,10 @@
                 "official": "Saint Martin",
                 "common": "Saint Martin"
             },
+            "swe": {
+                "official": "F\u00f6rvaltningsomr\u00e5det Saint-Martin",
+                "common": "Saint-Martin"
+            },
             "urd": {
                 "official": "\u0633\u06cc\u0646\u0679 \u0645\u0627\u0631\u0679\u0646",
                 "common": "\u0633\u06cc\u0646\u0679 \u0645\u0627\u0631\u0679\u0646"
@@ -21401,10 +21405,6 @@
             "zho": {
                 "official": "\u5723\u9a6c\u4e01",
                 "common": "\u5723\u9a6c\u4e01"
-            },
-            "swe": {
-                "official": "F\u00f6rvaltningsomr\u00e5det Saint-Martin",
-                "common": "Saint-Martin"
             }
         },
         "latlng": [
@@ -21548,6 +21548,10 @@
                 "official": "Reino de Marruecos",
                 "common": "Marruecos"
             },
+            "swe": {
+                "official": "Konungariket Marocko",
+                "common": "Marocko"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0645\u0631\u0627\u06a9\u0634",
                 "common": "\u0645\u0631\u0627\u06a9\u0634"
@@ -21555,10 +21559,6 @@
             "zho": {
                 "official": "\u6469\u6d1b\u54e5\u738b\u56fd",
                 "common": "\u6469\u6d1b\u54e5"
-            },
-            "swe": {
-                "official": "Konungariket Marocko",
-                "common": "Marocko"
             }
         },
         "latlng": [
@@ -21698,6 +21698,10 @@
                 "official": "Principado de M\u00f3naco",
                 "common": "M\u00f3naco"
             },
+            "swe": {
+                "official": "Furstend\u00f6met Monaco",
+                "common": "Monaco"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0646\u0627\u06a9\u0648",
                 "common": "\u0645\u0648\u0646\u0627\u06a9\u0648"
@@ -21705,10 +21709,6 @@
             "zho": {
                 "official": "\u6469\u7eb3\u54e5\u516c\u56fd",
                 "common": "\u6469\u7eb3\u54e5"
-            },
-            "swe": {
-                "official": "Furstend\u00f6met Monaco",
-                "common": "Monaco"
             }
         },
         "latlng": [
@@ -21847,6 +21847,10 @@
                 "official": "Rep\u00fablica de Moldova",
                 "common": "Moldavia"
             },
+            "swe": {
+                "official": "Republiken Moldavien",
+                "common": "Moldavien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0627\u0644\u062f\u0648\u0648\u0627",
                 "common": "\u0645\u0627\u0644\u062f\u0648\u0648\u0627"
@@ -21854,10 +21858,6 @@
             "zho": {
                 "official": "\u6469\u5c14\u591a\u74e6\u5171\u548c\u56fd",
                 "common": "\u6469\u5c14\u591a\u74e6"
-            },
-            "swe": {
-                "official": "Republiken Moldavien",
-                "common": "Moldavien"
             }
         },
         "latlng": [
@@ -22002,6 +22002,10 @@
                 "official": "Rep\u00fablica de Madagascar",
                 "common": "Madagascar"
             },
+            "swe": {
+                "official": "Republiken Madagaskar",
+                "common": "Madagaskar"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0688\u063a\u0627\u0633\u06a9\u0631",
                 "common": "\u0645\u0688\u063a\u0627\u0633\u06a9\u0631"
@@ -22009,10 +22013,6 @@
             "zho": {
                 "official": "\u9a6c\u8fbe\u52a0\u65af\u52a0\u5171\u548c\u56fd",
                 "common": "\u9a6c\u8fbe\u52a0\u65af\u52a0"
-            },
-            "swe": {
-                "official": "Republiken Madagaskar",
-                "common": "Madagaskar"
             }
         },
         "latlng": [
@@ -22149,6 +22149,10 @@
                 "official": "Rep\u00fablica de las Maldivas",
                 "common": "Maldivas"
             },
+            "swe": {
+                "official": "Republiken Maldiverna",
+                "common": "Maldiverna"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0627\u0644\u062f\u06cc\u067e",
                 "common": "\u0645\u0627\u0644\u062f\u06cc\u067e"
@@ -22156,10 +22160,6 @@
             "zho": {
                 "official": "\u9a6c\u5c14\u4ee3\u592b\u5171\u548c\u56fd",
                 "common": "\u9a6c\u5c14\u4ee3\u592b"
-            },
-            "swe": {
-                "official": "Republiken Maldiverna",
-                "common": "Maldiverna"
             }
         },
         "latlng": [
@@ -22296,6 +22296,10 @@
                 "official": "Estados Unidos Mexicanos",
                 "common": "M\u00e9xico"
             },
+            "swe": {
+                "official": "Mexikos f\u00f6renta stater",
+                "common": "Mexiko"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u06c1\u0627\u0626\u06d2 \u0645\u062a\u062d\u062f\u06c1 \u0645\u06cc\u06a9\u0633\u06cc\u06a9\u0648",
                 "common": "\u0645\u06cc\u06a9\u0633\u06cc\u06a9\u0648"
@@ -22303,10 +22307,6 @@
             "zho": {
                 "official": "\u58a8\u897f\u54e5\u5408\u4f17\u56fd",
                 "common": "\u58a8\u897f\u54e5"
-            },
-            "swe": {
-                "official": "Mexikos f\u00f6renta stater",
-                "common": "Mexiko"
             }
         },
         "latlng": [
@@ -22451,6 +22451,10 @@
                 "official": "Rep\u00fablica de las Islas Marshall",
                 "common": "Islas Marshall"
             },
+            "swe": {
+                "official": "Republiken Marshall\u00f6arna",
+                "common": "Marshall\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062c\u0632\u0627\u0626\u0631 \u0645\u0627\u0631\u0634\u0644",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u0645\u0627\u0631\u0634\u0644"
@@ -22458,10 +22462,6 @@
             "zho": {
                 "official": "\u9a6c\u7ecd\u5c14\u7fa4\u5c9b\u5171\u548c\u56fd",
                 "common": "\u9a6c\u7ecd\u5c14\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Republiken Marshall\u00f6arna",
-                "common": "Marshall\u00f6arna"
             }
         },
         "latlng": [
@@ -22599,6 +22599,10 @@
                 "official": "Rep\u00fablica de Macedonia del Norte",
                 "common": "Macedonia del Norte"
             },
+            "swe": {
+                "official": "Republiken Nordmakedonien",
+                "common": "Nordmakedonien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1",
                 "common": "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
@@ -22606,10 +22610,6 @@
             "zho": {
                 "official": "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b",
                 "common": "\u5317\u99ac\u5176\u9813"
-            },
-            "swe": {
-                "official": "Republiken Nordmakedonien",
-                "common": "Nordmakedonien"
             }
         },
         "latlng": [
@@ -22751,6 +22751,10 @@
                 "official": "Rep\u00fablica de Mal\u00ed",
                 "common": "Mali"
             },
+            "swe": {
+                "official": "Republiken Mali",
+                "common": "Mali"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0627\u0644\u06cc",
                 "common": "\u0645\u0627\u0644\u06cc"
@@ -22758,10 +22762,6 @@
             "zho": {
                 "official": "\u9a6c\u91cc\u5171\u548c\u56fd",
                 "common": "\u9a6c\u91cc"
-            },
-            "swe": {
-                "official": "Republiken Mali",
-                "common": "Mali"
             }
         },
         "latlng": [
@@ -22910,6 +22910,10 @@
                 "official": "Rep\u00fablica de Malta",
                 "common": "Malta"
             },
+            "swe": {
+                "official": "Republiken Malta",
+                "common": "Malta"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0627\u0644\u0679\u0627",
                 "common": "\u0645\u0627\u0644\u0679\u0627"
@@ -22917,10 +22921,6 @@
             "zho": {
                 "official": "\u9a6c\u8033\u4ed6\u5171\u548c\u56fd",
                 "common": "\u9a6c\u8033\u4ed6"
-            },
-            "swe": {
-                "official": "Republiken Malta",
-                "common": "Malta"
             }
         },
         "latlng": [
@@ -23057,6 +23057,10 @@
                 "official": "Rep\u00fablica de la Uni\u00f3n de Myanmar",
                 "common": "Myanmar"
             },
+            "swe": {
+                "official": "Republiken Unionen Myanmar",
+                "common": "Myanmar"
+            },
             "urd": {
                 "official": "\u0645\u062a\u062d\u062f\u06c1 \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u06cc\u0627\u0646\u0645\u0627\u0631",
                 "common": "\u0645\u06cc\u0627\u0646\u0645\u0627\u0631"
@@ -23064,10 +23068,6 @@
             "zho": {
                 "official": "\u7f05\u7538\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u7f05\u7538"
-            },
-            "swe": {
-                "official": "Republiken Unionen Myanmar",
-                "common": "Myanmar"
             }
         },
         "latlng": [
@@ -23208,6 +23208,10 @@
                 "official": "Montenegro",
                 "common": "Montenegro"
             },
+            "swe": {
+                "official": "Montenegro",
+                "common": "Montenegro"
+            },
             "urd": {
                 "official": "\u0645\u0648\u0646\u0679\u06cc\u0646\u06cc\u06af\u0631\u0648",
                 "common": "\u0645\u0648\u0646\u0679\u06cc\u0646\u06cc\u06af\u0631\u0648"
@@ -23215,10 +23219,6 @@
             "zho": {
                 "official": "\u9ed1\u5c71",
                 "common": "\u9ed1\u5c71"
-            },
-            "swe": {
-                "official": "Montenegro",
-                "common": "Montenegro"
             }
         },
         "latlng": [
@@ -23358,6 +23358,10 @@
                 "official": "Mongolia",
                 "common": "Mongolia"
             },
+            "swe": {
+                "official": "Mongoliet",
+                "common": "Mongoliet"
+            },
             "urd": {
                 "official": "\u0645\u0646\u06af\u0648\u0644\u06cc\u0627",
                 "common": "\u0645\u0646\u06af\u0648\u0644\u06cc\u0627"
@@ -23365,10 +23369,6 @@
             "zho": {
                 "official": "\u8499\u53e4",
                 "common": "\u8499\u53e4"
-            },
-            "swe": {
-                "official": "Mongoliet",
-                "common": "Mongoliet"
             }
         },
         "latlng": [
@@ -23517,6 +23517,10 @@
                 "official": "Mancomunidad de las Islas Marianas del Norte",
                 "common": "Islas Marianas del Norte"
             },
+            "swe": {
+                "official": "Nordmarianerna",
+                "common": "Nordmarianerna"
+            },
             "urd": {
                 "official": "\u062f\u0648\u0644\u062a\u0650 \u0645\u0634\u062a\u0631\u06a9\u06c1 \u062c\u0632\u0627\u0626\u0631 \u0634\u0645\u0627\u0644\u06cc \u0645\u0627\u0631\u06cc\u0627\u0646\u0627",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u0634\u0645\u0627\u0644\u06cc \u0645\u0627\u0631\u06cc\u0627\u0646\u0627"
@@ -23524,10 +23528,6 @@
             "zho": {
                 "official": "\u5317\u9a6c\u91cc\u4e9a\u7eb3\u7fa4\u5c9b",
                 "common": "\u5317\u9a6c\u91cc\u4e9a\u7eb3\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Nordmarianerna",
-                "common": "Nordmarianerna"
             }
         },
         "latlng": [
@@ -23663,6 +23663,10 @@
                 "official": "Rep\u00fablica de Mozambique",
                 "common": "Mozambique"
             },
+            "swe": {
+                "official": "Republiken Mo\u00e7ambique",
+                "common": "Mo\u00e7ambique"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0648\u0632\u0645\u0628\u06cc\u0642",
                 "common": "\u0645\u0648\u0632\u0645\u0628\u06cc\u0642"
@@ -23670,10 +23674,6 @@
             "zho": {
                 "official": "\u83ab\u6851\u6bd4\u514b\u5171\u548c\u56fd",
                 "common": "\u83ab\u6851\u6bd4\u514b"
-            },
-            "swe": {
-                "official": "Republiken Mo\u00e7ambique",
-                "common": "Mo\u00e7ambique"
             }
         },
         "latlng": [
@@ -23816,6 +23816,10 @@
                 "official": "Rep\u00fablica Isl\u00e1mica de Mauritania",
                 "common": "Mauritania"
             },
+            "swe": {
+                "official": "Islamiska republiken Mauretanien",
+                "common": "Mauretanien"
+            },
             "urd": {
                 "official": "\u0627\u0633\u0644\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0648\u0631\u06cc\u062a\u0627\u0646\u06cc\u06c1",
                 "common": "\u0645\u0648\u0631\u06cc\u062a\u0627\u0646\u06cc\u06c1"
@@ -23823,10 +23827,6 @@
             "zho": {
                 "official": "\u6bdb\u91cc\u5854\u5c3c\u4e9a\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u6bdb\u91cc\u5854\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Islamiska republiken Mauretanien",
-                "common": "Mauretanien"
             }
         },
         "latlng": [
@@ -23965,6 +23965,10 @@
                 "official": "Montserrat",
                 "common": "Montserrat"
             },
+            "swe": {
+                "official": "Montserrat",
+                "common": "Montserrat"
+            },
             "urd": {
                 "official": "\u0645\u0627\u0646\u0679\u0633\u0631\u06cc\u0679",
                 "common": "\u0645\u0627\u0646\u0679\u0633\u0631\u06cc\u0679"
@@ -23972,10 +23976,6 @@
             "zho": {
                 "official": "\u8499\u7279\u585e\u62c9\u7279",
                 "common": "\u8499\u7279\u585e\u62c9\u7279"
-            },
-            "swe": {
-                "official": "Montserrat",
-                "common": "Montserrat"
             }
         },
         "latlng": [
@@ -24109,6 +24109,10 @@
                 "official": "Martinica",
                 "common": "Martinica"
             },
+            "swe": {
+                "official": "Martinique",
+                "common": "Martinique"
+            },
             "urd": {
                 "official": "\u0645\u0627\u0631\u0679\u06cc\u0646\u06cc\u06a9",
                 "common": "\u0645\u0627\u0631\u0679\u06cc\u0646\u06cc\u06a9"
@@ -24116,10 +24120,6 @@
             "zho": {
                 "official": "\u9a6c\u63d0\u5c3c\u514b",
                 "common": "\u9a6c\u63d0\u5c3c\u514b"
-            },
-            "swe": {
-                "official": "Martinique",
-                "common": "Martinique"
             }
         },
         "latlng": [
@@ -24265,6 +24265,10 @@
                 "official": "Rep\u00fablica de Mauricio",
                 "common": "Mauricio"
             },
+            "swe": {
+                "official": "Republiken Mauritius",
+                "common": "Mauritius"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0648\u0631\u06cc\u0634\u0633",
                 "common": "\u0645\u0648\u0631\u06cc\u0634\u0633"
@@ -24272,10 +24276,6 @@
             "zho": {
                 "official": "\u6bdb\u91cc\u6c42\u65af\u5171\u548c\u56fd",
                 "common": "\u6bdb\u91cc\u6c42\u65af"
-            },
-            "swe": {
-                "official": "Republiken Mauritius",
-                "common": "Mauritius"
             }
         },
         "latlng": [
@@ -24415,6 +24415,10 @@
                 "official": "Rep\u00fablica de Malawi",
                 "common": "Malawi"
             },
+            "swe": {
+                "official": "Republiken Malawi",
+                "common": "Malawi"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0644\u0627\u0648\u06cc",
                 "common": "\u0645\u0644\u0627\u0648\u06cc"
@@ -24422,10 +24426,6 @@
             "zho": {
                 "official": "\u9a6c\u62c9\u7ef4\u5171\u548c\u56fd",
                 "common": "\u9a6c\u62c9\u7ef4"
-            },
-            "swe": {
-                "official": "Republiken Malawi",
-                "common": "Malawi"
             }
         },
         "latlng": [
@@ -24568,6 +24568,10 @@
                 "official": "Malasia",
                 "common": "Malasia"
             },
+            "swe": {
+                "official": "Malaysia",
+                "common": "Malaysia"
+            },
             "urd": {
                 "official": "\u0645\u0644\u0627\u0626\u06cc\u0634\u06cc\u0627",
                 "common": "\u0645\u0644\u0627\u0626\u06cc\u0634\u06cc\u0627"
@@ -24575,10 +24579,6 @@
             "zho": {
                 "official": "\u9a6c\u6765\u897f\u4e9a",
                 "common": "\u9a6c\u6765\u897f\u4e9a"
-            },
-            "swe": {
-                "official": "Malaysia",
-                "common": "Malaysia"
             }
         },
         "latlng": [
@@ -24718,6 +24718,10 @@
                 "official": "Departamento de Mayotte",
                 "common": "Mayotte"
             },
+            "swe": {
+                "official": "Departementsomr\u00e5det Mayotte",
+                "common": "Mayotte"
+            },
             "urd": {
                 "official": "\u0645\u0627\u06cc\u0648\u0679",
                 "common": "\u0645\u0627\u06cc\u0648\u0679"
@@ -24725,10 +24729,6 @@
             "zho": {
                 "official": "\u9a6c\u7ea6\u7279",
                 "common": "\u9a6c\u7ea6\u7279"
-            },
-            "swe": {
-                "official": "Departementsomr\u00e5det Mayotte",
-                "common": "Mayotte"
             }
         },
         "latlng": [
@@ -24908,6 +24908,10 @@
                 "official": "Rep\u00fablica de Namibia",
                 "common": "Namibia"
             },
+            "swe": {
+                "official": "Republiken Namibia",
+                "common": "Namibia"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0646\u0645\u06cc\u0628\u06cc\u0627",
                 "common": "\u0646\u0645\u06cc\u0628\u06cc\u0627"
@@ -24915,10 +24919,6 @@
             "zho": {
                 "official": "\u7eb3\u7c73\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u7eb3\u7c73\u6bd4\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Namibia",
-                "common": "Namibia"
             }
         },
         "latlng": [
@@ -25057,6 +25057,10 @@
                 "official": "nueva Caledonia",
                 "common": "Nueva Caledonia"
             },
+            "swe": {
+                "official": "Nya Kaledonien",
+                "common": "Nya Kaledonien"
+            },
             "urd": {
                 "official": "\u0646\u06cc\u0648 \u06a9\u06cc\u0644\u06cc\u0688\u0648\u0646\u06cc\u0627",
                 "common": "\u0646\u06cc\u0648 \u06a9\u06cc\u0644\u06cc\u0688\u0648\u0646\u06cc\u0627"
@@ -25064,10 +25068,6 @@
             "zho": {
                 "official": "\u65b0\u5580\u91cc\u591a\u5c3c\u4e9a",
                 "common": "\u65b0\u5580\u91cc\u591a\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Nya Kaledonien",
-                "common": "Nya Kaledonien"
             }
         },
         "latlng": [
@@ -25202,6 +25202,10 @@
                 "official": "Rep\u00fablica de N\u00edger",
                 "common": "N\u00edger"
             },
+            "swe": {
+                "official": "Republiken Niger",
+                "common": "Niger"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0646\u0627\u0626\u062c\u0631",
                 "common": "\u0646\u0627\u0626\u062c\u0631"
@@ -25209,10 +25213,6 @@
             "zho": {
                 "official": "\u5c3c\u65e5\u5c14\u5171\u548c\u56fd",
                 "common": "\u5c3c\u65e5\u5c14"
-            },
-            "swe": {
-                "official": "Republiken Niger",
-                "common": "Niger"
             }
         },
         "latlng": [
@@ -25361,6 +25361,10 @@
                 "official": "Territorio de la Isla Norfolk",
                 "common": "Isla de Norfolk"
             },
+            "swe": {
+                "official": "Norfolk\u00f6n",
+                "common": "Norfolk\u00f6n"
+            },
             "urd": {
                 "official": "\u062c\u0632\u06cc\u0631\u06c1 \u0646\u0648\u0631\u0641\u06a9 \u062e\u0637\u06c1",
                 "common": "\u062c\u0632\u06cc\u0631\u06c1 \u0646\u0648\u0631\u0641\u06a9"
@@ -25368,10 +25372,6 @@
             "zho": {
                 "official": "\u8bfa\u798f\u514b\u5c9b",
                 "common": "\u8bfa\u798f\u514b\u5c9b"
-            },
-            "swe": {
-                "official": "Norfolk\u00f6n",
-                "common": "Norfolk\u00f6n"
             }
         },
         "latlng": [
@@ -25508,6 +25508,10 @@
                 "official": "Rep\u00fablica Federal de Nigeria",
                 "common": "Nigeria"
             },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Nigeria",
+                "common": "Nigeria"
+            },
             "urd": {
                 "official": "\u0648\u0641\u0627\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0646\u0627\u0626\u062c\u06cc\u0631\u06cc\u0627",
                 "common": "\u0646\u0627\u0626\u062c\u06cc\u0631\u06cc\u0627"
@@ -25515,10 +25519,6 @@
             "zho": {
                 "official": "\u5c3c\u65e5\u5229\u4e9a\u8054\u90a6\u5171\u548c\u56fd",
                 "common": "\u5c3c\u65e5\u5229\u4e9a"
-            },
-            "swe": {
-                "official": "F\u00f6rbundsrepubliken Nigeria",
-                "common": "Nigeria"
             }
         },
         "latlng": [
@@ -25659,6 +25659,10 @@
                 "official": "Rep\u00fablica de Nicaragua",
                 "common": "Nicaragua"
             },
+            "swe": {
+                "official": "Republiken Nicaragua",
+                "common": "Nicaragua"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0646\u06a9\u0627\u0631\u0627\u06af\u0648\u0627",
                 "common": "\u0646\u06a9\u0627\u0631\u0627\u06af\u0648\u0627"
@@ -25666,10 +25670,6 @@
             "zho": {
                 "official": "\u5c3c\u52a0\u62c9\u74dc\u5171\u548c\u56fd",
                 "common": "\u5c3c\u52a0\u62c9\u74dc"
-            },
-            "swe": {
-                "official": "Republiken Nicaragua",
-                "common": "Nicaragua"
             }
         },
         "latlng": [
@@ -25811,6 +25811,10 @@
                 "official": "Niue",
                 "common": "Niue"
             },
+            "swe": {
+                "official": "Niue",
+                "common": "Niue"
+            },
             "urd": {
                 "official": "\u0646\u06cc\u0648\u0648\u06d2",
                 "common": "\u0646\u06cc\u0648\u0648\u06d2"
@@ -25818,10 +25822,6 @@
             "zho": {
                 "official": "\u7ebd\u57c3",
                 "common": "\u7ebd\u57c3"
-            },
-            "swe": {
-                "official": "Niue",
-                "common": "Niue"
             }
         },
         "latlng": [
@@ -25958,6 +25958,10 @@
                 "official": "Pa\u00edses Bajos",
                 "common": "Pa\u00edses Bajos"
             },
+            "swe": {
+                "official": "Nederl\u00e4nderna",
+                "common": "Nederl\u00e4nderna"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0646\u06cc\u062f\u0631\u0644\u06cc\u0646\u0688\u0632",
                 "common": "\u0646\u06cc\u062f\u0631\u0644\u06cc\u0646\u0688\u0632"
@@ -25965,10 +25969,6 @@
             "zho": {
                 "official": "\u8377\u5170",
                 "common": "\u8377\u5170"
-            },
-            "swe": {
-                "official": "Nederl\u00e4nderna",
-                "common": "Nederl\u00e4nderna"
             }
         },
         "latlng": [
@@ -26120,6 +26120,10 @@
                 "official": "Reino de Noruega",
                 "common": "Noruega"
             },
+            "swe": {
+                "official": "Konungariket Norge",
+                "common": "Norge"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0646\u0627\u0631\u0648\u06d2",
                 "common": "\u0646\u0627\u0631\u0648\u06d2"
@@ -26127,10 +26131,6 @@
             "zho": {
                 "official": "\u632a\u5a01\u738b\u56fd",
                 "common": "\u632a\u5a01"
-            },
-            "swe": {
-                "official": "Konungariket Norge",
-                "common": "Norge"
             }
         },
         "latlng": [
@@ -26270,6 +26270,10 @@
                 "official": "Rep\u00fablica Democr\u00e1tica Federal de Nepal",
                 "common": "Nepal"
             },
+            "swe": {
+                "official": "Demokratiska f\u00f6rbundsrepubliken Nepal",
+                "common": "Nepal"
+            },
             "urd": {
                 "official": "\u0648\u0641\u0627\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0646\u06cc\u067e\u0627\u0644",
                 "common": "\u0646\u06cc\u067e\u0627\u0644"
@@ -26277,10 +26281,6 @@
             "zho": {
                 "official": "\u5c3c\u6cca\u5c14\u8054\u90a6\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u5c3c\u6cca\u5c14"
-            },
-            "swe": {
-                "official": "Demokratiska f\u00f6rbundsrepubliken Nepal",
-                "common": "Nepal"
             }
         },
         "latlng": [
@@ -26426,6 +26426,10 @@
                 "official": "Rep\u00fablica de Nauru",
                 "common": "Nauru"
             },
+            "swe": {
+                "official": "Republiken Nauru",
+                "common": "Nauru"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0646\u0627\u0648\u0631\u0648",
                 "common": "\u0646\u0627\u0648\u0631\u0648"
@@ -26433,10 +26437,6 @@
             "zho": {
                 "official": "\u7459\u9c81\u5171\u548c\u56fd",
                 "common": "\u7459\u9c81"
-            },
-            "swe": {
-                "official": "Republiken Nauru",
-                "common": "Nauru"
             }
         },
         "latlng": [
@@ -26581,6 +26581,10 @@
                 "official": "nueva Zelanda",
                 "common": "Nueva Zelanda"
             },
+            "swe": {
+                "official": "Nya Zeeland",
+                "common": "Nya Zeeland"
+            },
             "urd": {
                 "official": "\u0646\u06cc\u0648\u0632\u06cc \u0644\u06cc\u0646\u0688",
                 "common": "\u0646\u06cc\u0648\u0632\u06cc \u0644\u06cc\u0646\u0688"
@@ -26588,10 +26592,6 @@
             "zho": {
                 "official": "\u65b0\u897f\u5170",
                 "common": "\u65b0\u897f\u5170"
-            },
-            "swe": {
-                "official": "Nya Zeeland",
-                "common": "Nya Zeeland"
             }
         },
         "latlng": [
@@ -26727,6 +26727,10 @@
                 "official": "Sultanato de Om\u00e1n",
                 "common": "Om\u00e1n"
             },
+            "swe": {
+                "official": "Sultanatet Oman",
+                "common": "Oman"
+            },
             "urd": {
                 "official": "\u0633\u0644\u0637\u0646\u062a \u0639\u0645\u0627\u0646",
                 "common": "\u0639\u0645\u0627\u0646"
@@ -26734,10 +26738,6 @@
             "zho": {
                 "official": "\u963f\u66fc\u82cf\u4e39\u56fd",
                 "common": "\u963f\u66fc"
-            },
-            "swe": {
-                "official": "Sultanatet Oman",
-                "common": "Oman"
             }
         },
         "latlng": [
@@ -26883,6 +26883,10 @@
                 "official": "Rep\u00fablica Isl\u00e1mica de Pakist\u00e1n",
                 "common": "Pakist\u00e1n"
             },
+            "swe": {
+                "official": "Islamiska republiken Pakistan",
+                "common": "Pakistan"
+            },
             "urd": {
                 "official": "\u0627\u0633\u0644\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u067e\u0627\u06a9\u0633\u062a\u0627\u0646",
                 "common": "\u067e\u0627\u06a9\u0633\u062a\u0627\u0646"
@@ -26890,10 +26894,6 @@
             "zho": {
                 "official": "\u5df4\u57fa\u65af\u5766\u4f0a\u65af\u5170\u5171\u548c\u56fd",
                 "common": "\u5df4\u57fa\u65af\u5766"
-            },
-            "swe": {
-                "official": "Islamiska republiken Pakistan",
-                "common": "Pakistan"
             }
         },
         "latlng": [
@@ -27038,6 +27038,10 @@
                 "official": "Rep\u00fablica de Panam\u00e1",
                 "common": "Panam\u00e1"
             },
+            "swe": {
+                "official": "Republiken Panama",
+                "common": "Panama"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u067e\u0627\u0646\u0627\u0645\u0627",
                 "common": "\u067e\u0627\u0646\u0627\u0645\u0627"
@@ -27045,10 +27049,6 @@
             "zho": {
                 "official": "\u5df4\u62ff\u9a6c\u5171\u548c\u56fd",
                 "common": "\u5df4\u62ff\u9a6c"
-            },
-            "swe": {
-                "official": "Republiken Panama",
-                "common": "Panama"
             }
         },
         "latlng": [
@@ -27187,6 +27187,10 @@
                 "official": "Grupo de Islas Pitcairn",
                 "common": "Islas Pitcairn"
             },
+            "swe": {
+                "official": "Pitcairn\u00f6arna",
+                "common": "Pitcairn\u00f6arna"
+            },
             "urd": {
                 "official": "\u067e\u0679\u06a9\u06cc\u0631\u0646 \u062c\u0632\u0627\u0626\u0631",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u067e\u0679\u06a9\u06cc\u0631\u0646"
@@ -27194,10 +27198,6 @@
             "zho": {
                 "official": "\u76ae\u7279\u51ef\u6069\u7fa4\u5c9b",
                 "common": "\u76ae\u7279\u51ef\u6069\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Pitcairn\u00f6arna",
-                "common": "Pitcairn\u00f6arna"
             }
         },
         "latlng": [
@@ -27343,6 +27343,10 @@
                 "official": "Rep\u00fablica de Per\u00fa",
                 "common": "Per\u00fa"
             },
+            "swe": {
+                "official": "Republiken Peru",
+                "common": "Peru"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u067e\u06cc\u0631\u0648",
                 "common": "\u067e\u06cc\u0631\u0648"
@@ -27350,10 +27354,6 @@
             "zho": {
                 "official": "\u79d8\u9c81\u5171\u548c\u56fd",
                 "common": "\u79d8\u9c81"
-            },
-            "swe": {
-                "official": "Republiken Peru",
-                "common": "Peru"
             }
         },
         "latlng": [
@@ -27500,6 +27500,10 @@
                 "official": "Rep\u00fablica de las Filipinas",
                 "common": "Filipinas"
             },
+            "swe": {
+                "official": "Republiken Filippinerna",
+                "common": "Filippinerna"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0641\u0644\u067e\u0627\u0626\u0646",
                 "common": "\u0641\u0644\u067e\u0627\u0626\u0646"
@@ -27507,10 +27511,6 @@
             "zho": {
                 "official": "\u83f2\u5f8b\u5bbe\u5171\u548c\u56fd",
                 "common": "\u83f2\u5f8b\u5bbe"
-            },
-            "swe": {
-                "official": "Republiken Filippinerna",
-                "common": "Filippinerna"
             }
         },
         "latlng": [
@@ -27651,6 +27651,10 @@
                 "official": "Rep\u00fablica de Palau",
                 "common": "Palau"
             },
+            "swe": {
+                "official": "Republiken Palau",
+                "common": "Palau"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u067e\u0644\u0627\u0624",
                 "common": "\u067e\u0644\u0627\u0624"
@@ -27658,10 +27662,6 @@
             "zho": {
                 "official": "\u5e15\u52b3\u5171\u548c\u56fd",
                 "common": "\u5e15\u52b3"
-            },
-            "swe": {
-                "official": "Republiken Palau",
-                "common": "Palau"
             }
         },
         "latlng": [
@@ -27807,6 +27807,10 @@
                 "official": "Estado Independiente de Pap\u00faa Nueva Guinea",
                 "common": "Pap\u00faa Nueva Guinea"
             },
+            "swe": {
+                "official": "Den oberoende staten Papua Nya Guinea",
+                "common": "Papua Nya Guinea"
+            },
             "urd": {
                 "official": "\u0622\u0632\u0627\u062f \u0631\u06cc\u0627\u0633\u062a\u0650 \u067e\u0627\u067e\u0648\u0627 \u0646\u06cc\u0648 \u06af\u0646\u06cc",
                 "common": "\u067e\u0627\u067e\u0648\u0627 \u0646\u06cc\u0648 \u06af\u0646\u06cc"
@@ -27814,10 +27818,6 @@
             "zho": {
                 "official": "\u5df4\u5e03\u4e9a\u65b0\u51e0\u5185\u4e9a",
                 "common": "\u5df4\u5e03\u4e9a\u65b0\u51e0\u5185\u4e9a"
-            },
-            "swe": {
-                "official": "Den oberoende staten Papua Nya Guinea",
-                "common": "Papua Nya Guinea"
             }
         },
         "latlng": [
@@ -27955,6 +27955,10 @@
                 "official": "Rep\u00fablica de Polonia",
                 "common": "Polonia"
             },
+            "swe": {
+                "official": "Republiken Polen",
+                "common": "Polen"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u067e\u0648\u0644\u06cc\u0646\u0688",
                 "common": "\u067e\u0648\u0644\u06cc\u0646\u0688"
@@ -27962,10 +27966,6 @@
             "zho": {
                 "official": "\u6ce2\u5170\u5171\u548c\u56fd",
                 "common": "\u6ce2\u5170"
-            },
-            "swe": {
-                "official": "Republiken Polen",
-                "common": "Polen"
             }
         },
         "latlng": [
@@ -28115,6 +28115,10 @@
                 "official": "Asociado de Puerto Rico",
                 "common": "Puerto Rico"
             },
+            "swe": {
+                "official": "Puerto Rico",
+                "common": "Puerto Rico"
+            },
             "urd": {
                 "official": " \u062f\u0648\u0644\u062a\u0650 \u0645\u0634\u062a\u0631\u06a9\u06c1 \u067e\u0648\u0631\u0679\u0648 \u0631\u06cc\u06a9\u0648",
                 "common": "\u067e\u0648\u0631\u0679\u0648 \u0631\u06cc\u06a9\u0648"
@@ -28122,10 +28126,6 @@
             "zho": {
                 "official": "\u6ce2\u591a\u9ece\u5404\u8054\u90a6",
                 "common": "\u6ce2\u591a\u9ece\u5404"
-            },
-            "swe": {
-                "official": "Puerto Rico",
-                "common": "Puerto Rico"
             }
         },
         "latlng": [
@@ -28266,6 +28266,10 @@
                 "official": "Rep\u00fablica Popular Democr\u00e1tica de Corea",
                 "common": "Corea del Norte"
             },
+            "swe": {
+                "official": "Demokratiska Folkrepubliken Korea",
+                "common": "Nordkorea"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc \u0639\u0648\u0627\u0645\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06a9\u0648\u0631\u06cc\u0627",
                 "common": "\u0634\u0645\u0627\u0644\u06cc \u06a9\u0648\u0631\u06cc\u0627"
@@ -28273,10 +28277,6 @@
             "zho": {
                 "official": "\u671d\u9c9c\u4eba\u6c11\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u671d\u9c9c"
-            },
-            "swe": {
-                "official": "Demokratiska Folkrepubliken Korea",
-                "common": "Nordkorea"
             }
         },
         "latlng": [
@@ -28417,6 +28417,10 @@
                 "official": "Rep\u00fablica Portuguesa",
                 "common": "Portugal"
             },
+            "swe": {
+                "official": "Republiken Portugal",
+                "common": "Portugal"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u067e\u0631\u062a\u06af\u0627\u0644",
                 "common": "\u067e\u0631\u062a\u06af\u0627\u0644"
@@ -28424,10 +28428,6 @@
             "zho": {
                 "official": "\u8461\u8404\u7259\u5171\u548c\u56fd",
                 "common": "\u8461\u8404\u7259"
-            },
-            "swe": {
-                "official": "Republiken Portugal",
-                "common": "Portugal"
             }
         },
         "latlng": [
@@ -28571,6 +28571,10 @@
                 "official": "Rep\u00fablica de Paraguay",
                 "common": "Paraguay"
             },
+            "swe": {
+                "official": "Republiken Paraguay",
+                "common": "Paraguay"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u067e\u06cc\u0631\u0627\u06af\u0648\u0626\u06d2",
                 "common": "\u067e\u06cc\u0631\u0627\u06af\u0648\u0626\u06d2"
@@ -28578,10 +28582,6 @@
             "zho": {
                 "official": "\u5df4\u62c9\u572d\u5171\u548c\u56fd",
                 "common": "\u5df4\u62c9\u572d"
-            },
-            "swe": {
-                "official": "Republiken Paraguay",
-                "common": "Paraguay"
             }
         },
         "latlng": [
@@ -28731,6 +28731,10 @@
                 "official": "Estado de Palestina",
                 "common": "Palestina"
             },
+            "swe": {
+                "official": "Palestina",
+                "common": "Palestina"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u0650 \u0641\u0644\u0633\u0637\u06cc\u0646",
                 "common": "\u0641\u0644\u0633\u0637\u06cc\u0646"
@@ -28738,10 +28742,6 @@
             "zho": {
                 "official": "\u5df4\u52d2\u65af\u5766\u56fd",
                 "common": "\u5df4\u52d2\u65af\u5766"
-            },
-            "swe": {
-                "official": "Palestina",
-                "common": "Palestina"
             }
         },
         "latlng": [
@@ -28882,6 +28882,10 @@
                 "official": "Polinesia franc\u00e9s",
                 "common": "Polinesia Francesa"
             },
+            "swe": {
+                "official": "Franska Polynesien",
+                "common": "Franska Polynesien"
+            },
             "urd": {
                 "official": "\u0641\u0631\u0627\u0646\u0633\u06cc\u0633\u06cc \u067e\u0648\u0644\u06cc\u0646\u06cc\u0634\u06cc\u0627",
                 "common": "\u0641\u0631\u0627\u0646\u0633\u06cc\u0633\u06cc \u067e\u0648\u0644\u06cc\u0646\u06cc\u0634\u06cc\u0627"
@@ -28889,10 +28893,6 @@
             "zho": {
                 "official": "\u6cd5\u5c5e\u6ce2\u5229\u5c3c\u897f\u4e9a",
                 "common": "\u6cd5\u5c5e\u6ce2\u5229\u5c3c\u897f\u4e9a"
-            },
-            "swe": {
-                "official": "Franska Polynesien",
-                "common": "Franska Polynesien"
             }
         },
         "latlng": [
@@ -29029,6 +29029,10 @@
                 "official": "Estado de Qatar",
                 "common": "Catar"
             },
+            "swe": {
+                "official": "Staten Qatar",
+                "common": "Qatar"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u0650 \u0642\u0637\u0631",
                 "common": "\u0642\u0637\u0631"
@@ -29036,10 +29040,6 @@
             "zho": {
                 "official": "\u5361\u5854\u5c14\u56fd",
                 "common": "\u5361\u5854\u5c14"
-            },
-            "swe": {
-                "official": "Staten Qatar",
-                "common": "Qatar"
             }
         },
         "latlng": [
@@ -29176,6 +29176,10 @@
                 "official": "Isla de la Reuni\u00f3n",
                 "common": "Reuni\u00f3n"
             },
+            "swe": {
+                "official": "R\u00e9union",
+                "common": "R\u00e9union"
+            },
             "urd": {
                 "official": "\u0631\u06d2 \u06cc\u0648\u0646\u06cc\u0648\u06ba \u062c\u0632\u06cc\u0631\u06c1",
                 "common": "\u0631\u06d2 \u06cc\u0648\u0646\u06cc\u0648\u06ba"
@@ -29183,10 +29187,6 @@
             "zho": {
                 "official": "\u7559\u5c3c\u65fa\u5c9b",
                 "common": "\u7559\u5c3c\u65fa\u5c9b"
-            },
-            "swe": {
-                "official": "R\u00e9union",
-                "common": "R\u00e9union"
             }
         },
         "latlng": [
@@ -29323,6 +29323,10 @@
                 "official": "Rumania",
                 "common": "Rumania"
             },
+            "swe": {
+                "official": "Rum\u00e4nien",
+                "common": "Rum\u00e4nien"
+            },
             "urd": {
                 "official": "\u0631\u0648\u0645\u0627\u0646\u06cc\u06c1",
                 "common": "\u0631\u0648\u0645\u0627\u0646\u06cc\u06c1"
@@ -29330,10 +29334,6 @@
             "zho": {
                 "official": "\u7f57\u9a6c\u5c3c\u4e9a",
                 "common": "\u7f57\u9a6c\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Rum\u00e4nien",
-                "common": "Rum\u00e4nien"
             }
         },
         "latlng": [
@@ -29481,6 +29481,10 @@
                 "official": "Federaci\u00f3n de Rusia",
                 "common": "Rusia"
             },
+            "swe": {
+                "official": "Ryska federationen",
+                "common": "Ryssland"
+            },
             "urd": {
                 "official": "\u0631\u0648\u0633\u06cc \u0648\u0641\u0627\u0642",
                 "common": "\u0631\u0648\u0633"
@@ -29488,10 +29492,6 @@
             "zho": {
                 "official": "\u4fc4\u7f57\u65af\u8054\u90a6",
                 "common": "\u4fc4\u7f57\u65af"
-            },
-            "swe": {
-                "official": "Ryska federationen",
-                "common": "Ryssland"
             }
         },
         "latlng": [
@@ -29653,6 +29653,10 @@
                 "official": "Rep\u00fablica de Rwanda",
                 "common": "Ruanda"
             },
+            "swe": {
+                "official": "Republiken Rwanda",
+                "common": "Rwanda"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0631\u0648\u0627\u0646\u0688\u0627",
                 "common": "\u0631\u0648\u0627\u0646\u0688\u0627"
@@ -29660,10 +29664,6 @@
             "zho": {
                 "official": "\u5362\u65fa\u8fbe\u5171\u548c\u56fd",
                 "common": "\u5362\u65fa\u8fbe"
-            },
-            "swe": {
-                "official": "Republiken Rwanda",
-                "common": "Rwanda"
             }
         },
         "latlng": [
@@ -29806,6 +29806,10 @@
                 "official": "Reino de Arabia Saudita",
                 "common": "Arabia Saud\u00ed"
             },
+            "swe": {
+                "official": "Kungad\u00f6met Saudiarabien",
+                "common": "Saudiarabien"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0633\u0639\u0648\u062f\u06cc \u0639\u0631\u0628",
                 "common": "\u0633\u0639\u0648\u062f\u06cc \u0639\u0631\u0628"
@@ -29813,10 +29817,6 @@
             "zho": {
                 "official": "\u6c99\u7279\u963f\u62c9\u4f2f\u738b\u56fd",
                 "common": "\u6c99\u7279\u963f\u62c9\u4f2f"
-            },
-            "swe": {
-                "official": "Kungad\u00f6met Saudiarabien",
-                "common": "Saudiarabien"
             }
         },
         "latlng": [
@@ -29965,6 +29965,10 @@
                 "official": "Rep\u00fablica de Sud\u00e1n",
                 "common": "Sud\u00e1n"
             },
+            "swe": {
+                "official": "Republiken Sudan",
+                "common": "Sudan"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0648\u062f\u0627\u0646",
                 "common": "\u0633\u0648\u062f\u0627\u0646"
@@ -29972,10 +29976,6 @@
             "zho": {
                 "official": "\u82cf\u4e39\u5171\u548c\u56fd",
                 "common": "\u82cf\u4e39"
-            },
-            "swe": {
-                "official": "Republiken Sudan",
-                "common": "Sudan"
             }
         },
         "latlng": [
@@ -30119,6 +30119,10 @@
                 "official": "Rep\u00fablica de Senegal",
                 "common": "Senegal"
             },
+            "swe": {
+                "official": "Republiken Senegal",
+                "common": "Senegal"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u06cc\u0646\u06cc\u06af\u0627\u0644",
                 "common": "\u0633\u06cc\u0646\u06cc\u06af\u0627\u0644"
@@ -30126,10 +30130,6 @@
             "zho": {
                 "official": "\u585e\u5185\u52a0\u5c14\u5171\u548c\u56fd",
                 "common": "\u585e\u5185\u52a0\u5c14"
-            },
-            "swe": {
-                "official": "Republiken Senegal",
-                "common": "Senegal"
             }
         },
         "latlng": [
@@ -30289,13 +30289,13 @@
                 "official": "Rep\u00fablica de Singapur",
                 "common": "Singapur"
             },
-            "urd": {
-                "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0646\u06af\u0627\u067e\u0648\u0631",
-                "common": "\u0633\u0646\u06af\u0627\u067e\u0648\u0631"
-            },
             "swe": {
                 "official": "Republiken Singapore",
                 "common": "Singapore"
+            },
+            "urd": {
+                "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0646\u06af\u0627\u067e\u0648\u0631",
+                "common": "\u0633\u0646\u06af\u0627\u067e\u0648\u0631"
             }
         },
         "latlng": [
@@ -30430,6 +30430,10 @@
                 "official": "Georgia del Sur y las Islas Sandwich del Sur",
                 "common": "Islas Georgias del Sur y Sandwich del Sur"
             },
+            "swe": {
+                "official": "Sydgeorgien",
+                "common": "Sydgeorgien"
+            },
             "urd": {
                 "official": "\u062c\u0646\u0648\u0628\u06cc \u062c\u0627\u0631\u062c\u06cc\u0627 \u0648 \u062c\u0632\u0627\u0626\u0631 \u062c\u0646\u0648\u0628\u06cc \u0633\u06cc\u0646\u0688\u0648\u0686",
                 "common": "\u062c\u0646\u0648\u0628\u06cc \u062c\u0627\u0631\u062c\u06cc\u0627"
@@ -30437,10 +30441,6 @@
             "zho": {
                 "official": "\u5357\u4e54\u6cbb\u4e9a\u5c9b\u548c\u5357\u6851\u5a01\u5947\u7fa4\u5c9b",
                 "common": "\u5357\u4e54\u6cbb\u4e9a"
-            },
-            "swe": {
-                "official": "Sydgeorgien",
-                "common": "Sydgeorgien"
             }
         },
         "latlng": [
@@ -30575,6 +30575,10 @@
                 "official": "Svalbard og Jan Mayen",
                 "common": "Islas Svalbard y Jan Mayen"
             },
+            "swe": {
+                "official": "Svalbard och Jan Mayen",
+                "common": "Svalbard och Jan Mayen"
+            },
             "urd": {
                 "official": "\u0633\u0648\u0627\u0644\u0628\u0627\u0631\u0688 \u0627\u0648\u0631 \u062c\u0627\u0646 \u0645\u06cc\u0626\u0646",
                 "common": "\u0633\u0648\u0627\u0644\u0628\u0627\u0631\u0688 \u0627\u0648\u0631 \u062c\u0627\u0646 \u0645\u06cc\u0626\u0646"
@@ -30582,10 +30586,6 @@
             "zho": {
                 "official": "\u65af\u74e6\u5c14\u5df4\u7279",
                 "common": "\u65af\u74e6\u5c14\u5df4\u7279"
-            },
-            "swe": {
-                "official": "Svalbard och Jan Mayen",
-                "common": "Svalbard och Jan Mayen"
             }
         },
         "latlng": [
@@ -30719,6 +30719,10 @@
                 "official": "islas Salom\u00f3n",
                 "common": "Islas Salom\u00f3n"
             },
+            "swe": {
+                "official": "Salomon\u00f6arna",
+                "common": "Salomon\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 \u0633\u0644\u06cc\u0645\u0627\u0646",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u0633\u0644\u06cc\u0645\u0627\u0646"
@@ -30726,10 +30730,6 @@
             "zho": {
                 "official": "\u6240\u7f57\u95e8\u7fa4\u5c9b",
                 "common": "\u6240\u7f57\u95e8\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Salomon\u00f6arna",
-                "common": "Salomon\u00f6arna"
             }
         },
         "latlng": [
@@ -30864,6 +30864,10 @@
                 "official": "Rep\u00fablica de Sierra Leona",
                 "common": "Sierra Leone"
             },
+            "swe": {
+                "official": "Republiken Sierra Leone",
+                "common": "Sierra Leone"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u06cc\u0631\u0627\u0644\u06cc\u0648\u0646",
                 "common": "\u0633\u06cc\u0631\u0627\u0644\u06cc\u0648\u0646"
@@ -30871,10 +30875,6 @@
             "zho": {
                 "official": "\u585e\u62c9\u5229\u6602\u5171\u548c\u56fd",
                 "common": "\u585e\u62c9\u5229\u6602"
-            },
-            "swe": {
-                "official": "Republiken Sierra Leone",
-                "common": "Sierra Leone"
             }
         },
         "latlng": [
@@ -31017,6 +31017,10 @@
                 "official": "Rep\u00fablica de El Salvador",
                 "common": "El Salvador"
             },
+            "swe": {
+                "official": "Republiken El Salvador",
+                "common": "El Salvador"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u06cc\u0644 \u0633\u06cc\u0644\u0648\u0627\u0688\u0648\u0631",
                 "common": "\u0627\u06cc\u0644 \u0633\u06cc\u0644\u0648\u0627\u0688\u0648\u0631"
@@ -31024,10 +31028,6 @@
             "zho": {
                 "official": "\u8428\u5c14\u74e6\u591a\u5171\u548c\u56fd",
                 "common": "\u8428\u5c14\u74e6\u591a"
-            },
-            "swe": {
-                "official": "Republiken El Salvador",
-                "common": "El Salvador"
             }
         },
         "latlng": [
@@ -31166,6 +31166,10 @@
                 "official": "Seren\u00edsima Rep\u00fablica de San Marino",
                 "common": "San Marino"
             },
+            "swe": {
+                "official": "Republiken San Marino",
+                "common": "San Marino"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0627\u0646 \u0645\u0627\u0631\u06cc\u0646\u0648",
                 "common": "\u0633\u0627\u0646 \u0645\u0627\u0631\u06cc\u0646\u0648"
@@ -31173,10 +31177,6 @@
             "zho": {
                 "official": "\u5723\u9a6c\u529b\u8bfa\u5171\u548c\u56fd",
                 "common": "\u5723\u9a6c\u529b\u8bfa"
-            },
-            "swe": {
-                "official": "Republiken San Marino",
-                "common": "San Marino"
             }
         },
         "latlng": [
@@ -31321,6 +31321,10 @@
                 "official": "Rep\u00fablica Federal de Somalia",
                 "common": "Somalia"
             },
+            "swe": {
+                "official": "F\u00f6rbundsrepubliken Somalia",
+                "common": "Somalia"
+            },
             "urd": {
                 "official": "\u0648\u0641\u0627\u0642\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0635\u0648\u0645\u0627\u0644\u06cc\u06c1",
                 "common": "\u0635\u0648\u0645\u0627\u0644\u06cc\u06c1"
@@ -31328,10 +31332,6 @@
             "zho": {
                 "official": "\u7d22\u9a6c\u91cc\u5171\u548c\u56fd",
                 "common": "\u7d22\u9a6c\u91cc"
-            },
-            "swe": {
-                "official": "F\u00f6rbundsrepubliken Somalia",
-                "common": "Somalia"
             }
         },
         "latlng": [
@@ -31470,6 +31470,10 @@
                 "official": "San Pedro y Miquel\u00f3n",
                 "common": "San Pedro y Miquel\u00f3n"
             },
+            "swe": {
+                "official": "Saint-Pierre och Miquelon",
+                "common": "Saint-Pierre och Miquelon"
+            },
             "urd": {
                 "official": "\u0633\u06cc\u0646\u0679 \u067e\u06cc\u0626\u0631 \u0648 \u0645\u06cc\u06a9\u06cc\u0644\u0648\u0646",
                 "common": "\u0633\u06cc\u0646\u0679 \u067e\u06cc\u0626\u0631 \u0648 \u0645\u06cc\u06a9\u06cc\u0644\u0648\u0646"
@@ -31477,10 +31481,6 @@
             "zho": {
                 "official": "\u5723\u76ae\u57c3\u5c14\u548c\u5bc6\u514b\u9686",
                 "common": "\u5723\u76ae\u57c3\u5c14\u548c\u5bc6\u514b\u9686"
-            },
-            "swe": {
-                "official": "Saint-Pierre och Miquelon",
-                "common": "Saint-Pierre och Miquelon"
             }
         },
         "latlng": [
@@ -31619,6 +31619,10 @@
                 "official": "Rep\u00fablica de Serbia",
                 "common": "Serbia"
             },
+            "swe": {
+                "official": "Republiken Serbien",
+                "common": "Serbien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0631\u0628\u06cc\u0627",
                 "common": "\u0633\u0631\u0628\u06cc\u0627"
@@ -31626,10 +31630,6 @@
             "zho": {
                 "official": "\u585e\u5c14\u7ef4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u585e\u5c14\u7ef4\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Serbien",
-                "common": "Serbien"
             }
         },
         "latlng": [
@@ -31772,6 +31772,10 @@
                 "official": "Rep\u00fablica de Sud\u00e1n del Sur",
                 "common": "Sud\u00e1n del Sur"
             },
+            "swe": {
+                "official": "Republiken Sydsudan",
+                "common": "Sydsudan"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062c\u0646\u0648\u0628\u06cc \u0633\u0648\u0688\u0627\u0646",
                 "common": "\u062c\u0646\u0648\u0628\u06cc \u0633\u0648\u0688\u0627\u0646"
@@ -31779,10 +31783,6 @@
             "zho": {
                 "official": "\u5357\u82cf\u4e39\u5171\u548c\u56fd",
                 "common": "\u5357\u82cf\u4e39"
-            },
-            "swe": {
-                "official": "Republiken Sydsudan",
-                "common": "Sydsudan"
             }
         },
         "latlng": [
@@ -31926,6 +31926,10 @@
                 "official": "Rep\u00fablica Democr\u00e1tica de Santo Tom\u00e9 y Pr\u00edncipe",
                 "common": "Santo Tom\u00e9 y Pr\u00edncipe"
             },
+            "swe": {
+                "official": "Demokratiska republiken S\u00e3o Tom\u00e9 och Pr\u00edncipe",
+                "common": "S\u00e3o Tom\u00e9 och Pr\u00edncipe"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0627\u0624 \u0679\u0648\u0645\u06d2 \u0648 \u067e\u0631\u0646\u0633\u067e\u06d2",
                 "common": "\u0633\u0627\u0624 \u0679\u0648\u0645\u06d2 \u0648 \u067e\u0631\u0646\u0633\u067e\u06d2"
@@ -31933,10 +31937,6 @@
             "zho": {
                 "official": "\u5723\u591a\u7f8e\u548c\u666e\u6797\u897f\u6bd4\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u5723\u591a\u7f8e\u548c\u666e\u6797\u897f\u6bd4"
-            },
-            "swe": {
-                "official": "Demokratiska republiken S\u00e3o Tom\u00e9 och Pr\u00edncipe",
-                "common": "S\u00e3o Tom\u00e9 och Pr\u00edncipe"
             }
         },
         "latlng": [
@@ -32074,6 +32074,10 @@
                 "official": "Rep\u00fablica de Suriname",
                 "common": "Surinam"
             },
+            "swe": {
+                "official": "Republiken Surinam",
+                "common": "Surinam"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0631\u06cc\u0646\u0627\u0645",
                 "common": "\u0633\u0631\u06cc\u0646\u0627\u0645"
@@ -32081,10 +32085,6 @@
             "zho": {
                 "official": "\u82cf\u91cc\u5357\u5171\u548c\u56fd",
                 "common": "\u82cf\u91cc\u5357"
-            },
-            "swe": {
-                "official": "Republiken Surinam",
-                "common": "Surinam"
             }
         },
         "latlng": [
@@ -32224,6 +32224,10 @@
                 "official": "Rep\u00fablica Eslovaca",
                 "common": "Rep\u00fablica Eslovaca"
             },
+            "swe": {
+                "official": "Republiken Slovakien",
+                "common": "Slovakien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0644\u0648\u0648\u0627\u06a9\u06cc\u06c1",
                 "common": "\u0633\u0644\u0648\u0648\u0627\u06a9\u06cc\u06c1"
@@ -32231,10 +32235,6 @@
             "zho": {
                 "official": "\u65af\u6d1b\u4f10\u514b\u5171\u548c\u56fd",
                 "common": "\u65af\u6d1b\u4f10\u514b"
-            },
-            "swe": {
-                "official": "Republiken Slovakien",
-                "common": "Slovakien"
             }
         },
         "latlng": [
@@ -32376,6 +32376,10 @@
                 "official": "Rep\u00fablica de Eslovenia",
                 "common": "Eslovenia"
             },
+            "swe": {
+                "official": "Republiken Slovenien",
+                "common": "Slovenien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0644\u0648\u0648\u06cc\u0646\u06cc\u0627",
                 "common": "\u0633\u0644\u0648\u0648\u06cc\u0646\u06cc\u0627"
@@ -32383,10 +32387,6 @@
             "zho": {
                 "official": "\u65af\u6d1b\u6587\u5c3c\u4e9a\u5171\u548c\u56fd",
                 "common": "\u65af\u6d1b\u6587\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Slovenien",
-                "common": "Slovenien"
             }
         },
         "latlng": [
@@ -32527,6 +32527,10 @@
                 "official": "Reino de Suecia",
                 "common": "Suecia"
             },
+            "swe": {
+                "official": "Konungariket Sverige",
+                "common": "Sverige"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0633\u0648\u06cc\u0688\u0646",
                 "common": "\u0633\u0648\u06cc\u0688\u0646"
@@ -32534,10 +32538,6 @@
             "zho": {
                 "official": "\u745e\u5178\u738b\u56fd",
                 "common": "\u745e\u5178"
-            },
-            "swe": {
-                "official": "Konungariket Sverige",
-                "common": "Sverige"
             }
         },
         "latlng": [
@@ -32689,6 +32689,10 @@
                 "official": "Reino de eSwatini",
                 "common": "Suazilandia"
             },
+            "swe": {
+                "official": "Konungariket Eswatini",
+                "common": "Swaziland"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0633\u0648\u0627\u0632\u06cc \u0644\u06cc\u0646\u0688",
                 "common": "\u0633\u0648\u0627\u0632\u06cc \u0644\u06cc\u0646\u0688"
@@ -32696,10 +32700,6 @@
             "zho": {
                 "official": "\u65af\u5a01\u58eb\u5170\u738b\u56fd",
                 "common": "\u65af\u5a01\u58eb\u5170"
-            },
-            "swe": {
-                "official": "Konungariket Eswatini",
-                "common": "Swaziland"
             }
         },
         "latlng": [
@@ -32847,6 +32847,10 @@
                 "official": "Sint Maarten",
                 "common": "Sint Maarten"
             },
+            "swe": {
+                "official": "Sint Maarten",
+                "common": "Sint Maarten"
+            },
             "urd": {
                 "official": "\u0633\u0646\u0679 \u0645\u0627\u0631\u0679\u0646",
                 "common": "\u0633\u0646\u0679 \u0645\u0627\u0631\u0679\u0646"
@@ -32854,10 +32858,6 @@
             "zho": {
                 "official": "\u5723\u9a6c\u4e01\u5c9b",
                 "common": "\u5723\u9a6c\u4e01\u5c9b"
-            },
-            "swe": {
-                "official": "Sint Maarten",
-                "common": "Sint Maarten"
             }
         },
         "latlng": [
@@ -33006,6 +33006,10 @@
                 "official": "Rep\u00fablica de las Seychelles",
                 "common": "Seychelles"
             },
+            "swe": {
+                "official": "Republiken Seychellerna",
+                "common": "Seychellerna"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u06cc\u0686\u06cc\u0644\u06cc\u0633",
                 "common": "\u0633\u06cc\u0686\u06cc\u0644\u06cc\u0633"
@@ -33013,10 +33017,6 @@
             "zho": {
                 "official": "\u585e\u820c\u5c14\u5171\u548c\u56fd",
                 "common": "\u585e\u820c\u5c14"
-            },
-            "swe": {
-                "official": "Republiken Seychellerna",
-                "common": "Seychellerna"
             }
         },
         "latlng": [
@@ -33153,6 +33153,10 @@
                 "official": "Rep\u00fablica \u00c1rabe Siria",
                 "common": "Siria"
             },
+            "swe": {
+                "official": "Syriska arabiska republiken",
+                "common": "Syrien"
+            },
             "urd": {
                 "official": "\u0639\u0631\u0628 \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0633\u0648\u0631\u06cc\u06c1",
                 "common": "\u0633\u0648\u0631\u06cc\u06c1"
@@ -33160,10 +33164,6 @@
             "zho": {
                 "official": "\u53d9\u5229\u4e9a\u963f\u62c9\u4f2f\u5171\u548c\u56fd",
                 "common": "\u53d9\u5229\u4e9a"
-            },
-            "swe": {
-                "official": "Syriska arabiska republiken",
-                "common": "Syrien"
             }
         },
         "latlng": [
@@ -33303,6 +33303,10 @@
                 "official": "Islas Turcas y Caicos",
                 "common": "Islas Turks y Caicos"
             },
+            "swe": {
+                "official": "Turks- och Caicos\u00f6arna",
+                "common": "Turks- och Caicos\u00f6arna"
+            },
             "urd": {
                 "official": "\u062c\u0632\u0627\u0626\u0631 \u06a9\u06cc\u06a9\u0633 \u0648 \u062a\u0631\u06a9\u06cc\u06c1",
                 "common": "\u062c\u0632\u0627\u0626\u0631 \u06a9\u06cc\u06a9\u0633 \u0648 \u062a\u0631\u06a9\u06cc\u06c1"
@@ -33310,10 +33314,6 @@
             "zho": {
                 "official": "\u7279\u514b\u65af\u548c\u51ef\u79d1\u65af\u7fa4\u5c9b",
                 "common": "\u7279\u514b\u65af\u548c\u51ef\u79d1\u65af\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Turks- och Caicos\u00f6arna",
-                "common": "Turks- och Caicos\u00f6arna"
             }
         },
         "latlng": [
@@ -33459,6 +33459,10 @@
                 "official": "Rep\u00fablica de Chad",
                 "common": "Chad"
             },
+            "swe": {
+                "official": "Republiken Tchad",
+                "common": "Tchad"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u0627\u0688",
                 "common": "\u0686\u0627\u0688"
@@ -33466,10 +33470,6 @@
             "zho": {
                 "official": "\u4e4d\u5f97\u5171\u548c\u56fd",
                 "common": "\u4e4d\u5f97"
-            },
-            "swe": {
-                "official": "Republiken Tchad",
-                "common": "Tchad"
             }
         },
         "latlng": [
@@ -33613,6 +33613,10 @@
                 "official": "Rep\u00fablica de Togo",
                 "common": "Togo"
             },
+            "swe": {
+                "official": "Republiken Togo",
+                "common": "Togo"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0679\u0648\u06af\u0648",
                 "common": "\u0679\u0648\u06af\u0648"
@@ -33620,10 +33624,6 @@
             "zho": {
                 "official": "\u591a\u54e5\u5171\u548c\u56fd",
                 "common": "\u591a\u54e5"
-            },
-            "swe": {
-                "official": "Republiken Togo",
-                "common": "Togo"
             }
         },
         "latlng": [
@@ -33767,6 +33767,10 @@
                 "official": "Reino de Tailandia",
                 "common": "Tailandia"
             },
+            "swe": {
+                "official": "Konungariket Thailand",
+                "common": "Thailand"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u062a\u06be\u0627\u0626\u06cc \u0644\u06cc\u0646\u0688",
                 "common": "\u062a\u06be\u0627\u0626\u06cc \u0644\u06cc\u0646\u0688"
@@ -33774,10 +33778,6 @@
             "zho": {
                 "official": "\u6cf0\u738b\u56fd",
                 "common": "\u6cf0\u56fd"
-            },
-            "swe": {
-                "official": "Konungariket Thailand",
-                "common": "Thailand"
             }
         },
         "latlng": [
@@ -33925,6 +33925,10 @@
                 "official": "Rep\u00fablica de Tayikist\u00e1n",
                 "common": "Tayikist\u00e1n"
             },
+            "swe": {
+                "official": "Republiken Tadzjikistan",
+                "common": "Tadzjikistan"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062a\u0627\u062c\u06a9\u0633\u062a\u0627\u0646",
                 "common": "\u062a\u0627\u062c\u06a9\u0633\u062a\u0627\u0646"
@@ -33932,10 +33936,6 @@
             "zho": {
                 "official": "\u5854\u5409\u514b\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u5854\u5409\u514b\u65af\u5766"
-            },
-            "swe": {
-                "official": "Republiken Tadzjikistan",
-                "common": "Tadzjikistan"
             }
         },
         "latlng": [
@@ -34084,6 +34084,10 @@
                 "official": "Tokelau",
                 "common": "Islas Tokelau"
             },
+            "swe": {
+                "official": "Tokelau\u00f6arna",
+                "common": "Tokelau\u00f6arna"
+            },
             "urd": {
                 "official": "\u0679\u0648\u06a9\u06cc\u0644\u0627\u0624",
                 "common": "\u0679\u0648\u06a9\u06cc\u0644\u0627\u0624"
@@ -34091,10 +34095,6 @@
             "zho": {
                 "official": "\u6258\u514b\u52b3",
                 "common": "\u6258\u514b\u52b3"
-            },
-            "swe": {
-                "official": "Tokelau\u00f6arna",
-                "common": "Tokelau\u00f6arna"
             }
         },
         "latlng": [
@@ -34233,6 +34233,10 @@
                 "official": "Turkmenist\u00e1n",
                 "common": "Turkmenist\u00e1n"
             },
+            "swe": {
+                "official": "Turkmenistan",
+                "common": "Turkmenistan"
+            },
             "urd": {
                 "official": "\u062a\u0631\u06a9\u0645\u0627\u0646\u0633\u062a\u0627\u0646",
                 "common": "\u062a\u0631\u06a9\u0645\u0627\u0646\u0633\u062a\u0627\u0646"
@@ -34240,10 +34244,6 @@
             "zho": {
                 "official": "\u571f\u5e93\u66fc\u65af\u5766",
                 "common": "\u571f\u5e93\u66fc\u65af\u5766"
-            },
-            "swe": {
-                "official": "Turkmenistan",
-                "common": "Turkmenistan"
             }
         },
         "latlng": [
@@ -34393,6 +34393,10 @@
                 "official": "Rep\u00fablica Democr\u00e1tica de Timor-Leste",
                 "common": "Timor Oriental"
             },
+            "swe": {
+                "official": "Demokratiska republiken \u00d6sttimor",
+                "common": "\u00d6sttimor a.k.a. Timor-Leste"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0645\u0634\u0631\u0642\u06cc \u062a\u06cc\u0645\u0648\u0631",
                 "common": "\u0645\u0634\u0631\u0642\u06cc \u062a\u06cc\u0645\u0648\u0631"
@@ -34400,10 +34404,6 @@
             "zho": {
                 "official": "\u4e1c\u5e1d\u6c76\u6c11\u4e3b\u5171\u548c\u56fd",
                 "common": "\u4e1c\u5e1d\u6c76"
-            },
-            "swe": {
-                "official": "Demokratiska republiken \u00d6sttimor",
-                "common": "\u00d6sttimor a.k.a. Timor-Leste"
             }
         },
         "latlng": [
@@ -34544,6 +34544,10 @@
                 "official": "Reino de Tonga",
                 "common": "Tonga"
             },
+            "swe": {
+                "official": "Konungariket Tonga",
+                "common": "Tonga"
+            },
             "urd": {
                 "official": "\u0645\u0645\u0644\u06a9\u062a\u0650 \u0679\u0648\u0646\u06af\u0627",
                 "common": "\u0679\u0648\u0646\u06af\u0627"
@@ -34551,10 +34555,6 @@
             "zho": {
                 "official": "\u6c64\u52a0\u738b\u56fd",
                 "common": "\u6c64\u52a0"
-            },
-            "swe": {
-                "official": "Konungariket Tonga",
-                "common": "Tonga"
             }
         },
         "latlng": [
@@ -34689,6 +34689,10 @@
                 "official": "Rep\u00fablica de Trinidad y Tobago",
                 "common": "Trinidad y Tobago"
             },
+            "swe": {
+                "official": "Republiken Trinidad och Tobago",
+                "common": "Trinidad och Tobago"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0679\u0631\u06cc\u0646\u06cc\u0688\u0627\u0688 \u0648 \u0679\u0648\u0628\u0627\u06af\u0648",
                 "common": "\u0679\u0631\u06cc\u0646\u06cc\u0688\u0627\u0688 \u0648 \u0679\u0648\u0628\u0627\u06af\u0648"
@@ -34696,10 +34700,6 @@
             "zho": {
                 "official": "\u7279\u7acb\u5c3c\u8fbe\u548c\u591a\u5df4\u54e5\u5171\u548c\u56fd",
                 "common": "\u7279\u7acb\u5c3c\u8fbe\u548c\u591a\u5df4\u54e5"
-            },
-            "swe": {
-                "official": "Republiken Trinidad och Tobago",
-                "common": "Trinidad och Tobago"
             }
         },
         "latlng": [
@@ -34835,6 +34835,10 @@
                 "official": "Rep\u00fablica de T\u00fanez",
                 "common": "T\u00fanez"
             },
+            "swe": {
+                "official": "Republiken Tunisien",
+                "common": "Tunisien"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062a\u0648\u0646\u0633",
                 "common": "\u062a\u0648\u0646\u0633"
@@ -34842,10 +34846,6 @@
             "zho": {
                 "official": "\u7a81\u5c3c\u65af\u5171\u548c\u56fd",
                 "common": "\u7a81\u5c3c\u65af"
-            },
-            "swe": {
-                "official": "Republiken Tunisien",
-                "common": "Tunisien"
             }
         },
         "latlng": [
@@ -34985,6 +34985,10 @@
                 "official": "Rep\u00fablica de Turqu\u00eda",
                 "common": "Turqu\u00eda"
             },
+            "swe": {
+                "official": "Republiken Turkiet",
+                "common": "Turkiet"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062a\u0631\u06a9\u06cc",
                 "common": "\u062a\u0631\u06a9\u06cc"
@@ -34992,10 +34996,6 @@
             "zho": {
                 "official": "\u571f\u8033\u5176\u5171\u548c\u56fd",
                 "common": "\u571f\u8033\u5176"
-            },
-            "swe": {
-                "official": "Republiken Turkiet",
-                "common": "Turkiet"
             }
         },
         "latlng": [
@@ -35147,6 +35147,10 @@
                 "official": "Tuvalu",
                 "common": "Tuvalu"
             },
+            "swe": {
+                "official": "Tuvalu",
+                "common": "Tuvalu"
+            },
             "urd": {
                 "official": "\u062a\u0648\u0648\u0627\u0644\u0648",
                 "common": "\u062a\u0648\u0648\u0627\u0644\u0648"
@@ -35154,10 +35158,6 @@
             "zho": {
                 "official": "\u56fe\u74e6\u5362",
                 "common": "\u56fe\u74e6\u5362"
-            },
-            "swe": {
-                "official": "Tuvalu",
-                "common": "Tuvalu"
             }
         },
         "latlng": [
@@ -35298,13 +35298,13 @@
                 "official": "Rep\u00fablica de China en Taiw\u00e1n",
                 "common": "Taiw\u00e1n"
             },
-            "urd": {
-                "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 (\u062a\u0627\u0626\u06cc\u0648\u0627\u0646)",
-                "common": "\u062a\u0627\u0626\u06cc\u0648\u0627\u0646"
-            },
             "swe": {
                 "official": "Republiken Kina",
                 "common": "Taiwan"
+            },
+            "urd": {
+                "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0686\u06cc\u0646 (\u062a\u0627\u0626\u06cc\u0648\u0627\u0646)",
+                "common": "\u062a\u0627\u0626\u06cc\u0648\u0627\u0646"
             }
         },
         "latlng": [
@@ -35446,6 +35446,10 @@
                 "official": "Rep\u00fablica Unida de Tanzania",
                 "common": "Tanzania"
             },
+            "swe": {
+                "official": "F\u00f6renade republiken Tanzania",
+                "common": "Tanzania"
+            },
             "urd": {
                 "official": "\u0645\u062a\u062d\u062f\u06c1 \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062a\u0646\u0632\u0627\u0646\u06cc\u06c1",
                 "common": "\u062a\u0646\u0632\u0627\u0646\u06cc\u06c1"
@@ -35453,10 +35457,6 @@
             "zho": {
                 "official": "\u5766\u6851\u5c3c\u4e9a\u8054\u5408\u5171\u548c\u56fd",
                 "common": "\u5766\u6851\u5c3c\u4e9a"
-            },
-            "swe": {
-                "official": "F\u00f6renade republiken Tanzania",
-                "common": "Tanzania"
             }
         },
         "latlng": [
@@ -35606,6 +35606,10 @@
                 "official": "Rep\u00fablica de Uganda",
                 "common": "Uganda"
             },
+            "swe": {
+                "official": "Republiken Uganda",
+                "common": "Uganda"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06cc\u0648\u06af\u0646\u0688\u0627",
                 "common": "\u06cc\u0648\u06af\u0646\u0688\u0627"
@@ -35613,10 +35617,6 @@
             "zho": {
                 "official": "\u4e4c\u5e72\u8fbe\u5171\u548c\u56fd",
                 "common": "\u4e4c\u5e72\u8fbe"
-            },
-            "swe": {
-                "official": "Republiken Uganda",
-                "common": "Uganda"
             }
         },
         "latlng": [
@@ -35758,6 +35758,10 @@
                 "official": "Ucrania",
                 "common": "Ucrania"
             },
+            "swe": {
+                "official": "Ukraina",
+                "common": "Ukraina"
+            },
             "urd": {
                 "official": "\u06cc\u0648\u06a9\u0631\u06cc\u0646",
                 "common": "\u06cc\u0648\u06a9\u0631\u06cc\u0646"
@@ -35765,10 +35769,6 @@
             "zho": {
                 "official": "\u4e4c\u514b\u5170",
                 "common": "\u4e4c\u514b\u5170"
-            },
-            "swe": {
-                "official": "Ukraina",
-                "common": "Ukraina"
             }
         },
         "latlng": [
@@ -35910,6 +35910,10 @@
                 "official": "Estados Unidos Islas menores alejadas de",
                 "common": "Islas Ultramarinas Menores de Estados Unidos"
             },
+            "swe": {
+                "official": "F\u00f6renta staternas mindre \u00f6ar i Oceanien och V\u00e4stindien",
+                "common": "F\u00f6renta staternas mindre \u00f6ar i Oceanien och V\u00e4stindien"
+            },
             "urd": {
                 "official": "\u0627\u0645\u0631\u06cc\u06a9\u06cc \u0686\u06be\u0648\u0679\u06d2 \u0628\u06cc\u0631\u0648\u0646\u06cc \u062c\u0632\u0627\u0626\u0631",
                 "common": "\u0627\u0645\u0631\u06cc\u06a9\u06cc \u0686\u06be\u0648\u0679\u06d2 \u0628\u06cc\u0631\u0648\u0646\u06cc \u062c\u0632\u0627\u0626\u0631"
@@ -35917,10 +35921,6 @@
             "zho": {
                 "official": "\u7f8e\u56fd\u672c\u571f\u5916\u5c0f\u5c9b\u5c7f",
                 "common": "\u7f8e\u56fd\u672c\u571f\u5916\u5c0f\u5c9b\u5c7f"
-            },
-            "swe": {
-                "official": "F\u00f6renta staternas mindre \u00f6ar i Oceanien och V\u00e4stindien",
-                "common": "F\u00f6renta staternas mindre \u00f6ar i Oceanien och V\u00e4stindien"
             }
         },
         "latlng": [
@@ -36056,6 +36056,10 @@
                 "official": "Rep\u00fablica Oriental del Uruguay",
                 "common": "Uruguay"
             },
+            "swe": {
+                "official": "Republiken Uruguay",
+                "common": "Uruguay"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0634\u0631\u0642\u06cc\u06c1 \u06cc\u0648\u0631\u0627\u06af\u0648\u0626\u06d2",
                 "common": "\u06cc\u0648\u0631\u0627\u06af\u0648\u0626\u06d2"
@@ -36063,10 +36067,6 @@
             "zho": {
                 "official": "\u4e4c\u62c9\u572d\u4e1c\u5cb8\u5171\u548c\u56fd",
                 "common": "\u4e4c\u62c9\u572d"
-            },
-            "swe": {
-                "official": "Republiken Uruguay",
-                "common": "Uruguay"
             }
         },
         "latlng": [
@@ -36521,6 +36521,10 @@
                 "official": "Estados Unidos de Am\u00e9rica",
                 "common": "Estados Unidos"
             },
+            "swe": {
+                "official": "Amerikas f\u00f6renta stater",
+                "common": "USA"
+            },
             "urd": {
                 "official": "\u0631\u06cc\u0627\u0633\u062a\u06c1\u0627\u0626\u06d2 \u0645\u062a\u062d\u062f\u06c1 \u0627\u0645\u0631\u06cc\u06a9\u0627",
                 "common": "\u0631\u06cc\u0627\u0633\u062a\u06c1\u0627\u0626\u06d2 \u0645\u062a\u062d\u062f\u06c1"
@@ -36528,10 +36532,6 @@
             "zho": {
                 "official": "\u7f8e\u5229\u575a\u5408\u4f17\u56fd",
                 "common": "\u7f8e\u56fd"
-            },
-            "swe": {
-                "official": "Amerikas f\u00f6renta stater",
-                "common": "USA"
             }
         },
         "latlng": [
@@ -36676,6 +36676,10 @@
                 "official": "Rep\u00fablica de Uzbekist\u00e1n",
                 "common": "Uzbekist\u00e1n"
             },
+            "swe": {
+                "official": "Republiken Uzbekistan",
+                "common": "Uzbekistan"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0627\u0632\u0628\u06a9\u0633\u062a\u0627\u0646",
                 "common": "\u0627\u0632\u0628\u06a9\u0633\u062a\u0627\u0646"
@@ -36683,10 +36687,6 @@
             "zho": {
                 "official": "\u4e4c\u5179\u522b\u514b\u65af\u5766\u5171\u548c\u56fd",
                 "common": "\u4e4c\u5179\u522b\u514b\u65af\u5766"
-            },
-            "swe": {
-                "official": "Republiken Uzbekistan",
-                "common": "Uzbekistan"
             }
         },
         "latlng": [
@@ -36835,6 +36835,10 @@
                 "official": "Ciudad del Vaticano",
                 "common": "Ciudad del Vaticano"
             },
+            "swe": {
+                "official": "Vatikanstaten",
+                "common": "Vatikanstaten"
+            },
             "urd": {
                 "official": "\u0648\u06cc\u0679\u06cc\u06a9\u0646 \u0633\u0679\u06cc",
                 "common": "\u0648\u06cc\u0679\u06cc\u06a9\u0646 \u0633\u0679\u06cc"
@@ -36842,10 +36846,6 @@
             "zho": {
                 "official": "\u68b5\u8482\u5188\u57ce\u56fd",
                 "common": "\u68b5\u8482\u5188"
-            },
-            "swe": {
-                "official": "Vatikanstaten",
-                "common": "Vatikanstaten"
             }
         },
         "latlng": [
@@ -36981,6 +36981,10 @@
                 "official": "San Vicente y las Granadinas",
                 "common": "San Vicente y Granadinas"
             },
+            "swe": {
+                "official": "Saint Vincent och Grenadinerna",
+                "common": "Saint Vincent och Grenadinerna"
+            },
             "urd": {
                 "official": "\u0633\u06cc\u0646\u0679 \u0648\u06cc\u0646\u0633\u06cc\u0646\u0679 \u0648 \u06af\u0631\u06cc\u0646\u0627\u0688\u0627\u0626\u0646\u0632",
                 "common": "\u0633\u06cc\u0646\u0679 \u0648\u06cc\u0646\u0633\u06cc\u0646\u0679 \u0648 \u06af\u0631\u06cc\u0646\u0627\u0688\u0627\u0626\u0646\u0632"
@@ -36988,10 +36992,6 @@
             "zho": {
                 "official": "\u5723\u6587\u68ee\u7279\u548c\u683c\u6797\u7eb3\u4e01\u65af",
                 "common": "\u5723\u6587\u68ee\u7279\u548c\u683c\u6797\u7eb3\u4e01\u65af"
-            },
-            "swe": {
-                "official": "Saint Vincent och Grenadinerna",
-                "common": "Saint Vincent och Grenadinerna"
             }
         },
         "latlng": [
@@ -37128,6 +37128,10 @@
                 "official": "Rep\u00fablica Bolivariana de Venezuela",
                 "common": "Venezuela"
             },
+            "swe": {
+                "official": "Bolivarianska republiken Venezuela",
+                "common": "Venezuela"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0648\u06cc\u0646\u06cc\u0632\u0648\u06cc\u0644\u0627",
                 "common": "\u0648\u06cc\u0646\u06cc\u0632\u0648\u06cc\u0644\u0627"
@@ -37135,10 +37139,6 @@
             "zho": {
                 "official": "\u59d4\u5185\u745e\u62c9\u73bb\u5229\u74e6\u5c14\u5171\u548c\u56fd",
                 "common": "\u59d4\u5185\u745e\u62c9"
-            },
-            "swe": {
-                "official": "Bolivarianska republiken Venezuela",
-                "common": "Venezuela"
             }
         },
         "latlng": [
@@ -37277,6 +37277,10 @@
                 "official": "Islas V\u00edrgenes",
                 "common": "Islas V\u00edrgenes del Reino Unido"
             },
+            "swe": {
+                "official": "Brittiska Jungfru\u00f6arna",
+                "common": "Brittiska Jungfru\u00f6arna"
+            },
             "urd": {
                 "official": "\u0628\u0631\u0637\u0627\u0646\u0648\u06cc \u062c\u0632\u0627\u0626\u0631 \u0648\u0631\u062c\u0646",
                 "common": "\u0628\u0631\u0637\u0627\u0646\u0648\u06cc \u062c\u0632\u0627\u0626\u0631 \u0648\u0631\u062c\u0646"
@@ -37284,10 +37288,6 @@
             "zho": {
                 "official": "\u82f1\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b",
                 "common": "\u82f1\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Brittiska Jungfru\u00f6arna",
-                "common": "Brittiska Jungfru\u00f6arna"
             }
         },
         "latlng": [
@@ -37422,6 +37422,10 @@
                 "official": "Islas V\u00edrgenes de los Estados Unidos",
                 "common": "Islas V\u00edrgenes de los Estados Unidos"
             },
+            "swe": {
+                "official": "Amerikanska Jungfru\u00f6arna",
+                "common": "Amerikanska Jungfru\u00f6arna"
+            },
             "urd": {
                 "official": "\u0627\u0645\u0631\u06cc\u06a9\u06cc \u062c\u0632\u0627\u0626\u0631 \u0648\u0631\u062c\u0646",
                 "common": "\u0627\u0645\u0631\u06cc\u06a9\u06cc \u062c\u0632\u0627\u0626\u0631 \u0648\u0631\u062c\u0646"
@@ -37429,10 +37433,6 @@
             "zho": {
                 "official": "\u7f8e\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b",
                 "common": "\u7f8e\u5c5e\u7ef4\u5c14\u4eac\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Amerikanska Jungfru\u00f6arna",
-                "common": "Amerikanska Jungfru\u00f6arna"
             }
         },
         "latlng": [
@@ -37569,6 +37569,10 @@
                 "official": "Rep\u00fablica Socialista de Vietnam",
                 "common": "Vietnam"
             },
+            "swe": {
+                "official": "Socialistiska republiken Vietnam",
+                "common": "Vietnam"
+            },
             "urd": {
                 "official": "\u0627\u0634\u062a\u0631\u0627\u06a9\u06cc \u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0648\u06cc\u062a\u0646\u0627\u0645",
                 "common": "\u0648\u06cc\u062a\u0646\u0627\u0645"
@@ -37576,10 +37580,6 @@
             "zho": {
                 "official": "\u8d8a\u5357\u793e\u4f1a\u4e3b\u4e49\u5171\u548c\u56fd",
                 "common": "\u8d8a\u5357"
-            },
-            "swe": {
-                "official": "Socialistiska republiken Vietnam",
-                "common": "Vietnam"
             }
         },
         "latlng": [
@@ -37730,6 +37730,10 @@
                 "official": "Rep\u00fablica de Vanuatu",
                 "common": "Vanuatu"
             },
+            "swe": {
+                "official": "Republiken Vanuatu",
+                "common": "Vanuatu"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0648\u0627\u0646\u0648\u0627\u062a\u0648",
                 "common": "\u0648\u0627\u0646\u0648\u0627\u062a\u0648"
@@ -37737,10 +37741,6 @@
             "zho": {
                 "official": "\u74e6\u52aa\u963f\u56fe\u5171\u548c\u56fd",
                 "common": "\u74e6\u52aa\u963f\u56fe"
-            },
-            "swe": {
-                "official": "Republiken Vanuatu",
-                "common": "Vanuatu"
             }
         },
         "latlng": [
@@ -37876,6 +37876,10 @@
                 "official": "Territorio de las Islas Wallis y Futuna",
                 "common": "Wallis y Futuna"
             },
+            "swe": {
+                "official": "Territoriet Wallis- och Futuna\u00f6arna",
+                "common": "Wallis- och Futuna\u00f6arna"
+            },
             "urd": {
                 "official": "\u0633\u0631 \u0632\u0645\u06cc\u0646\u0650 \u0648\u0627\u0644\u0633 \u0648 \u0641\u062a\u0648\u0646\u06c1 \u062c\u0632\u0627\u0626\u0631",
                 "common": "\u0648\u0627\u0644\u0633 \u0648 \u0641\u062a\u0648\u0646\u06c1"
@@ -37883,10 +37887,6 @@
             "zho": {
                 "official": "\u74e6\u5229\u65af\u548c\u5bcc\u56fe\u7eb3\u7fa4\u5c9b",
                 "common": "\u74e6\u5229\u65af\u548c\u5bcc\u56fe\u7eb3\u7fa4\u5c9b"
-            },
-            "swe": {
-                "official": "Territoriet Wallis- och Futuna\u00f6arna",
-                "common": "Wallis- och Futuna\u00f6arna"
             }
         },
         "latlng": [
@@ -38027,6 +38027,10 @@
                 "official": "Estado Independiente de Samoa",
                 "common": "Samoa"
             },
+            "swe": {
+                "official": "Sj\u00e4lvst\u00e4ndiga staten Samoa",
+                "common": "Samoa"
+            },
             "urd": {
                 "official": "\u0622\u0632\u0627\u062f \u0633\u0644\u0637\u0646\u062a\u0650 \u0633\u0627\u0645\u0648\u0627",
                 "common": "\u0633\u0627\u0645\u0648\u0648\u0627"
@@ -38034,10 +38038,6 @@
             "zho": {
                 "official": "\u8428\u6469\u4e9a\u72ec\u7acb\u56fd",
                 "common": "\u8428\u6469\u4e9a"
-            },
-            "swe": {
-                "official": "Sj\u00e4lvst\u00e4ndiga staten Samoa",
-                "common": "Samoa"
             }
         },
         "latlng": [
@@ -38173,6 +38173,10 @@
                 "official": "Rep\u00fablica de Yemen",
                 "common": "Yemen"
             },
+            "swe": {
+                "official": "Republiken Jemen",
+                "common": "Jemen"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u06cc\u0645\u0646",
                 "common": "\u06cc\u0645\u0646"
@@ -38180,10 +38184,6 @@
             "zho": {
                 "official": "\u4e5f\u95e8\u5171\u548c\u56fd",
                 "common": "\u4e5f\u95e8"
-            },
-            "swe": {
-                "official": "Republiken Jemen",
-                "common": "Jemen"
             }
         },
         "latlng": [
@@ -38375,6 +38375,10 @@
                 "official": "Rep\u00fablica de Sud\u00e1frica",
                 "common": "Rep\u00fablica de Sud\u00e1frica"
             },
+            "swe": {
+                "official": "Republiken Sydafrika",
+                "common": "Sydafrika"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u062c\u0646\u0648\u0628\u06cc \u0627\u0641\u0631\u06cc\u0642\u0627",
                 "common": "\u062c\u0646\u0648\u0628\u06cc \u0627\u0641\u0631\u06cc\u0642\u0627"
@@ -38382,10 +38386,6 @@
             "zho": {
                 "official": "\u5357\u975e\u5171\u548c\u56fd",
                 "common": "\u5357\u975e"
-            },
-            "swe": {
-                "official": "Republiken Sydafrika",
-                "common": "Sydafrika"
             }
         },
         "latlng": [
@@ -38527,6 +38527,10 @@
                 "official": "Rep\u00fablica de Zambia",
                 "common": "Zambia"
             },
+            "swe": {
+                "official": "Republiken Zambia",
+                "common": "Zambia"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0632\u06cc\u0645\u0628\u06cc\u0627",
                 "common": "\u0632\u06cc\u0645\u0628\u06cc\u0627"
@@ -38534,10 +38538,6 @@
             "zho": {
                 "official": "\u8d5e\u6bd4\u4e9a\u5171\u548c\u56fd",
                 "common": "\u8d5e\u6bd4\u4e9a"
-            },
-            "swe": {
-                "official": "Republiken Zambia",
-                "common": "Zambia"
             }
         },
         "latlng": [
@@ -38783,6 +38783,10 @@
                 "official": "Rep\u00fablica de Zimbabue",
                 "common": "Zimbabue"
             },
+            "swe": {
+                "official": "Republiken Zimbabwe",
+                "common": "Zimbabwe"
+            },
             "urd": {
                 "official": "\u062c\u0645\u06c1\u0648\u0631\u06cc\u06c1 \u0632\u0645\u0628\u0627\u0628\u0648\u06d2",
                 "common": "\u0632\u0645\u0628\u0627\u0628\u0648\u06d2"
@@ -38790,10 +38794,6 @@
             "zho": {
                 "official": "\u6d25\u5df4\u5e03\u97e6\u5171\u548c\u56fd",
                 "common": "\u6d25\u5df4\u5e03\u97e6"
-            },
-            "swe": {
-                "official": "Republiken Zimbabwe",
-                "common": "Zimbabwe"
             }
         },
         "latlng": [


### PR DESCRIPTION
This pull request adds the Swedish translations to `countries.json`, both official ones as well as common ones. 

The common names have been sourced from the [ISO 3166](https://sv.wikipedia.org/wiki/ISO_3166#ISO_3166-1-koder) article on Swedish Wikipedia.

The official names have been sourced from the Swedish Wikipedia pages of individual countries. Hence, for example `Finland` becomes `Republiken Finland`, as it is defined in [Finland's Wikipedia article](https://sv.wikipedia.org/wiki/Finland). In these articles, the preceding text "officiellt" (officially) or "formellt" (formally) signifies the official naming.

When no official naming has been provided in the Wikipedia article, I have kept both the common and official name the same.

If I'm missing something or something is wrong, do say! :)

P.S. I know that in https://github.com/mledoze/countries/pull/170 there was an intent to add all the Scandinavian languages. However, no official names were provided then and the PR got closed. This PR only adds Swedish, but also includes the official names.