### PR TITLE
Changed array to object for empty currencies

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -1715,7 +1715,7 @@
         "independent": false,
         "status": "officially-assigned",
         "unMember": false,
-        "currencies": [],
+        "currencies": {},
         "idd": {
             "root": "",
             "suffixes": []
@@ -5780,7 +5780,7 @@
         "independent": false,
         "status": "officially-assigned",
         "unMember": false,
-        "currencies": [],
+        "currencies": {},
         "idd": {
             "root": "+4",
             "suffixes": [
@@ -12255,7 +12255,7 @@
         "independent": true,
         "status": "officially-assigned",
         "unMember": true,
-        "currencies": [],
+        "currencies": {},
         "idd": {
             "root": "+6",
             "suffixes": [
@@ -15274,7 +15274,7 @@
         "independent": false,
         "status": "officially-assigned",
         "unMember": false,
-        "currencies": [],
+        "currencies": {},
         "idd": {
             "root": "",
             "suffixes": [


### PR DESCRIPTION
Empty currencies has type array ( [] ), it's wrong, they should have object type
Now it's generates errors when try to unmarshal it to objects