### PR TITLE
Change demonyms property type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ export interface Country {
   languages: { [languageCode: string]: string }
   translations: { [languageCode: string]: OfficialAndCommon }
   latlng: [number, number]
-  demonyms: { [languageCode: string]?: Demonyms }
+  demonyms: { [languageCode: string]: Demonyms }
   landlocked: boolean
   borders: string[]
   area: number


### PR DESCRIPTION
Change the type of the `demonyms` property from optional to required. Now, it must have a defined value for each languageCode.

Before: `demonyms: { [languageCode: string]?: Demonyms }`
After:  `demonyms: { [languageCode: string]: Demonyms }`