### PR TITLE
Updated Croatia's currency to EUR as the HRK

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -13825,7 +13825,7 @@
         "cioc": "GBS",
         "independent": true,
         "status": "officially-assigned",
-        "unMember": false,
+        "unMember": true,
         "currencies": {
             "XOF": {
                 "name": "West African CFA franc",

--- a/countries.json
+++ b/countries.json
@@ -15636,9 +15636,9 @@
         "status": "officially-assigned",
         "unMember": true,
         "currencies": {
-            "HRK": {
-                "name": "Croatian kuna",
-                "symbol": "kn"
+            "EUR": {
+                "name": "Euro",
+                "symbol": "\u20ac"
             }
         },
         "idd": {


### PR DESCRIPTION
As of 1 Jan 2023, the Euro is the official currency. HRK will be accepted until 14 Jan 2023