### PR TITLE
Update Guinea-Bissau UN membership to true

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -13825,7 +13825,7 @@
         "cioc": "GBS",
         "independent": true,
         "status": "officially-assigned",
-        "unMember": false,
+        "unMember": true,
         "currencies": {
             "XOF": {
                 "name": "West African CFA franc",


### PR DESCRIPTION
Hi I noticed that Guinea-Bissau has `unMember: false`, but it is actually a member. (Data source here: https://www.un.org/en/about-us/member-states#gotoG). Here's a pull request to rectify that.

Thanks,
Ed