### PR TITLE
feat: Add Arabic translation to all countries

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -49,6 +49,10 @@
             "pap": "Papiamento"
         },
         "translations": {
+            "ara": {
+                "official": "\u0623\u0631\u0648\u0628\u0627",
+                "common": "\u0623\u0631\u0648\u0628\u0627"
+            },
             "ces": {
                 "official": "Aruba",
                 "common": "Aruba"
@@ -205,6 +209,10 @@
             "tuk": "Turkmen"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0641\u0641\u0627\u0646\u0633\u062a\u0627\u0646 \u0627\u0644\u0625\u0633\u0644\u0627\u0645\u064a\u0629",
+                "common": "\u0623\u0641\u063a\u0627\u0646\u0633\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "Afgh\u00e1nsk\u00e1 isl\u00e1msk\u00e1 republika",
                 "common": "Afgh\u00e1nist\u00e1n"
@@ -359,6 +367,10 @@
             "por": "Portuguese"
         },
         "translations": {
+            "ara": {
+                "official": "\u0623\u0646\u063a\u0648\u0644\u0627",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0646\u063a\u0648\u0644\u0627"
+            },
             "ces": {
                 "official": "Angolsk\u00e1 republika",
                 "common": "Angola"
@@ -509,6 +521,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0623\u0646\u063a\u0648\u064a\u0644\u0627",
+                "common": "\u0623\u0646\u063a\u0648\u064a\u0644\u0627"
+            },
             "ces": {
                 "official": "Anguilla",
                 "common": "Anguilla"
@@ -657,6 +673,10 @@
             "swe": "Swedish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0623\u0648\u0644\u0627\u0646\u062f",
+                "common": "\u062c\u0632\u0631 \u0623\u0648\u0644\u0627\u0646\u062f"
+            },
             "ces": {
                 "official": "\u00c5landsk\u00e9 ostrovy",
                 "common": "\u00c5landy"
@@ -805,6 +825,10 @@
             "sqi": "Albanian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0644\u0628\u0627\u0646\u064a\u0627",
+                "common": "\u0623\u0644\u0628\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Alb\u00e1nsk\u00e1 republika",
                 "common": "Alb\u00e1nie"
@@ -957,6 +981,10 @@
             "cat": "Catalan"
         },
         "translations": {
+            "ara": {
+                "official": "\u0625\u0645\u0627\u0631\u0629 \u0623\u0646\u062f\u0648\u0631\u0627",
+                "common": "\u0623\u0646\u062f\u0648\u0631\u0627"
+            },
             "ces": {
                 "official": "Andorrsk\u00e9 kn\u00ed\u017eectv\u00ed",
                 "common": "Andorra"
@@ -1067,7 +1095,7 @@
             "native": {
                 "ara": {
                     "official": "\u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0645\u062a\u062d\u062f\u0629",
-                    "common": "\u062f\u0648\u0644\u0629 \u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0645\u062a\u062d\u062f\u0629"
+                    "common": "\u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a"
                 }
             }
         },
@@ -1108,6 +1136,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0645\u062a\u062d\u062f\u0629",
+                "common": "\u0627\u0644\u0625\u0645\u0627\u0631\u0627\u062a"
+            },
             "ces": {
                 "official": "Spojen\u00e9 arabsk\u00e9 emir\u00e1ty",
                 "common": "Spojen\u00e9 arabsk\u00e9 emir\u00e1ty"
@@ -1263,6 +1295,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0623\u0631\u062c\u0646\u062a\u064a\u0646",
+                "common": "\u0627\u0644\u0623\u0631\u062c\u0646\u062a\u064a\u0646"
+            },
             "ces": {
                 "official": "Argentinsk\u00e1 republika",
                 "common": "Argentina"
@@ -1417,6 +1453,10 @@
             "hye": "Armenian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0631\u0645\u064a\u0646\u064a\u0627",
+                "common": "\u0623\u0631\u0645\u064a\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Arm\u00e9nsk\u00e1 republika",
                 "common": "Arm\u00e9nie"
@@ -1575,6 +1615,10 @@
             "smo": "Samoan"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0627\u0645\u0648\u0627 \u0627\u0644\u0623\u0645\u0631\u064a\u0643\u064a\u0629",
+                "common": "\u0633\u0627\u0645\u0648\u0627 \u0627\u0644\u0623\u0645\u0631\u064a\u0643\u064a\u0629"
+            },
             "ces": {
                 "official": "Americk\u00e1 Samoa",
                 "common": "Americk\u00e1 Samoa"
@@ -1704,6 +1748,10 @@
         "subregion": "",
         "languages": {},
         "translations": {
+            "ara": {
+                "official": "\u0623\u0646\u062a\u0627\u0631\u062a\u064a\u0643\u0627",
+                "common": "\u0623\u0646\u062a\u0627\u0631\u062a\u064a\u0643\u0627"
+            },
             "ces": {
                 "official": "Antarktida",
                 "common": "Antarktida"
@@ -1850,6 +1898,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0642\u0627\u0637\u0639\u0627\u062a \u0648\u0623\u0642\u0627\u0644\u064a\u0645 \u0645\u0627 \u0648\u0631\u0627\u0621 \u0627\u0644\u0628\u062d\u0627\u0631 \u0627\u0644\u0641\u0631\u0646\u0633\u064a\u0629",
+                "common": "\u0623\u0631\u0627\u0636 \u0641\u0631\u0646\u0633\u064a\u0629 \u062c\u0646\u0648\u0628\u064a\u0629 \u0648\u0623\u0646\u062a\u0627\u0631\u062a\u064a\u0643\u064a\u0629"
+            },
             "ces": {
                 "official": "Teritorium Francouzsk\u00e1 ji\u017en\u00ed a antarktick\u00e1 \u00fazem\u00ed",
                 "common": "Francouzsk\u00e1 ji\u017en\u00ed a antarktick\u00e1 \u00fazem\u00ed"
@@ -1995,6 +2047,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0623\u0646\u062a\u064a\u063a\u0648\u0627 \u0648\u0628\u0627\u0631\u0628\u0648\u062f\u0627",
+                "common": "\u0623\u0646\u062a\u064a\u063a\u0648\u0627 \u0648\u0628\u0627\u0631\u0628\u0648\u062f\u0627"
+            },
             "ces": {
                 "official": "Antigua a Barbuda",
                 "common": "Antigua a Barbuda"
@@ -2140,6 +2196,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0643\u0648\u0645\u0648\u0646\u0648\u0644\u062b \u0623\u0633\u062a\u0631\u0627\u0644\u064a\u0627",
+                "common": "\u0623\u0633\u062a\u0631\u0627\u0644\u064a\u0627"
+            },
             "ces": {
                 "official": "Australsk\u00e9 spole\u010denstv\u00ed",
                 "common": "Austr\u00e1lie"
@@ -2287,6 +2347,10 @@
             "bar": "Austro-Bavarian German"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0646\u0645\u0633\u0627",
+                "common": "\u0627\u0644\u0646\u0645\u0633\u0627"
+            },
             "ces": {
                 "official": "Rakousk\u00e1 republika",
                 "common": "Rakousko"
@@ -2448,6 +2512,10 @@
             "rus": "Russian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0630\u0631\u0628\u064a\u062c\u0627\u0646",
+                "common": "\u0623\u0630\u0631\u0628\u064a\u062c\u0627\u0646"
+            },
             "ces": {
                 "official": "\u00c1zerb\u00e1jd\u017e\u00e1nsk\u00e1 republika",
                 "common": "\u00c1zerb\u00e1jd\u017e\u00e1n"
@@ -2607,6 +2675,10 @@
             "run": "Kirundi"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0648\u0631\u0648\u0646\u062f\u064a",
+                "common": "\u0628\u0648\u0631\u0648\u0646\u062f\u064a"
+            },
             "ces": {
                 "official": "Burundsk\u00e1 republika",
                 "common": "Burundi"
@@ -2774,6 +2846,10 @@
             "nld": "Dutch"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0628\u0644\u062c\u064a\u0643\u0627",
+                "common": "\u0628\u0644\u062c\u064a\u0643\u0627"
+            },
             "ces": {
                 "official": "Belgick\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Belgie"
@@ -2926,6 +3002,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0646\u064a\u0646",
+                "common": "\u0628\u0646\u064a\u0646"
+            },
             "ces": {
                 "official": "Beninsk\u00e1 republika",
                 "common": "Benin"
@@ -3076,6 +3156,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0628\u0648\u0631\u0643\u064a\u0646\u0627 \u0641\u0627\u0633\u0648",
+                "common": "\u0628\u0648\u0631\u0643\u064a\u0646\u0627 \u0641\u0627\u0633\u0648"
+            },
             "ces": {
                 "official": "Burkina Faso",
                 "common": "Burkina Faso"
@@ -3230,6 +3314,10 @@
             "ben": "Bengali"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0646\u063a\u0644\u0627\u062f\u064a\u0634 \u0627\u0644\u0634\u0639\u0628\u064a\u0629",
+                "common": "\u0628\u0646\u063a\u0644\u0627\u062f\u064a\u0634"
+            },
             "ces": {
                 "official": "Banglad\u00e9\u0161sk\u00e1 lidov\u00e1 republika",
                 "common": "Banglad\u00e9\u0161"
@@ -3380,6 +3468,10 @@
             "bul": "Bulgarian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0644\u063a\u0627\u0631\u064a\u0627",
+                "common": "\u0628\u0644\u063a\u0627\u0631\u064a\u0627"
+            },
             "ces": {
                 "official": "Bulharsk\u00e1 republika",
                 "common": "Bulharsko"
@@ -3493,7 +3585,7 @@
             "native": {
                 "ara": {
                     "official": "\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0628\u062d\u0631\u064a\u0646",
-                    "common": "\u200f\u0627\u0644\u0628\u062d\u0631\u064a\u0646"
+                    "common": "\u0627\u0644\u0628\u062d\u0631\u064a\u0646"
                 }
             }
         },
@@ -3533,6 +3625,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0628\u062d\u0631\u064a\u0646",
+                "common": "\u0627\u0644\u0628\u062d\u0631\u064a\u0646"
+            },
             "ces": {
                 "official": "Kr\u00e1lovstv\u00ed Bahrajn",
                 "common": "Bahrajn"
@@ -3683,6 +3779,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0643\u0648\u0645\u0646\u0648\u0644\u062b \u062c\u0632\u0631 \u0627\u0644\u0628\u0647\u0627\u0645\u0627",
+                "common": "\u0627\u0644\u0628\u0647\u0627\u0645\u0627"
+            },
             "ces": {
                 "official": "Bahamsk\u00e9 spole\u010denstv\u00ed",
                 "common": "Bahamy"
@@ -3840,6 +3940,10 @@
             "srp": "Serbian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0628\u0648\u0633\u0646\u0629 \u0648\u0627\u0644\u0647\u0631\u0633\u0643",
+                "common": "\u0627\u0644\u0628\u0648\u0633\u0646\u0629 \u0648\u0627\u0644\u0647\u0631\u0633\u0643"
+            },
             "ces": {
                 "official": "Bosna a Hercegovina",
                 "common": "Bosna a Hercegovina"
@@ -3992,6 +4096,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062a\u062c\u0645\u0639 \u0627\u0644\u0625\u0642\u0644\u064a\u0645\u064a \u0644\u0633\u0627\u0646\u062a \u0628\u0627\u0631\u062a\u064a\u0644\u064a\u0645\u064a",
+                "common": "\u0633\u0627\u0646 \u0628\u0627\u0631\u062a\u0644\u064a\u0645\u064a"
+            },
             "ces": {
                 "official": "Svat\u00fd Bartolom\u011bj",
                 "common": "Svat\u00fd Bartolom\u011bj"
@@ -4144,6 +4252,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0627\u0646\u062a \u0647\u064a\u0644\u064a\u0646\u0627 \u0648\u0623\u0633\u064a\u0646\u0634\u064a\u0646 \u0648\u062a\u0631\u064a\u0633\u062a\u0627\u0646 \u062f\u0627 \u0643\u0648\u0646\u0627",
+                "common": "\u0633\u0627\u0646\u062a \u0647\u064a\u0644\u064a\u0646\u0627 \u0648\u0623\u0633\u064a\u0646\u0634\u064a\u0646 \u0648\u062a\u0631\u064a\u0633\u062a\u0627\u0646 \u062f\u0627 \u0643\u0648\u0646\u0627"
+            },
             "ces": {
                 "official": "Svat\u00e1 Helena, Ascension a Tristan da Cunha",
                 "common": "Svat\u00e1 Helena, Ascension a Tristan da Cunha"
@@ -4298,6 +4410,10 @@
             "rus": "Russian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u064a\u0644\u0627\u0631\u0648\u0633\u064a\u0627",
+                "common": "\u0628\u064a\u0644\u0627\u0631\u0648\u0633\u064a\u0627"
+            },
             "ces": {
                 "official": "B\u011blorusk\u00e1 republika",
                 "common": "B\u011blorusko"
@@ -4459,6 +4575,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0628\u0644\u064a\u0632",
+                "common": "\u0628\u0644\u064a\u0632"
+            },
             "ces": {
                 "official": "Belize",
                 "common": "Belize"
@@ -4610,6 +4730,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0628\u0631\u0645\u0648\u062f\u0627",
+                "common": "\u0628\u0631\u0645\u0648\u062f\u0627"
+            },
             "ces": {
                 "official": "Bermudsk\u00e9 ostrovy",
                 "common": "Bermudy"
@@ -4778,6 +4902,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0628\u0648\u0644\u064a\u0641\u064a\u0627 \u0627\u0644\u0645\u062a\u0639\u062f\u062f\u0629 \u0627\u0644\u0642\u0648\u0645\u064a\u0627\u062a",
+                "common": "\u0628\u0648\u0644\u064a\u0641\u064a\u0627"
+            },
             "ces": {
                 "official": "Mnohon\u00e1rodnostn\u00ed st\u00e1t Bol\u00edvie",
                 "common": "Bol\u00edvie"
@@ -4938,6 +5066,10 @@
             "pap": "Papiamento"
         },
         "translations": {
+            "ara": {
+                "official": "\u0628\u0648\u0646\u064a\u0631 \u0648\u0633\u064a\u0646\u062a \u0623\u0648\u0633\u062a\u0627\u062a\u064a\u0648\u0633 \u0648\u0633\u0627\u0628\u0627",
+                "common": "\u0627\u0644\u062c\u0632\u0631 \u0627\u0644\u0643\u0627\u0631\u064a\u0628\u064a\u0629 \u0627\u0644\u0647\u0648\u0644\u0646\u062f\u064a\u0629"
+            },
             "ces": {
                 "official": "Karibsk\u00e9 Nizozemsko",
                 "common": "Karibsk\u00e9 Nizozemsko"
@@ -5086,6 +5218,10 @@
             "por": "Portuguese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0628\u0631\u0627\u0632\u064a\u0644 \u0627\u0644\u0627\u062a\u062d\u0627\u062f\u064a\u0629",
+                "common": "\u0627\u0644\u0628\u0631\u0627\u0632\u064a\u0644"
+            },
             "ces": {
                 "official": "Brazilsk\u00e1 federativn\u00ed republika",
                 "common": "Braz\u00edlie"
@@ -5242,6 +5378,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0628\u0627\u0631\u0628\u0627\u062f\u0648\u0633",
+                "common": "\u0628\u0627\u0631\u0628\u0627\u062f\u0648\u0633"
+            },
             "ces": {
                 "official": "Barbados",
                 "common": "Barbados"
@@ -5394,6 +5534,10 @@
             "msa": "Malay"
         },
         "translations": {
+            "ara": {
+                "official": "\u0628\u0631\u0648\u0646\u0627\u064a \u062f\u0627\u0631 \u0627\u0644\u0633\u0644\u0627\u0645",
+                "common": "\u0628\u0631\u0648\u0646\u0627\u064a"
+            },
             "ces": {
                 "official": "Sultan\u00e1t Brunej",
                 "common": "Brunej"
@@ -5546,6 +5690,10 @@
             "dzo": "Dzongkha"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0628\u0648\u062a\u0627\u0646",
+                "common": "\u0628\u0648\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "Bh\u00fat\u00e1nsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Bh\u00fat\u00e1n"
@@ -5689,6 +5837,10 @@
             "nor": "Norwegian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0628\u0648\u0641\u064a\u0647",
+                "common": "\u062c\u0632\u0631 \u0628\u0648\u0641\u064a\u0647"
+            },
             "ces": {
                 "official": "Bouvet\u016fv ostrov",
                 "common": "Bouvet\u016fv ostrov"
@@ -5841,6 +5993,10 @@
             "tsn": "Tswana"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627",
+                "common": "\u0628\u0648\u062a\u0633\u0648\u0627\u0646\u0627"
+            },
             "ces": {
                 "official": "Botswansk\u00e1 republika",
                 "common": "Botswana"
@@ -5998,6 +6154,10 @@
             "sag": "Sango"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0641\u0631\u064a\u0642\u064a\u0627 \u0627\u0644\u0648\u0633\u0637\u0649",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0641\u0631\u064a\u0642\u064a\u0627 \u0627\u0644\u0648\u0633\u0637\u0649"
+            },
             "ces": {
                 "official": "St\u0159edoafrick\u00e1 republika",
                 "common": "St\u0159edoafrick\u00e1 republika"
@@ -6220,6 +6380,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0643\u0646\u062f\u0627",
+                "common": "\u0643\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Kanada",
                 "common": "Kanada"
@@ -6369,6 +6533,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0625\u0642\u0644\u064a\u0645 \u062c\u0632\u0631 \u0643\u0648\u0643\u0648\u0633",
+                "common": "\u062c\u0632\u0631 \u0643\u0648\u0643\u0648\u0633"
+            },
             "ces": {
                 "official": "Kokosov\u00e9 ostrovy",
                 "common": "Kokosov\u00e9 ostrovy"
@@ -6534,6 +6702,10 @@
             "roh": "Romansh"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0627\u062a\u062d\u0627\u062f \u0627\u0644\u0633\u0648\u064a\u0633\u0631\u064a",
+                "common": "\u0633\u0648\u064a\u0633\u0631\u0627"
+            },
             "ces": {
                 "official": "\u0160v\u00fdcarsk\u00e1 konfederace",
                 "common": "\u0160v\u00fdcarsko"
@@ -6687,6 +6859,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062a\u0634\u064a\u0644\u064a",
+                "common": "\u062a\u0634\u064a\u0644\u064a"
+            },
             "ces": {
                 "official": "Chilsk\u00e1 republika",
                 "common": "Chile"
@@ -6846,6 +7022,10 @@
             "zho": "Chinese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0635\u064a\u0646 \u0627\u0644\u0634\u0639\u0628\u064a\u0629",
+                "common": "\u0627\u0644\u0635\u064a\u0646"
+            },
             "ces": {
                 "official": "\u010c\u00ednsk\u00e1 lidov\u00e1 republika",
                 "common": "\u010c\u00edna"
@@ -7012,6 +7192,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0627\u062d\u0644 \u0627\u0644\u0639\u0627\u062c",
+                "common": "\u0633\u0627\u062d\u0644 \u0627\u0644\u0639\u0627\u062c"
+            },
             "ces": {
                 "official": "Republika Pob\u0159e\u017e\u00ed slonoviny",
                 "common": "Pob\u0159e\u017e\u00ed slonoviny"
@@ -7170,6 +7354,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0643\u0627\u0645\u064a\u0631\u0648\u0646",
+                "common": "\u0627\u0644\u0643\u0627\u0645\u064a\u0631\u0648\u0646"
+            },
             "ces": {
                 "official": "Kamerunsk\u00e1 republika",
                 "common": "Kamerun"
@@ -7346,6 +7534,10 @@
             "swa": "Swahili"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0643\u0648\u0646\u063a\u0648 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629",
+                "common": "\u0627\u0644\u0643\u0648\u0646\u063a\u0648"
+            },
             "ces": {
                 "official": "Demokratick\u00e1 republika Kongo",
                 "common": "DR Kongo"
@@ -7513,6 +7705,10 @@
             "lin": "Lingala"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0643\u0648\u0646\u063a\u0648",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0643\u0648\u0646\u063a\u0648"
+            },
             "ces": {
                 "official": "Kon\u017esk\u00e1 republika",
                 "common": "Kongo"
@@ -7674,6 +7870,10 @@
             "rar": "Cook Islands M\u0101ori"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0643\u0648\u0643",
+                "common": "\u062c\u0632\u0631 \u0643\u0648\u0643"
+            },
             "ces": {
                 "official": "Cookovy ostrovy",
                 "common": "Cookovy ostrovy"
@@ -7821,6 +8021,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0648\u0644\u0648\u0645\u0628\u064a\u0627",
+                "common": "\u0643\u0648\u0644\u0648\u0645\u0628\u064a\u0627"
+            },
             "ces": {
                 "official": "Kolumbijsk\u00e1 republika",
                 "common": "Kolumbie"
@@ -7934,7 +8138,7 @@
             "native": {
                 "ara": {
                     "official": "\u0627\u0644\u0627\u062a\u062d\u0627\u062f \u0627\u0644\u0642\u0645\u0631\u064a",
-                    "common": "\u0627\u0644\u0642\u0645\u0631\u200e"
+                    "common": "\u062c\u0632\u0631 \u0627\u0644\u0642\u0645\u0631"
                 },
                 "fra": {
                     "official": "Union des Comores",
@@ -7986,6 +8190,10 @@
             "zdj": "Comorian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0625\u062a\u062d\u0627\u062f \u0627\u0644\u0642\u0645\u0631\u064a",
+                "common": "\u062c\u0632\u0631 \u0627\u0644\u0642\u0645\u0631"
+            },
             "ces": {
                 "official": "Komorsk\u00fd svaz",
                 "common": "Komory"
@@ -8133,6 +8341,10 @@
             "por": "Portuguese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0627\u0628\u0648 \u0641\u064a\u0631\u062f\u064a",
+                "common": "\u0643\u0627\u0628\u0648 \u0641\u064a\u0631\u062f\u064a"
+            },
             "ces": {
                 "official": "Kapverdsk\u00e1 republika",
                 "common": "Kapverdy"
@@ -8280,6 +8492,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0648\u0633\u062a\u0627\u0631\u064a\u0643\u0627",
+                "common": "\u0643\u0648\u0633\u062a\u0627\u0631\u064a\u0643\u0627"
+            },
             "ces": {
                 "official": "Kostarick\u00e1 republika",
                 "common": "Kostarika"
@@ -8434,6 +8650,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0648\u0628\u0627",
+                "common": "\u0643\u0648\u0628\u0627"
+            },
             "ces": {
                 "official": "Kub\u00e1nsk\u00e1 republika",
                 "common": "Kuba"
@@ -8594,6 +8814,10 @@
             "pap": "Papiamento"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0643\u0648\u0631\u0627\u0633\u0627\u0648",
+                "common": "\u0643\u0648\u0631\u0627\u0633\u0627\u0648"
+            },
             "ces": {
                 "official": "Autonomn\u00ed zem\u011b Cura\u00e7ao",
                 "common": "Cura\u00e7ao"
@@ -8740,6 +8964,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u064a\u0631\u0629 \u0643\u0631\u064a\u0633\u0645\u0627\u0633",
+                "common": "\u062c\u0632\u064a\u0631\u0629 \u0643\u0631\u064a\u0633\u0645\u0627\u0633"
+            },
             "ces": {
                 "official": "Teritorium V\u00e1no\u010dn\u00edho ostrova",
                 "common": "V\u00e1no\u010dn\u00ed ostrov"
@@ -8885,6 +9113,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0643\u0627\u064a\u0645\u0627\u0646",
+                "common": "\u062c\u0632\u0631 \u0643\u0627\u064a\u0645\u0627\u0646"
+            },
             "ces": {
                 "official": "Kajmansk\u00e9 ostrovy",
                 "common": "Kajmansk\u00e9 ostrovy"
@@ -9040,6 +9272,10 @@
             "tur": "Turkish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0642\u0628\u0631\u0635",
+                "common": "\u0642\u0628\u0631\u0635"
+            },
             "ces": {
                 "official": "Kypersk\u00e1 republika",
                 "common": "Kypr"
@@ -9192,6 +9428,10 @@
             "slk": "Slovak"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u062a\u0634\u064a\u0643",
+                "common": "\u0627\u0644\u062a\u0634\u064a\u0643"
+            },
             "ces": {
                 "official": "\u010cesk\u00e1 republika",
                 "common": "\u010cesko"
@@ -9344,6 +9584,10 @@
             "deu": "German"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0644\u0645\u0627\u0646\u064a\u0627 \u0627\u0644\u0627\u062a\u062d\u0627\u062f\u064a\u0629",
+                "common": "\u0623\u0644\u0645\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Spolkov\u00e1 republika N\u011bmecko",
                 "common": "N\u011bmecko"
@@ -9461,7 +9705,7 @@
             "native": {
                 "ara": {
                     "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062c\u064a\u0628\u0648\u062a\u064a",
-                    "common": "\u062c\u064a\u0628\u0648\u062a\u064a\u200e"
+                    "common": "\u062c\u064a\u0628\u0648\u062a\u064a"
                 },
                 "fra": {
                     "official": "R\u00e9publique de Djibouti",
@@ -9510,6 +9754,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062c\u064a\u0628\u0648\u062a\u064a",
+                "common": "\u062c\u064a\u0628\u0648\u062a\u064a"
+            },
             "ces": {
                 "official": "D\u017eibutsk\u00e1 republika",
                 "common": "D\u017eibutsko"
@@ -9662,6 +9910,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0643\u0648\u0645\u0648\u0646\u0648\u0644\u062b \u062f\u0648\u0645\u064a\u0646\u064a\u0643\u0627",
+                "common": "\u062f\u0648\u0645\u064a\u0646\u064a\u0643\u0627"
+            },
             "ces": {
                 "official": "Dominik\u00e1nsk\u00e9 spole\u010denstv\u00ed",
                 "common": "Dominika"
@@ -9810,6 +10062,10 @@
             "dan": "Danish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u062f\u0646\u0645\u0627\u0631\u0643",
+                "common": "\u0627\u0644\u062f\u0646\u0645\u0627\u0631\u0643"
+            },
             "ces": {
                 "official": "D\u00e1nsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "D\u00e1nsko"
@@ -9959,6 +10215,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u062f\u0648\u0645\u064a\u0646\u064a\u0643\u0627\u0646",
+                "common": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u062f\u0648\u0645\u064a\u0646\u064a\u0643\u0627\u0646"
+            },
             "ces": {
                 "official": "Dominik\u00e1nsk\u00e1 republika",
                 "common": "Dominik\u00e1nsk\u00e1 republika"
@@ -10109,6 +10369,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629 \u0627\u0644\u0634\u0639\u0628\u064a\u0629 \u0627\u0644\u062c\u0632\u0627\u0626\u0631\u064a\u0629",
+                "common": "\u0627\u0644\u062c\u0632\u0627\u0626\u0631"
+            },
             "ces": {
                 "official": "Al\u017e\u00edrsk\u00e1 demokratick\u00e1 a lidov\u00e1 republika",
                 "common": "Al\u017e\u00edrsko"
@@ -10264,6 +10528,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0625\u0643\u0648\u0627\u062f\u0648\u0631",
+                "common": "\u0627\u0644\u0625\u0643\u0648\u0627\u062f\u0648\u0631"
+            },
             "ces": {
                 "official": "Ekv\u00e1dorsk\u00e1 republika",
                 "common": "Ekv\u00e1dor"
@@ -10414,6 +10682,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0635\u0631 \u0627\u0644\u0639\u0631\u0628\u064a\u0629",
+                "common": "\u0645\u0635\u0631"
+            },
             "ces": {
                 "official": "Egyptsk\u00e1 arabsk\u00e1 republika",
                 "common": "Egypt"
@@ -10525,8 +10797,8 @@
             "official": "State of Eritrea",
             "native": {
                 "ara": {
-                    "official": "\u062f\u0648\u0644\u0629 \u0625\u0631\u062a\u0631\u064a\u0627",
-                    "common": "\u0625\u0631\u062a\u0631\u064a\u0627\u200e"
+                    "official": "\u062f\u0648\u0644\u0629 \u0625\u0631\u064a\u062a\u0631\u064a\u0627",
+                    "common": "\u0625\u0631\u064a\u062a\u0631\u064a\u0627"
                 },
                 "eng": {
                     "official": "State of Eritrea",
@@ -10579,6 +10851,10 @@
             "tir": "Tigrinya"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0625\u0631\u064a\u062a\u0631\u064a\u0627",
+                "common": "\u0625\u0631\u064a\u062a\u0631\u064a\u0627"
+            },
             "ces": {
                 "official": "St\u00e1t Eritrea",
                 "common": "Eritrea"
@@ -10748,6 +11024,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0635\u062d\u0631\u0627\u0648\u064a\u0629 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629",
+                "common": "\u0627\u0644\u0635\u062d\u0631\u0627\u0621 \u0627\u0644\u063a\u0631\u0628\u064a\u0629"
+            },
             "ces": {
                 "official": "Z\u00e1padn\u00ed Sahara",
                 "common": "Z\u00e1padn\u00ed Sahara"
@@ -10899,6 +11179,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0625\u0633\u0628\u0627\u0646\u064a\u0627",
+                "common": "\u0625\u0633\u0628\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "\u0160pan\u011blsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "\u0160pan\u011blsko"
@@ -11053,6 +11337,10 @@
             "est": "Estonian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0625\u0633\u062a\u0648\u0646\u064a\u0627",
+                "common": "\u0625\u0633\u062a\u0648\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Estonsk\u00e1 republika",
                 "common": "Estonsko"
@@ -11204,6 +11492,10 @@
             "amh": "Amharic"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0625\u062b\u064a\u0648\u0628\u064a\u0627 \u0627\u0644\u0641\u062f\u0631\u0627\u0644\u064a\u0629 \u0627\u0644\u062f\u064a\u0645\u0648\u0642\u0631\u0627\u0637\u064a\u0629",
+                "common": "\u0625\u062b\u064a\u0648\u0628\u064a\u0627"
+            },
             "ces": {
                 "official": "Etiopsk\u00e1 federativn\u00ed demokratick\u00e1 republika",
                 "common": "Etiopie"
@@ -11365,6 +11657,10 @@
             "swe": "Swedish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0641\u0646\u0644\u0646\u062f\u0627",
+                "common": "\u0641\u0646\u0644\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Finsk\u00e1 republika",
                 "common": "Finsko"
@@ -11528,6 +11824,10 @@
             "hif": "Fiji Hindi"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062c\u0632\u0631 \u0641\u064a\u062c\u064a",
+                "common": "\u0641\u064a\u062c\u064a"
+            },
             "ces": {
                 "official": "Republika Fid\u017eijsk\u00fdch ostrov\u016f",
                 "common": "Fid\u017ei"
@@ -11675,6 +11975,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0641\u0648\u0643\u0644\u0627\u0646\u062f",
+                "common": "\u062c\u0632\u0631 \u0641\u0648\u0643\u0644\u0627\u0646\u062f"
+            },
             "ces": {
                 "official": "Falklandsk\u00e9 ostrovy",
                 "common": "Falklandy"
@@ -11822,6 +12126,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0641\u0631\u0646\u0633\u064a\u0629",
+                "common": "\u0641\u0631\u0646\u0633\u0627"
+            },
             "ces": {
                 "official": "Francouzsk\u00e1 republika",
                 "common": "Francie"
@@ -11987,6 +12295,10 @@
             "fao": "Faroese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0641\u0627\u0631\u0648",
+                "common": "\u062c\u0632\u0631 \u0641\u0627\u0631\u0648"
+            },
             "ces": {
                 "official": "Faersk\u00e9 ostrovy",
                 "common": "Faersk\u00e9 ostrovy"
@@ -12129,6 +12441,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0648\u0644\u0627\u064a\u0627\u062a \u0645\u064a\u0643\u0631\u0648\u0646\u064a\u0633\u064a\u0627 \u0627\u0644\u0645\u062a\u062d\u062f\u0629",
+                "common": "\u0645\u064a\u0643\u0631\u0648\u0646\u064a\u0633\u064a\u0627"
+            },
             "ces": {
                 "official": "Federativn\u00ed st\u00e1ty Mikron\u00e9sie",
                 "common": "Mikron\u00e9sie"
@@ -12276,6 +12592,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u063a\u0627\u0628\u0648\u0646",
+                "common": "\u0627\u0644\u063a\u0627\u0628\u0648\u0646"
+            },
             "ces": {
                 "official": "Gabonsk\u00e1 republika",
                 "common": "Gabon"
@@ -12427,6 +12747,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0645\u062a\u062d\u062f\u0629 \u0644\u0628\u0631\u064a\u0637\u0627\u0646\u064a\u0627 \u0627\u0644\u0639\u0638\u0645\u0649 \u0648\u0627\u064a\u0631\u0644\u0646\u062f\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629",
+                "common": "\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0645\u062a\u062d\u062f\u0629"
+            },
             "ces": {
                 "official": "Spojen\u00e9 kr\u00e1lovstv\u00ed Velk\u00e9 Brit\u00e1nie a Severn\u00edho Irska",
                 "common": "Spojen\u00e9 kr\u00e1lovstv\u00ed"
@@ -12575,6 +12899,10 @@
             "kat": "Georgian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0648\u0631\u062c\u064a\u0627",
+                "common": "\u062c\u0648\u0631\u062c\u064a\u0627"
+            },
             "ces": {
                 "official": "Gruzie",
                 "common": "Gruzie"
@@ -12741,6 +13069,10 @@
             "nfr": "Guern\u00e9siais"
         },
         "translations": {
+            "ara": {
+                "official": "\u063a\u064a\u0631\u0646\u0632\u064a",
+                "common": "\u063a\u064a\u0631\u0646\u0632\u064a"
+            },
             "ces": {
                 "official": "Rycht\u00e1\u0159stv\u00ed Guernsey",
                 "common": "Guernsey"
@@ -12886,6 +13218,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u063a\u0627\u0646\u0627",
+                "common": "\u063a\u0627\u0646\u0627"
+            },
             "ces": {
                 "official": "Ghansk\u00e1 republika",
                 "common": "Ghana"
@@ -13035,6 +13371,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0628\u0644 \u0637\u0627\u0631\u0642",
+                "common": "\u062c\u0628\u0644 \u0637\u0627\u0631\u0642"
+            },
             "ces": {
                 "official": "Gibraltar",
                 "common": "Gibraltar"
@@ -13184,6 +13524,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u063a\u064a\u0646\u064a\u0627",
+                "common": "\u063a\u064a\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Guinejsk\u00e1 republika",
                 "common": "Guinea"
@@ -13337,6 +13681,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u063a\u0648\u0627\u062f\u0644\u0648\u0628",
+                "common": "\u063a\u0648\u0627\u062f\u0644\u0648\u0628"
+            },
             "ces": {
                 "official": "Guadeloupe",
                 "common": "Guadeloupe"
@@ -13483,6 +13831,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u063a\u0627\u0645\u0628\u064a\u0627",
+                "common": "\u063a\u0627\u0645\u0628\u064a\u0627"
+            },
             "ces": {
                 "official": "Gambijsk\u00e1 republika",
                 "common": "Gambie"
@@ -13637,6 +13989,10 @@
             "pov": "Upper Guinea Creole"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u063a\u064a\u0646\u064a\u0627 \u0628\u064a\u0633\u0627\u0648",
+                "common": "\u063a\u064a\u0646\u064a\u0627 \u0628\u064a\u0633\u0627\u0648"
+            },
             "ces": {
                 "official": "Republika Guinea-Bissau",
                 "common": "Guinea-Bissau"
@@ -13799,6 +14155,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u063a\u064a\u0646\u064a\u0627 \u0627\u0644\u0627\u0633\u062a\u0648\u0627\u0626\u064a\u0629",
+                "common": "\u063a\u064a\u0646\u064a\u0627 \u0627\u0644\u0627\u0633\u062a\u0648\u0627\u0626\u064a\u0629"
+            },
             "ces": {
                 "official": "Republika Rovn\u00edkov\u00e1 Guinea",
                 "common": "Rovn\u00edkov\u00e1 Guinea"
@@ -13950,6 +14310,10 @@
             "ell": "Greek"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0647\u064a\u0644\u064a\u0646\u064a\u0629",
+                "common": "\u0627\u0644\u064a\u0648\u0646\u0627\u0646"
+            },
             "ces": {
                 "official": "\u0158eck\u00e1 republika",
                 "common": "\u0158ecko"
@@ -14100,6 +14464,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u063a\u0631\u064a\u0646\u0627\u062f\u0627",
+                "common": "\u063a\u0631\u064a\u0646\u0627\u062f\u0627"
+            },
             "ces": {
                 "official": "Grenada",
                 "common": "Grenada"
@@ -14246,6 +14614,10 @@
             "kal": "Greenlandic"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0631\u064a\u0646\u0644\u0627\u0646\u062f",
+                "common": "\u062c\u0631\u064a\u0646\u0644\u0627\u0646\u062f"
+            },
             "ces": {
                 "official": "Gr\u00f3nsko",
                 "common": "Gr\u00f3nsko"
@@ -14391,6 +14763,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u063a\u0648\u0627\u062a\u064a\u0645\u0627\u0644\u0627",
+                "common": "\u063a\u0648\u0627\u062a\u064a\u0645\u0627\u0644\u0627"
+            },
             "ces": {
                 "official": "Republika Guatemala",
                 "common": "Guatemala"
@@ -14543,6 +14919,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u063a\u0648\u064a\u0627\u0646\u0627 \u0627\u0644\u0641\u0631\u0646\u0633\u064a\u0629",
+                "common": "\u063a\u0648\u064a\u0627\u0646\u0627"
+            },
             "ces": {
                 "official": "Francouzsk\u00e1 Guyana",
                 "common": "Francouzsk\u00e1 Guyana"
@@ -14702,6 +15082,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u063a\u0648\u0627\u0645",
+                "common": "\u063a\u0648\u0627\u0645"
+            },
             "ces": {
                 "official": "Guam",
                 "common": "Guam"
@@ -14848,6 +15232,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u063a\u064a\u0627\u0646\u0627 \u0627\u0644\u062a\u0639\u0627\u0648\u0646\u064a\u0629",
+                "common": "\u063a\u064a\u0627\u0646\u0627"
+            },
             "ces": {
                 "official": "Kooperativn\u00ed republika Guyana",
                 "common": "Guyana"
@@ -15003,6 +15391,10 @@
             "zho": "Chinese"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0646\u0637\u0642\u0629 \u0647\u0648\u0646\u063a \u0643\u0648\u0646\u063a \u0627\u0644\u0627\u062f\u0627\u0631\u064a\u0629 \u0627\u0644\u062a\u0627\u0628\u0639\u0629 \u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0635\u064a\u0646 \u0627\u0644\u0634\u0639\u0628\u064a\u0629",
+                "common": "\u0647\u0648\u0646\u063a \u0643\u0648\u0646\u063a"
+            },
             "ces": {
                 "official": "Zvl\u00e1\u0161tn\u00ed administrativn\u00ed oblast \u010c\u00ednsk\u00e9 lidov\u00e9 republiky Hongkong",
                 "common": "Hongkong"
@@ -15143,6 +15535,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u064a\u0631\u0629 \u0647\u064a\u0631\u062f \u0648\u062c\u0632\u0631 \u0645\u0627\u0643\u062f\u0648\u0646\u0627\u0644\u062f",
+                "common": "\u062c\u0632\u064a\u0631\u0629 \u0647\u064a\u0631\u062f \u0648\u062c\u0632\u0631 \u0645\u0627\u0643\u062f\u0648\u0646\u0627\u0644\u062f"
+            },
             "ces": {
                 "official": "Heard\u016fv ostrov a McDonaldovy ostrovy",
                 "common": "Heard\u016fv ostrov a McDonaldovy ostrovy"
@@ -15290,6 +15686,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0647\u0646\u062f\u0648\u0631\u0627\u0633",
+                "common": "\u0647\u0646\u062f\u0648\u0631\u0627\u0633"
+            },
             "ces": {
                 "official": "Hondurask\u00e1 republika",
                 "common": "Honduras"
@@ -15442,6 +15842,10 @@
             "hrv": "Croatian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0631\u0648\u0627\u062a\u064a\u0627",
+                "common": "\u0643\u0631\u0648\u0627\u062a\u064a\u0627"
+            },
             "ces": {
                 "official": "Chorvatsk\u00e1 republika",
                 "common": "Chorvatsko"
@@ -15601,6 +16005,10 @@
             "hat": "Haitian Creole"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0647\u0627\u064a\u062a\u064a",
+                "common": "\u0647\u0627\u064a\u062a\u064a"
+            },
             "ces": {
                 "official": "Republika Haiti",
                 "common": "Haiti"
@@ -15748,6 +16156,10 @@
             "hun": "Hungarian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0645\u062c\u0631\u064a\u0629",
+                "common": "\u0627\u0644\u0645\u062c\u0631"
+            },
             "ces": {
                 "official": "Ma\u010farsko",
                 "common": "Ma\u010farsko"
@@ -15903,6 +16315,10 @@
             "ind": "Indonesian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0625\u0646\u062f\u0648\u0646\u064a\u0633\u064a\u0627",
+                "common": "\u0625\u0646\u062f\u0648\u0646\u064a\u0633\u064a\u0627"
+            },
             "ces": {
                 "official": "Indon\u00e9sk\u00e1 republika",
                 "common": "Indon\u00e9sie"
@@ -16064,6 +16480,10 @@
             "glv": "Manx"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u064a\u0631\u0629 \u0645\u0627\u0646",
+                "common": "\u062c\u0632\u064a\u0631\u0629 \u0645\u0627\u0646"
+            },
             "ces": {
                 "official": "Ostrov Man",
                 "common": "Ostrov Man"
@@ -16223,6 +16643,10 @@
             "tam": "Tamil"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0647\u0646\u062f",
+                "common": "\u0627\u0644\u0647\u0646\u062f"
+            },
             "ces": {
                 "official": "Indick\u00e1 republika",
                 "common": "Indie"
@@ -16375,6 +16799,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0625\u0642\u0644\u064a\u0645 \u0627\u0644\u0645\u062d\u064a\u0637 \u0627\u0644\u0647\u0646\u062f\u064a \u0627\u0644\u0628\u0631\u064a\u0637\u0627\u0646\u064a",
+                "common": "\u0625\u0642\u0644\u064a\u0645 \u0627\u0644\u0645\u062d\u064a\u0637 \u0627\u0644\u0647\u0646\u062f\u064a \u0627\u0644\u0628\u0631\u064a\u0637\u0627\u0646\u064a"
+            },
             "ces": {
                 "official": "Britsk\u00e9 indickooce\u00e1nsk\u00e9 \u00fazem\u00ed",
                 "common": "Britsk\u00e9 indickooce\u00e1nsk\u00e9 \u00fazem\u00ed"
@@ -16528,6 +16956,10 @@
             "gle": "Irish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u064a\u0631\u0644\u0646\u062f\u0627",
+                "common": "\u0623\u064a\u0631\u0644\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Irsko",
                 "common": "Irsko"
@@ -16679,6 +17111,10 @@
             "fas": "Persian (Farsi)"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0625\u064a\u0631\u0627\u0646 \u0627\u0644\u0625\u0633\u0644\u0627\u0645\u064a\u0629",
+                "common": "\u0625\u064a\u0631\u0627\u0646"
+            },
             "ces": {
                 "official": "Isl\u00e1msk\u00e1 republika \u00cdr\u00e1n",
                 "common": "\u00cdr\u00e1n"
@@ -16844,6 +17280,10 @@
             "ckb": "Sorani"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0627\u0642",
+                "common": "\u0627\u0644\u0639\u0631\u0627\u0642"
+            },
             "ces": {
                 "official": "Ir\u00e1ck\u00e1 republika",
                 "common": "Ir\u00e1k"
@@ -16999,6 +17439,10 @@
             "isl": "Icelandic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0622\u064a\u0633\u0644\u0646\u062f\u0627",
+                "common": "\u0622\u064a\u0633\u0644\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Island",
                 "common": "Island"
@@ -17151,6 +17595,10 @@
             "heb": "Hebrew"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0625\u0633\u0631\u0627\u0626\u064a\u0644",
+                "common": "\u0625\u0633\u0631\u0627\u0626\u064a\u0644"
+            },
             "ces": {
                 "official": "St\u00e1t Izrael",
                 "common": "Izrael"
@@ -17304,6 +17752,10 @@
             "ita": "Italian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0625\u064a\u0637\u0627\u0644\u064a\u0629",
+                "common": "\u0625\u064a\u0637\u0627\u0644\u064a\u0627"
+            },
             "ces": {
                 "official": "Italsk\u00e1 republika",
                 "common": "It\u00e1lie"
@@ -17461,6 +17913,10 @@
             "jam": "Jamaican Patois"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0627\u0645\u0627\u064a\u0643\u0627",
+                "common": "\u062c\u0627\u0645\u0627\u064a\u0643\u0627"
+            },
             "ces": {
                 "official": "Jamajka",
                 "common": "Jamajka"
@@ -17623,6 +18079,10 @@
             "nrf": "J\u00e8rriais"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u064a\u0631\u0632\u064a",
+                "common": "\u062c\u064a\u0631\u0632\u064a"
+            },
             "ces": {
                 "official": "Rycht\u00e1\u0159stv\u00ed Jersey",
                 "common": "Jersey"
@@ -17771,6 +18231,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0623\u0631\u062f\u0646\u064a\u0629 \u0627\u0644\u0647\u0627\u0634\u0645\u064a\u0629",
+                "common": "\u0627\u0644\u0623\u0631\u062f\u0646"
+            },
             "ces": {
                 "official": "Jord\u00e1nsk\u00e9 h\u00e1\u0161imovsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Jord\u00e1nsko"
@@ -17925,6 +18389,10 @@
             "jpn": "Japanese"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u064a\u0627\u0628\u0627\u0646",
+                "common": "\u0627\u0644\u064a\u0627\u0628\u0627\u0646"
+            },
             "ces": {
                 "official": "Japonsko",
                 "common": "Japonsko"
@@ -18084,6 +18552,10 @@
             "rus": "Russian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0627\u0632\u0627\u062e\u0633\u062a\u0627\u0646",
+                "common": "\u0643\u0627\u0632\u0627\u062e\u0633\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "Republika Kazachst\u00e1n",
                 "common": "Kazachst\u00e1n"
@@ -18242,6 +18714,10 @@
             "swa": "Swahili"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u064a\u0646\u064a\u0627",
+                "common": "\u0643\u064a\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Ke\u0148sk\u00e1 republika",
                 "common": "Ke\u0148a"
@@ -18402,6 +18878,10 @@
             "rus": "Russian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0642\u064a\u0631\u063a\u064a\u0632\u064a\u0629",
+                "common": "\u0642\u064a\u0631\u063a\u064a\u0632\u0633\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "Kyrgyzsk\u00e1 republika",
                 "common": "Kyrgyzst\u00e1n"
@@ -18557,6 +19037,10 @@
             "khm": "Khmer"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0643\u0645\u0628\u0648\u062f\u064a\u0627",
+                "common": "\u0643\u0645\u0628\u0648\u062f\u064a\u0627"
+            },
             "ces": {
                 "official": "Kambod\u017esk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Kambod\u017ea"
@@ -18717,6 +19201,10 @@
             "gil": "Gilbertese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u064a\u0631\u064a\u0628\u0627\u062a\u064a",
+                "common": "\u0643\u064a\u0631\u064a\u0628\u0627\u062a\u064a"
+            },
             "ces": {
                 "official": "Republika Kiribati",
                 "common": "Kiribati"
@@ -18863,6 +19351,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u062a\u062d\u0627\u062f \u0627\u0644\u0642\u062f\u064a\u0633 \u0643\u0631\u064a\u0633\u062a\u0648\u0641\u0631 \u0648\u0646\u064a\u0641\u064a\u0633",
+                "common": "\u0633\u0627\u0646\u062a \u0643\u064a\u062a\u0633 \u0648\u0646\u064a\u0641\u064a\u0633"
+            },
             "ces": {
                 "official": "Federace Sv. Kry\u0161tof a Nevis",
                 "common": "Svat\u00fd Kry\u0161tof a Nevis"
@@ -19013,6 +19505,10 @@
             "kor": "Korean"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0648\u0631\u064a\u0627",
+                "common": "\u0643\u0648\u0631\u064a\u0627 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629"
+            },
             "ces": {
                 "official": "Korejsk\u00e1 republika",
                 "common": "Ji\u017en\u00ed Korea"
@@ -19166,6 +19662,10 @@
             "srp": "Serbian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0648\u0633\u0648\u0641\u0648",
+                "common": "\u0643\u0648\u0633\u0648\u0641\u0648"
+            },
             "ces": {
                 "official": "Kosovsk\u00e1 republika",
                 "common": "Kosovo"
@@ -19318,6 +19818,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0627\u0644\u0643\u0648\u064a\u062a",
+                "common": "\u0627\u0644\u0643\u0648\u064a\u062a"
+            },
             "ces": {
                 "official": "St\u00e1t Kuvajt",
                 "common": "Kuvajt"
@@ -19469,6 +19973,10 @@
             "lao": "Lao"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0644\u0627\u0648\u0633 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629 \u0627\u0644\u0634\u0639\u0628\u064a\u0629",
+                "common": "\u0644\u0627\u0648\u0633"
+            },
             "ces": {
                 "official": "Laosk\u00e1 lidov\u011b demokratick\u00e1 republika",
                 "common": "Laos"
@@ -19627,6 +20135,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0644\u0628\u0646\u0627\u0646\u064a\u0629",
+                "common": "\u0644\u0628\u0646\u0627\u0646"
+            },
             "ces": {
                 "official": "Libanonsk\u00e1 republika",
                 "common": "Libanon"
@@ -19776,6 +20288,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0644\u064a\u0628\u064a\u0631\u064a\u0627",
+                "common": "\u0644\u064a\u0628\u064a\u0631\u064a\u0627"
+            },
             "ces": {
                 "official": "Liberijsk\u00e1 republika",
                 "common": "Lib\u00e9rie"
@@ -19886,8 +20402,8 @@
             "official": "State of Libya",
             "native": {
                 "ara": {
-                    "official": "\u0627\u0644\u062f\u0648\u0644\u0629 \u0644\u064a\u0628\u064a\u0627",
-                    "common": "\u200f\u0644\u064a\u0628\u064a\u0627"
+                    "official": "\u062f\u0648\u0644\u0629 \u0644\u064a\u0628\u064a\u0627",
+                    "common": "\u0644\u064a\u0628\u064a\u0627"
                 }
             }
         },
@@ -19927,6 +20443,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0644\u064a\u0628\u064a\u0627",
+                "common": "\u0644\u064a\u0628\u064a\u0627"
+            },
             "ces": {
                 "official": "St\u00e1t Libye",
                 "common": "Libye"
@@ -20079,6 +20599,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0627\u0646\u062a \u0644\u0648\u0633\u064a\u0627",
+                "common": "\u0633\u0627\u0646\u062a \u0644\u0648\u0633\u064a\u0627"
+            },
             "ces": {
                 "official": "Svat\u00e1 Lucie",
                 "common": "Svat\u00e1 Lucie"
@@ -20226,6 +20750,10 @@
             "deu": "German"
         },
         "translations": {
+            "ara": {
+                "official": "\u0625\u0645\u0627\u0631\u0629 \u0644\u064a\u062e\u062a\u0646\u0634\u062a\u0627\u064a\u0646",
+                "common": "\u0644\u064a\u062e\u062a\u0646\u0634\u062a\u0627\u064a\u0646"
+            },
             "ces": {
                 "official": "Kn\u00ed\u017eectv\u00ed Lichten\u0161tejnsk\u00e9",
                 "common": "Lichten\u0161tejnsko"
@@ -20383,6 +20911,10 @@
             "tam": "Tamil"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0631\u064a\u0644\u0627\u0646\u0643\u0627 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629 \u0627\u0644\u0634\u0639\u0628\u064a\u0629",
+                "common": "\u0633\u0631\u064a\u0644\u0627\u0646\u0643\u0627"
+            },
             "ces": {
                 "official": "Sr\u00edlansk\u00e1 demokratick\u00e1 socialistick\u00e1 republika",
                 "common": "Sr\u00ed Lanka"
@@ -20541,6 +21073,10 @@
             "sot": "Sotho"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0644\u064a\u0633\u0648\u062a\u0648",
+                "common": "\u0644\u064a\u0633\u0648\u062a\u0648"
+            },
             "ces": {
                 "official": "Lesothsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Lesotho"
@@ -20690,6 +21226,10 @@
             "lit": "Lithuanian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0644\u064a\u062a\u0648\u0627\u0646\u064a\u0627",
+                "common": "\u0644\u064a\u062a\u0648\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Litevsk\u00e1 republika",
                 "common": "Litva"
@@ -20854,6 +21394,10 @@
             "ltz": "Luxembourgish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0642\u064a\u0629 \u0644\u0648\u0643\u0633\u0645\u0628\u0648\u0631\u063a",
+                "common": "\u0644\u0648\u0643\u0633\u0645\u0628\u0648\u0631\u063a"
+            },
             "ces": {
                 "official": "Lucembursk\u00e9 velkov\u00e9vodstv\u00ed",
                 "common": "Lucembursko"
@@ -21005,6 +21549,10 @@
             "lav": "Latvian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0644\u0627\u062a\u0641\u064a\u0627",
+                "common": "\u0644\u0627\u062a\u0641\u064a\u0627"
+            },
             "ces": {
                 "official": "Loty\u0161sk\u00e1 republika",
                 "common": "Loty\u0161sko"
@@ -21163,6 +21711,10 @@
             "zho": "Chinese"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0646\u0637\u0642\u0629 \u0645\u0627\u0643\u0627\u0648 \u0627\u0644\u0625\u062f\u0627\u0631\u064a\u0629 \u0627\u0644\u062a\u0627\u0628\u0639\u0629 \u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0635\u064a\u0646 \u0627\u0644\u0634\u0639\u0628\u064a\u0629",
+                "common": "\u0645\u0627\u0643\u0627\u0648"
+            },
             "ces": {
                 "official": "Zvl\u00e1\u0161tn\u00ed spr\u00e1vn\u00ed oblast \u010c\u00ednsk\u00e9 lidov\u00e9 republiky Macao",
                 "common": "Macao"
@@ -21314,6 +21866,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0627\u0646\u062a \u0645\u0627\u0631\u062a\u0646",
+                "common": "\u0633\u0627\u0646\u062a \u0645\u0627\u0631\u062a\u0646"
+            },
             "ces": {
                 "official": "Svat\u00fd Martin",
                 "common": "Svat\u00fd Martin (Francie)"
@@ -21469,6 +22025,10 @@
             "ber": "Berber"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0645\u063a\u0631\u0628\u064a\u0629",
+                "common": "\u0627\u0644\u0645\u063a\u0631\u0628"
+            },
             "ces": {
                 "official": "Marock\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Maroko"
@@ -21620,6 +22180,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0625\u0645\u0627\u0631\u0629 \u0645\u0648\u0646\u0627\u0643\u0648",
+                "common": "\u0645\u0648\u0646\u0627\u0643\u0648"
+            },
             "ces": {
                 "official": "Monack\u00e9 kn\u00ed\u017eectv\u00ed",
                 "common": "Monako"
@@ -21770,6 +22334,10 @@
             "ron": "Moldavian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0648\u0644\u062f\u0648\u06a4\u0627",
+                "common": "\u0645\u0648\u0644\u062f\u0648\u06a4\u0627"
+            },
             "ces": {
                 "official": "Moldavsk\u00e1 republika",
                 "common": "Moldavsko"
@@ -21926,6 +22494,10 @@
             "mlg": "Malagasy"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u062f\u063a\u0634\u0642\u0631",
+                "common": "\u0645\u062f\u063a\u0634\u0642\u0631"
+            },
             "ces": {
                 "official": "Madagaskarsk\u00e1 republika",
                 "common": "Madagaskar"
@@ -22074,6 +22646,10 @@
             "div": "Maldivian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0645\u0627\u0644\u062f\u064a\u0641",
+                "common": "\u0627\u0644\u0645\u0627\u0644\u062f\u064a\u0641"
+            },
             "ces": {
                 "official": "Maledivsk\u00e1 republika",
                 "common": "Maledivy"
@@ -22222,6 +22798,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0648\u0644\u0627\u064a\u0627\u062a \u0627\u0644\u0645\u062a\u062d\u062f\u0629 \u0627\u0644\u0645\u0643\u0633\u064a\u0643\u064a\u0629",
+                "common": "\u0627\u0644\u0645\u0633\u0643\u064a\u0643"
+            },
             "ces": {
                 "official": "Spojen\u00e9 st\u00e1ty mexick\u00e9",
                 "common": "Mexiko"
@@ -22378,6 +22958,10 @@
             "mah": "Marshallese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062c\u0632\u0631 \u0645\u0627\u0631\u0634\u0627\u0644",
+                "common": "\u062c\u0632\u0631 \u0645\u0627\u0631\u0634\u0627\u0644"
+            },
             "ces": {
                 "official": "Republika Marshallovy ostrovy",
                 "common": "Marshallovy ostrovy"
@@ -22527,6 +23111,10 @@
             "mkd": "Macedonian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0634\u0645\u0627\u0644 \u0645\u0642\u062f\u0648\u0646\u064a\u0627",
+                "common": "\u0634\u0645\u0627\u0644 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Republika Severn\u00ed Makedonie",
                 "common": "Severn\u00ed Makedonie"
@@ -22680,6 +23268,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0627\u0644\u064a",
+                "common": "\u0645\u0627\u0644\u064a"
+            },
             "ces": {
                 "official": "Republika Mali",
                 "common": "Mali"
@@ -22840,6 +23432,10 @@
             "mlt": "Maltese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0627\u0644\u0637\u0627",
+                "common": "\u0645\u0627\u0644\u0637\u0627"
+            },
             "ces": {
                 "official": "Maltsk\u00e1 republika",
                 "common": "Malta"
@@ -22988,6 +23584,10 @@
             "mya": "Burmese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u062a\u062d\u0627\u062f \u0645\u064a\u0627\u0646\u0645\u0627\u0631",
+                "common": "\u0645\u064a\u0627\u0646\u0645\u0627\u0631"
+            },
             "ces": {
                 "official": "Republika Myanmarsk\u00fd svaz",
                 "common": "Myanmar"
@@ -23140,6 +23740,10 @@
             "cnr": "Montenegrin"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u0627\u0633\u0648\u062f",
+                "common": "\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u0627\u0633\u0648\u062f"
+            },
             "ces": {
                 "official": "\u010cern\u00e1 Hora",
                 "common": "\u010cern\u00e1 Hora"
@@ -23291,6 +23895,10 @@
             "mon": "Mongolian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0646\u063a\u0648\u0644\u064a\u0627",
+                "common": "\u0645\u0646\u063a\u0648\u0644\u064a\u0627"
+            },
             "ces": {
                 "official": "St\u00e1t Mongolsko",
                 "common": "Mongolsko"
@@ -23451,6 +24059,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0643\u0648\u0645\u0648\u0646\u0648\u0644\u062b \u062c\u0632\u0631 \u0645\u0627\u0631\u064a\u0627\u0646\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629",
+                "common": "\u062c\u0632\u0631 \u0645\u0627\u0631\u064a\u0627\u0646\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
+            },
             "ces": {
                 "official": "Spole\u010denstv\u00ed Severn\u00edch Marian",
                 "common": "Severn\u00ed Mariany"
@@ -23598,6 +24210,10 @@
             "por": "Portuguese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0648\u0632\u0645\u0628\u064a\u0642",
+                "common": "\u0645\u0648\u0632\u0645\u0628\u064a\u0642"
+            },
             "ces": {
                 "official": "Mosambick\u00e1 republika",
                 "common": "Mosambik"
@@ -23752,6 +24368,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0625\u0633\u0644\u0627\u0645\u064a\u0629 \u0627\u0644\u0645\u0648\u0631\u064a\u062a\u0627\u0646\u064a\u0629",
+                "common": "\u0645\u0648\u0631\u064a\u062a\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Maurit\u00e1nsk\u00e1 isl\u00e1msk\u00e1 republika",
                 "common": "Maurit\u00e1nie"
@@ -23902,6 +24522,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0648\u0646\u062a\u0633\u0631\u0627\u062a",
+                "common": "\u0645\u0648\u0646\u062a\u0633\u0631\u0627\u062a"
+            },
             "ces": {
                 "official": "Montserrat",
                 "common": "Montserrat"
@@ -24047,6 +24671,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0627\u0631\u062a\u064a\u0646\u064a\u0643",
+                "common": "\u0645\u0627\u0631\u062a\u064a\u0646\u064a\u0643"
+            },
             "ces": {
                 "official": "Martinik",
                 "common": "Martinik"
@@ -24204,6 +24832,10 @@
             "mfe": "Mauritian Creole"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0648\u0631\u064a\u0634\u064a\u0648\u0633",
+                "common": "\u0645\u0648\u0631\u064a\u0634\u064a\u0648\u0633"
+            },
             "ces": {
                 "official": "Mauricijsk\u00e1 republika",
                 "common": "Mauricius"
@@ -24355,6 +24987,10 @@
             "nya": "Chewa"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0627\u0644\u0627\u0648\u064a",
+                "common": "\u0645\u0627\u0644\u0627\u0648\u064a"
+            },
             "ces": {
                 "official": "Malawisk\u00e1 republika",
                 "common": "Malawi"
@@ -24509,6 +25145,10 @@
             "msa": "Malay"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0627\u0644\u064a\u0632\u064a\u0627",
+                "common": "\u0645\u0627\u0644\u064a\u0632\u064a\u0627"
+            },
             "ces": {
                 "official": "Malajsie",
                 "common": "Malajsie"
@@ -24660,6 +25300,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0627\u064a\u0648\u062a",
+                "common": "\u0645\u0627\u064a\u0648\u062a"
+            },
             "ces": {
                 "official": "Mayotte",
                 "common": "Mayotte"
@@ -24851,6 +25495,10 @@
             "tsn": "Tswana"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0646\u0627\u0645\u064a\u0628\u064a\u0627",
+                "common": "\u0646\u0627\u0645\u064a\u0628\u064a\u0627"
+            },
             "ces": {
                 "official": "Namibijsk\u00e1 republika",
                 "common": "Namibie"
@@ -25001,6 +25649,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0643\u0627\u0644\u064a\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u062c\u062f\u064a\u062f\u0629",
+                "common": "\u0643\u0627\u0644\u064a\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u062c\u062f\u064a\u062f\u0629"
+            },
             "ces": {
                 "official": "Nov\u00e1 Kaledonie",
                 "common": "Nov\u00e1 Kaledonie"
@@ -25147,6 +25799,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0646\u064a\u062c\u0631",
+                "common": "\u0627\u0644\u0646\u064a\u062c\u0631"
+            },
             "ces": {
                 "official": "Nigersk\u00e1 republika",
                 "common": "Niger"
@@ -25307,6 +25963,10 @@
             "pih": "Norfuk"
         },
         "translations": {
+            "ara": {
+                "official": "\u0625\u0642\u0644\u064a\u0645 \u062c\u0632\u064a\u0631\u0629 \u0646\u0648\u0631\u0641\u0648\u0644\u0643",
+                "common": "\u062c\u0632\u064a\u0631\u0629 \u0646\u0648\u0631\u0641\u0648\u0644\u0643"
+            },
             "ces": {
                 "official": "Teritorium ostrova Norfolk",
                 "common": "Norfolk"
@@ -25455,6 +26115,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0646\u064a\u062c\u064a\u0631\u064a\u0627 \u0627\u0644\u0627\u062a\u062d\u0627\u062f\u064a\u0629",
+                "common": "\u0646\u064a\u062c\u064a\u0631\u064a\u0627"
+            },
             "ces": {
                 "official": "Nigerijsk\u00e1 federativn\u00ed republika",
                 "common": "Nig\u00e9rie"
@@ -25607,6 +26271,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0646\u064a\u0643\u0627\u0631\u0627\u063a\u0648\u0627",
+                "common": "\u0646\u064a\u0643\u0627\u0631\u0627\u063a\u0648\u0627"
+            },
             "ces": {
                 "official": "Republika Nikaragua",
                 "common": "Nikaragua"
@@ -25760,6 +26428,10 @@
             "niu": "Niuean"
         },
         "translations": {
+            "ara": {
+                "official": "\u0646\u064a\u064a\u0648\u064a",
+                "common": "\u0646\u064a\u064a\u0648\u064a"
+            },
             "ces": {
                 "official": "Niue",
                 "common": "Niue"
@@ -25908,6 +26580,10 @@
             "nld": "Dutch"
         },
         "translations": {
+            "ara": {
+                "official": "\u0647\u0648\u0644\u0646\u062f\u0627",
+                "common": "\u0647\u0648\u0644\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Nizozemsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Nizozemsko"
@@ -26071,6 +26747,10 @@
             "smi": "Sami"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0646\u0631\u0648\u064a\u062c",
+                "common": "\u0627\u0644\u0646\u0631\u0648\u064a\u062c"
+            },
             "ces": {
                 "official": "Norsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Norsko"
@@ -26222,6 +26902,10 @@
             "nep": "Nepali"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0646\u064a\u0628\u0627\u0644 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629 \u0627\u0644\u0627\u062a\u062d\u0627\u062f\u064a\u0629",
+                "common": "\u0646\u064a\u0628\u0627\u0644"
+            },
             "ces": {
                 "official": "Federativn\u00ed demokratick\u00e1 republika Nep\u00e1l",
                 "common": "Nep\u00e1l"
@@ -26379,6 +27063,10 @@
             "nau": "Nauru"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0646\u0627\u0648\u0631\u0648",
+                "common": "\u0646\u0627\u0648\u0631\u0648"
+            },
             "ces": {
                 "official": "Republika Nauru",
                 "common": "Nauru"
@@ -26535,6 +27223,10 @@
             "nzs": "New Zealand Sign Language"
         },
         "translations": {
+            "ara": {
+                "official": "\u0646\u064a\u0648\u0632\u064a\u0644\u0646\u062f\u0627",
+                "common": "\u0646\u064a\u0648\u0632\u064a\u0644\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Nov\u00fd Z\u00e9land",
                 "common": "Nov\u00fd Z\u00e9land"
@@ -26682,6 +27374,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0644\u0637\u0646\u0629 \u0639\u0645\u0627\u0646",
+                "common": "\u0639\u0645\u0627\u0646"
+            },
             "ces": {
                 "official": "Sultan\u00e1t Om\u00e1n",
                 "common": "Om\u00e1n"
@@ -26839,6 +27535,10 @@
             "urd": "Urdu"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0627\u0643\u0633\u062a\u0627\u0646 \u0627\u0644\u0625\u0633\u0644\u0627\u0645\u064a\u0629",
+                "common": "\u0628\u0627\u0643\u0633\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "P\u00e1kist\u00e1nsk\u00e1 isl\u00e1msk\u00e1 republika",
                 "common": "P\u00e1kist\u00e1n"
@@ -26995,6 +27695,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0646\u0645\u0627",
+                "common": "\u0628\u0646\u0645\u0627"
+            },
             "ces": {
                 "official": "Panamsk\u00e1 republika",
                 "common": "Panama"
@@ -27145,6 +27849,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0628\u064a\u062a\u0643\u064a\u0631\u0646",
+                "common": "\u062c\u0632\u0631 \u0628\u064a\u062a\u0643\u064a\u0631\u0646"
+            },
             "ces": {
                 "official": "Pitcairnovy ostrovy",
                 "common": "Pitcairnovy ostrovy"
@@ -27302,6 +28010,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u064a\u0631\u0648",
+                "common": "\u0628\u064a\u0631\u0648"
+            },
             "ces": {
                 "official": "Peru\u00e1nsk\u00e1 republika",
                 "common": "Peru"
@@ -27460,6 +28172,10 @@
             "fil": "Filipino"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0641\u0644\u0628\u064a\u0646",
+                "common": "\u0627\u0644\u0641\u0644\u0628\u064a\u0646"
+            },
             "ces": {
                 "official": "Filip\u00ednsk\u00e1 republika",
                 "common": "Filip\u00edny"
@@ -27612,6 +28328,10 @@
             "pau": "Palauan"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0627\u0644\u0627\u0648",
+                "common": "\u0628\u0627\u0644\u0627\u0648"
+            },
             "ces": {
                 "official": "Republika Palau",
                 "common": "Palau"
@@ -27769,6 +28489,10 @@
             "tpi": "Tok Pisin"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0628\u0627\u0628\u0648\u0627 \u063a\u064a\u0646\u064a\u0627 \u0627\u0644\u062c\u062f\u064a\u062f\u0629",
+                "common": "\u0628\u0627\u0628\u0648\u0627 \u063a\u064a\u0646\u064a\u0627 \u0627\u0644\u062c\u062f\u064a\u062f\u0629"
+            },
             "ces": {
                 "official": "Nez\u00e1visl\u00fd st\u00e1t Papua Nov\u00e1 Guinea",
                 "common": "Papua-Nov\u00e1 Guinea"
@@ -27918,6 +28642,10 @@
             "pol": "Polish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0628\u0648\u0644\u0646\u062f\u064a\u0629",
+                "common": "\u0628\u0648\u0644\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Polsk\u00e1 republika",
                 "common": "Polsko"
@@ -28079,6 +28807,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0643\u0648\u0645\u0646\u0648\u0644\u062b \u0628\u0648\u064a\u0631\u062a\u0648\u0631\u064a\u0643\u0648",
+                "common": "\u0628\u0648\u064a\u0631\u062a\u0648\u0631\u064a\u0643\u0648"
+            },
             "ces": {
                 "official": "Portoriko",
                 "common": "Portoriko"
@@ -28231,6 +28963,10 @@
             "kor": "Korean"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0643\u0648\u0631\u064a\u0627 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629 \u0627\u0644\u0634\u0639\u0628\u064a\u0629",
+                "common": "\u0643\u0648\u0631\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
+            },
             "ces": {
                 "official": "Korejsk\u00e1 lidov\u011b demokratick\u00e1 republika",
                 "common": "Severn\u00ed Korea"
@@ -28383,6 +29119,10 @@
             "por": "Portuguese"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0628\u0631\u062a\u063a\u0627\u0644\u064a\u0629",
+                "common": "\u0627\u0644\u0628\u0631\u062a\u063a\u0627\u0644"
+            },
             "ces": {
                 "official": "Portugalsk\u00e1 republika",
                 "common": "Portugalsko"
@@ -28538,6 +29278,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0628\u0627\u0631\u0627\u063a\u0648\u0627\u064a",
+                "common": "\u0628\u0627\u0631\u0627\u063a\u0648\u0627\u064a"
+            },
             "ces": {
                 "official": "Paraguaysk\u00e1 republika",
                 "common": "Paraguay"
@@ -28699,6 +29443,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0641\u0644\u0633\u0637\u064a\u0646",
+                "common": "\u0641\u0644\u0633\u0637\u064a\u0646"
+            },
             "ces": {
                 "official": "St\u00e1t Palestina",
                 "common": "Palestina"
@@ -28851,6 +29599,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0628\u0648\u0644\u064a\u0646\u0632\u064a\u0627 \u0627\u0644\u0641\u0631\u0646\u0633\u064a\u0629",
+                "common": "\u0628\u0648\u0644\u064a\u0646\u0632\u064a\u0627 \u0627\u0644\u0641\u0631\u0646\u0633\u064a\u0629"
+            },
             "ces": {
                 "official": "Francouzsk\u00e1 Polyn\u00e9sie",
                 "common": "Francouzsk\u00e1 Polyn\u00e9sie"
@@ -28999,6 +29751,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0642\u0637\u0631",
+                "common": "\u0642\u0637\u0631"
+            },
             "ces": {
                 "official": "St\u00e1t Katar",
                 "common": "Katar"
@@ -29147,6 +29903,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u064a\u0631\u0629 \u0644\u0627 \u0631\u064a\u0648\u0646\u064a\u0648\u0646",
+                "common": "\u0644\u0627 \u0631\u064a\u0648\u0646\u064a\u0648\u0646"
+            },
             "ces": {
                 "official": "R\u00e9union",
                 "common": "R\u00e9union"
@@ -29295,6 +30055,10 @@
             "ron": "Romanian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0631\u0648\u0645\u0627\u0646\u064a\u0627",
+                "common": "\u0631\u0648\u0645\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Rumunsko",
                 "common": "Rumunsko"
@@ -29454,6 +30218,10 @@
             "rus": "Russian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0631\u0648\u0633\u064a\u0627 \u0627\u0644\u0627\u062a\u062d\u0627\u062f\u064a\u0629",
+                "common": "\u0631\u0648\u0633\u064a\u0627"
+            },
             "ces": {
                 "official": "Rusk\u00e1 federace",
                 "common": "Rusko"
@@ -29627,6 +30395,10 @@
             "kin": "Kinyarwanda"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0631\u0648\u0627\u0646\u062f\u0627",
+                "common": "\u0631\u0648\u0627\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Rwandsk\u00e1 republika",
                 "common": "Rwanda"
@@ -29739,7 +30511,7 @@
             "native": {
                 "ara": {
                     "official": "\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629",
-                    "common": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629"
+                    "common": "\u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629"
                 }
             }
         },
@@ -29781,6 +30553,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629",
+                "common": "\u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629"
+            },
             "ces": {
                 "official": "Sa\u00fadskoarabsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Sa\u00fadsk\u00e1 Ar\u00e1bie"
@@ -29941,6 +30717,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0633\u0648\u062f\u0627\u0646",
+                "common": "\u0627\u0644\u0633\u0648\u062f\u0627\u0646"
+            },
             "ces": {
                 "official": "S\u00fad\u00e1nsk\u00e1 republika",
                 "common": "S\u00fad\u00e1n"
@@ -30096,6 +30876,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0633\u0646\u063a\u0627\u0644",
+                "common": "\u0627\u0644\u0633\u0646\u063a\u0627\u0644"
+            },
             "ces": {
                 "official": "Senegalsk\u00e1 republika",
                 "common": "Senegal"
@@ -30267,6 +31051,10 @@
             "zho": "Chinese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0646\u063a\u0627\u0641\u0648\u0631\u0629",
+                "common": "\u0633\u0646\u063a\u0627\u0641\u0648\u0631\u0629"
+            },
             "ces": {
                 "official": "Singapursk\u00e1 republika",
                 "common": "Singapur"
@@ -30413,6 +31201,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0648\u0631\u062c\u064a\u0627 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629 \u0648\u062c\u0632\u0631 \u0633\u0627\u0646\u062f\u0648\u062a\u0634 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629",
+                "common": "\u062c\u0648\u0631\u062c\u064a\u0627 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629"
+            },
             "ces": {
                 "official": "Ji\u017en\u00ed Georgie a Ji\u017en\u00ed Sandwichovy ostrovy",
                 "common": "Ji\u017en\u00ed Georgie a Ji\u017en\u00ed Sandwichovy ostrovy"
@@ -30559,6 +31351,10 @@
             "nor": "Norwegian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0641\u0627\u0644\u0628\u0627\u0631\u062f \u0648\u064a\u0627\u0646 \u0645\u0627\u064a\u0646",
+                "common": "\u0633\u0641\u0627\u0644\u0628\u0627\u0631\u062f \u0648\u064a\u0627\u0646 \u0645\u0627\u064a\u0646"
+            },
             "ces": {
                 "official": "\u0160picberky a Jan Mayen",
                 "common": "\u0160picberky a Jan Mayen"
@@ -30704,6 +31500,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0633\u0644\u064a\u0645\u0627\u0646",
+                "common": "\u062c\u0632\u0631 \u0633\u0644\u064a\u0645\u0627\u0646"
+            },
             "ces": {
                 "official": "\u0160alamounovy ostrovy",
                 "common": "\u0160alamounovy ostrovy"
@@ -30850,6 +31650,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u064a\u0631\u0627\u0644\u064a\u0648\u0646",
+                "common": "\u0633\u064a\u0631\u0627\u0644\u064a\u0648\u0646"
+            },
             "ces": {
                 "official": "Republika Sierra Leone",
                 "common": "Sierra Leone"
@@ -31000,6 +31804,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0633\u0644\u0641\u0627\u062f\u0648\u0631",
+                "common": "\u0627\u0644\u0633\u0644\u0641\u0627\u062f\u0648\u0631"
+            },
             "ces": {
                 "official": "Salvadorsk\u00e1 republika",
                 "common": "Salvador"
@@ -31150,6 +31958,10 @@
             "ita": "Italian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0627\u0646 \u0645\u0627\u0631\u064a\u0646\u0648",
+                "common": "\u0633\u0627\u0646 \u0645\u0627\u0631\u064a\u0646\u0648"
+            },
             "ces": {
                 "official": "Republika San Marino",
                 "common": "San Marino"
@@ -31258,8 +32070,8 @@
             "official": "Federal Republic of Somalia",
             "native": {
                 "ara": {
-                    "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0635\u0648\u0645\u0627\u0644\u200e\u200e",
-                    "common": "\u0627\u0644\u0635\u0648\u0645\u0627\u0644\u200e\u200e"
+                    "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0635\u0648\u0645\u0627\u0644 \u0627\u0644\u0641\u064a\u062f\u0631\u0627\u0644\u064a\u0629",
+                    "common": "\u0627\u0644\u0635\u0648\u0645\u0627\u0644"
                 },
                 "som": {
                     "official": "Jamhuuriyadda Federaalka Soomaaliya",
@@ -31306,6 +32118,10 @@
             "som": "Somali"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0635\u0648\u0645\u0627\u0644 \u0627\u0644\u0641\u064a\u062f\u0631\u0627\u0644\u064a\u0629",
+                "common": "\u0627\u0644\u0635\u0648\u0645\u0627\u0644"
+            },
             "ces": {
                 "official": "Som\u00e1lsk\u00e1 demokratick\u00e1 republika",
                 "common": "Som\u00e1lsko"
@@ -31456,6 +32272,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0627\u0646 \u0628\u064a\u064a\u0631 \u0648\u0645\u064a\u0643\u0644\u0648\u0646",
+                "common": "\u0633\u0627\u0646 \u0628\u064a\u064a\u0631 \u0648\u0645\u064a\u0643\u0644\u0648\u0646"
+            },
             "ces": {
                 "official": "Saint-Pierre a Miquelon",
                 "common": "Saint-Pierre a Miquelon"
@@ -31606,6 +32426,10 @@
             "srp": "Serbian"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0635\u064a\u0631\u0628\u064a\u0627",
+                "common": "\u0635\u064a\u0631\u0628\u064a\u0627"
+            },
             "ces": {
                 "official": "Srbsk\u00e1 republika",
                 "common": "Srbsko"
@@ -31760,6 +32584,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062c\u0646\u0648\u0628 \u0627\u0644\u0633\u0648\u062f\u0627\u0646",
+                "common": "\u062c\u0646\u0648\u0628 \u0627\u0644\u0633\u0648\u062f\u0627\u0646"
+            },
             "ces": {
                 "official": "Jihos\u00fad\u00e1nsk\u00e1 republika",
                 "common": "Ji\u017en\u00ed S\u00fad\u00e1n"
@@ -31915,6 +32743,10 @@
             "por": "Portuguese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0627\u0648 \u062a\u0648\u0645\u064a \u0648\u0628\u0631\u064a\u0646\u0633\u064a\u0628 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629",
+                "common": "\u0633\u0627\u0648 \u062a\u0648\u0645\u064a \u0648\u0628\u0631\u064a\u0646\u0633\u064a\u0628"
+            },
             "ces": {
                 "official": "Demokratick\u00e1 republika Svat\u00fd Tom\u00e1\u0161 a Princ\u016fv ostrov",
                 "common": "Svat\u00fd Tom\u00e1\u0161 a Princ\u016fv ostrov"
@@ -32064,6 +32896,10 @@
             "nld": "Dutch"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0648\u0631\u064a\u0646\u0627\u0645",
+                "common": "\u0633\u0648\u0631\u064a\u0646\u0627\u0645"
+            },
             "ces": {
                 "official": "Republika Surinam",
                 "common": "Surinam"
@@ -32215,6 +33051,10 @@
             "slk": "Slovak"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0644\u0648\u0641\u0627\u0643\u064a\u0627",
+                "common": "\u0633\u0644\u0648\u0641\u0627\u0643\u064a\u0627"
+            },
             "ces": {
                 "official": "Slovensk\u00e1 republika",
                 "common": "Slovensko"
@@ -32368,6 +33208,10 @@
             "slv": "Slovene"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u0644\u0648\u0641\u064a\u0646\u064a\u0627",
+                "common": "\u0633\u0644\u0648\u0641\u064a\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Slovinsk\u00e1 republika",
                 "common": "Slovinsko"
@@ -32520,6 +33364,10 @@
             "swe": "Swedish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0627\u0644\u0633\u0648\u064a\u062f",
+                "common": "\u0627\u0644\u0633\u0648\u064a\u062f"
+            },
             "ces": {
                 "official": "\u0160v\u00e9dsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "\u0160v\u00e9dsko"
@@ -32683,6 +33531,10 @@
             "ssw": "Swazi"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u0625\u0633\u0648\u0627\u062a\u064a\u0646\u064a",
+                "common": "\u0625\u0633\u0648\u0627\u062a\u064a\u0646\u064a"
+            },
             "ces": {
                 "official": "Svazijsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Svazijsko"
@@ -32842,6 +33694,10 @@
             "nld": "Dutch"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u064a\u0646\u062a \u0645\u0627\u0631\u062a\u0646",
+                "common": "\u0633\u064a\u0646\u062a \u0645\u0627\u0631\u062a\u0646"
+            },
             "ces": {
                 "official": "Svat\u00fd Martin",
                 "common": "Svat\u00fd Martin (Nizozemsko)"
@@ -33002,6 +33858,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0633\u064a\u0634\u0644",
+                "common": "\u0633\u064a\u0634\u0644"
+            },
             "ces": {
                 "official": "Seychelsk\u00e1 republika",
                 "common": "Seychely"
@@ -33150,6 +34010,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0627\u0644\u0633\u0648\u0631\u064a\u0629",
+                "common": "\u0633\u0648\u0631\u064a\u0627"
+            },
             "ces": {
                 "official": "Syrsk\u00e1 arabsk\u00e1 republika",
                 "common": "S\u00fdrie"
@@ -33301,6 +34165,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u062a\u0648\u0631\u0643\u0633 \u0648\u0643\u0627\u064a\u0643\u0648\u0633",
+                "common": "\u062c\u0632\u0631 \u062a\u0648\u0631\u0643\u0633 \u0648\u0643\u0627\u064a\u0643\u0648\u0633"
+            },
             "ces": {
                 "official": "Turks a Caicos",
                 "common": "Turks a Caicos"
@@ -33408,7 +34276,7 @@
             "native": {
                 "ara": {
                     "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062a\u0634\u0627\u062f",
-                    "common": "\u062a\u0634\u0627\u062f\u200e"
+                    "common": "\u062a\u0634\u0627\u062f"
                 },
                 "fra": {
                     "official": "R\u00e9publique du Tchad",
@@ -33454,6 +34322,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062a\u0634\u0627\u062f",
+                "common": "\u062a\u0634\u0627\u062f"
+            },
             "ces": {
                 "official": "\u010cadsk\u00e1 republika",
                 "common": "\u010cad"
@@ -33609,6 +34481,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062a\u0648\u063a\u0648",
+                "common": "\u062a\u0648\u063a\u0648"
+            },
             "ces": {
                 "official": "Republika Togo",
                 "common": "Togo"
@@ -33764,6 +34640,10 @@
             "tha": "Thai"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u062a\u0627\u064a\u0644\u0646\u062f",
+                "common": "\u062a\u0627\u064a\u0644\u0646\u062f"
+            },
             "ces": {
                 "official": "Thajsk\u00e9 kr\u00e1lovstv\u00ed",
                 "common": "Thajsko"
@@ -33923,6 +34803,10 @@
             "tgk": "Tajik"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0637\u0627\u062c\u064a\u0643\u0633\u062a\u0627\u0646",
+                "common": "\u0637\u0627\u062c\u064a\u0643\u0633\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "Republika T\u00e1d\u017eikist\u00e1n",
                 "common": "T\u00e1d\u017eikist\u00e1n"
@@ -34083,6 +34967,10 @@
             "tkl": "Tokelauan"
         },
         "translations": {
+            "ara": {
+                "official": "\u062a\u0648\u0643\u064a\u0644\u0627\u0648",
+                "common": "\u062a\u0648\u0643\u064a\u0644\u0627\u0648"
+            },
             "ces": {
                 "official": "Tokelau",
                 "common": "Tokelau"
@@ -34233,6 +35121,10 @@
             "tuk": "Turkmen"
         },
         "translations": {
+            "ara": {
+                "official": "\u062a\u0631\u0643\u0645\u0627\u0646\u0633\u062a\u0627\u0646",
+                "common": "\u062a\u0631\u0643\u0645\u0627\u0646\u0633\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "Turkmenist\u00e1n",
                 "common": "Turkmenist\u00e1n"
@@ -34394,6 +35286,10 @@
             "tet": "Tetum"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062a\u064a\u0645\u0648\u0631 \u0627\u0644\u0634\u0631\u0642\u064a\u0629 \u0627\u0644\u062f\u064a\u0645\u0642\u0631\u0627\u0637\u064a\u0629",
+                "common": "\u062a\u064a\u0645\u0648\u0631 \u0627\u0644\u0634\u0631\u0642\u064a\u0629"
+            },
             "ces": {
                 "official": "Demokratick\u00e1 republika V\u00fdchodn\u00ed Timor",
                 "common": "V\u00fdchodn\u00ed Timor"
@@ -34546,6 +35442,10 @@
             "ton": "Tongan"
         },
         "translations": {
+            "ara": {
+                "official": "\u0645\u0645\u0644\u0643\u0629 \u062a\u0648\u0646\u063a\u0627",
+                "common": "\u062a\u0648\u0646\u063a\u0627"
+            },
             "ces": {
                 "official": "Kr\u00e1lovstv\u00ed Tonga",
                 "common": "Tonga"
@@ -34692,6 +35592,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062a\u0631\u064a\u0646\u064a\u062f\u0627\u062f \u0648\u062a\u0648\u0628\u0627\u063a\u0648",
+                "common": "\u062a\u0631\u064a\u0646\u064a\u062f\u0627\u062f \u0648\u062a\u0648\u0628\u0627\u063a\u0648"
+            },
             "ces": {
                 "official": "Republika Trinidad a Tobago",
                 "common": "Trinidad a Tobago"
@@ -34839,6 +35743,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u062a\u0648\u0646\u0633\u064a\u0629",
+                "common": "\u062a\u0648\u0646\u0633"
+            },
             "ces": {
                 "official": "Tunisk\u00e1 republika",
                 "common": "Tunisko"
@@ -34990,6 +35898,10 @@
             "tur": "Turkish"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u062a\u0631\u0643\u064a\u0629",
+                "common": "\u062a\u0631\u0643\u064a\u0627"
+            },
             "ces": {
                 "official": "Tureck\u00e1 republika",
                 "common": "Turecko"
@@ -35153,6 +36065,10 @@
             "tvl": "Tuvaluan"
         },
         "translations": {
+            "ara": {
+                "official": "\u062a\u0648\u0641\u0627\u0644\u0648",
+                "common": "\u062a\u0648\u0641\u0627\u0644\u0648"
+            },
             "ces": {
                 "official": "Tuvalu",
                 "common": "Tuvalu"
@@ -35305,6 +36221,10 @@
             "zho": "Chinese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0635\u064a\u0646 (\u062a\u0627\u064a\u0648\u0627\u0646)",
+                "common": "\u062a\u0627\u064a\u0648\u0627\u0646"
+            },
             "ces": {
                 "official": "\u010c\u00ednsk\u00e1 republika",
                 "common": "Tchaj-wan"
@@ -35458,6 +36378,10 @@
             "swa": "Swahili"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062a\u0646\u0632\u0627\u0646\u064a\u0627 \u0627\u0644\u0627\u062a\u062d\u0627\u062f\u064a\u0629",
+                "common": "\u062a\u0646\u0632\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Sjednocen\u00e1 tanzansk\u00e1 republika",
                 "common": "Tanzanie"
@@ -35619,6 +36543,10 @@
             "swa": "Swahili"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0648\u063a\u0646\u062f\u0627",
+                "common": "\u0623\u0648\u063a\u0646\u062f\u0627"
+            },
             "ces": {
                 "official": "Ugandsk\u00e1 republika",
                 "common": "Uganda"
@@ -35772,6 +36700,10 @@
             "ukr": "Ukrainian"
         },
         "translations": {
+            "ara": {
+                "official": "\u0623\u0648\u0643\u0631\u0627\u0646\u064a\u0627",
+                "common": "\u0623\u0648\u0643\u0631\u0627\u0646\u064a\u0627"
+            },
             "ces": {
                 "official": "Ukrajina",
                 "common": "Ukrajina"
@@ -35923,6 +36855,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0627\u0644\u0648\u0644\u0627\u064a\u0627\u062a \u0627\u0644\u0645\u062a\u062d\u062f\u0629 \u0627\u0644\u0635\u063a\u064a\u0631\u0629 \u0627\u0644\u0646\u0627\u0626\u064a\u0629",
+                "common": "\u062c\u0632\u0631 \u0627\u0644\u0648\u0644\u0627\u064a\u0627\u062a \u0627\u0644\u0645\u062a\u062d\u062f\u0629 \u0627\u0644\u0635\u063a\u064a\u0631\u0629 \u0627\u0644\u0646\u0627\u0626\u064a\u0629"
+            },
             "ces": {
                 "official": "Men\u0161\u00ed odlehl\u00e9 ostrovy Spojen\u00fdch st\u00e1t\u016f americk\u00fdch",
                 "common": "Men\u0161\u00ed odlehl\u00e9 ostrovy USA"
@@ -36070,6 +37006,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u0623\u0648\u0631\u0648\u063a\u0648\u0627\u064a \u0627\u0644\u0634\u0631\u0642\u064a\u0629",
+                "common": "\u0627\u0644\u0623\u0648\u0631\u0648\u063a\u0648\u0627\u064a"
+            },
             "ces": {
                 "official": "Uruguaysk\u00e1 v\u00fdchodn\u00ed republika",
                 "common": "Uruguay"
@@ -36599,6 +37539,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u0648\u0644\u0627\u064a\u0627\u062a \u0627\u0644\u0645\u062a\u062d\u062f\u0629 \u0627\u0644\u0627\u0645\u0631\u064a\u0643\u064a\u0629",
+                "common": "\u0627\u0644\u0648\u0644\u0627\u064a\u0627\u062a \u0627\u0644\u0645\u062a\u062d\u062f\u0629"
+            },
             "ces": {
                 "official": "Spojen\u00e9 st\u00e1ty americk\u00e9",
                 "common": "Spojen\u00e9 st\u00e1ty"
@@ -36755,6 +37699,10 @@
             "uzb": "Uzbek"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0623\u0648\u0632\u0628\u0627\u0643\u0633\u062a\u0627\u0646",
+                "common": "\u0623\u0648\u0632\u0628\u0627\u0643\u0633\u062a\u0627\u0646"
+            },
             "ces": {
                 "official": "Republika Uzbekist\u00e1n",
                 "common": "Uzbekist\u00e1n"
@@ -36915,6 +37863,10 @@
             "lat": "Latin"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0641\u0627\u062a\u064a\u0643\u0627\u0646",
+                "common": "\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0641\u0627\u062a\u064a\u0643\u0627\u0646"
+            },
             "ces": {
                 "official": "M\u011bstsk\u00fd st\u00e1t Vatik\u00e1n",
                 "common": "Vatik\u00e1n"
@@ -37062,6 +38014,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u0633\u0627\u0646\u062a \u0641\u064a\u0646\u0633\u0646\u062a \u0648\u0627\u0644\u063a\u0631\u064a\u0646\u0627\u062f\u064a\u0646",
+                "common": "\u0633\u0627\u0646\u062a \u0641\u064a\u0646\u0633\u0646\u062a \u0648\u0627\u0644\u063a\u0631\u064a\u0646\u0627\u062f\u064a\u0646"
+            },
             "ces": {
                 "official": "Svat\u00fd Vincenc a Grenadiny",
                 "common": "Svat\u00fd Vincenc a Grenadiny"
@@ -37210,6 +38166,10 @@
             "spa": "Spanish"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0641\u0646\u0632\u0648\u064a\u0644\u0627 \u0627\u0644\u0628\u0648\u0644\u064a\u0641\u0627\u0631\u064a\u0629",
+                "common": "\u0641\u0646\u0632\u0648\u064a\u0644\u0627"
+            },
             "ces": {
                 "official": "Bol\u00edvarsk\u00e1 republika Venezuela",
                 "common": "Venezuela"
@@ -37360,6 +38320,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0627\u0644\u0639\u0630\u0631\u0627\u0621 \u0627\u0644\u0628\u0631\u064a\u0637\u0627\u0646\u064a\u0629",
+                "common": "\u062c\u0632\u0631 \u0627\u0644\u0639\u0630\u0631\u0627\u0621"
+            },
             "ces": {
                 "official": "Britsk\u00e9 Panensk\u00e9 ostrovy",
                 "common": "Britsk\u00e9 Panensk\u00e9 ostrovy"
@@ -37506,6 +38470,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0632\u0631 \u0627\u0644\u0639\u0630\u0631\u0627\u0621 \u0627\u0644\u0627\u0645\u0631\u064a\u0643\u064a\u0629",
+                "common": "\u062c\u0632\u0631 \u0627\u0644\u0639\u0630\u0631\u0627\u0621 \u0627\u0644\u0627\u0645\u0631\u064a\u0643\u064a\u0629"
+            },
             "ces": {
                 "official": "Americk\u00e9 Panensk\u00e9 ostrovy",
                 "common": "Americk\u00e9 Panensk\u00e9 ostrovy"
@@ -37654,6 +38622,10 @@
             "vie": "Vietnamese"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0641\u064a\u062a\u0646\u0627\u0645 \u0627\u0644\u0627\u0634\u062a\u0631\u0627\u0643\u064a\u0629",
+                "common": "\u0641\u064a\u062a\u0646\u0627\u0645"
+            },
             "ces": {
                 "official": "Vietnamsk\u00e1 socialistick\u00e1 republika",
                 "common": "Vietnam"
@@ -37816,6 +38788,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0641\u0627\u0646\u0648\u0627\u062a\u0648",
+                "common": "\u0641\u0627\u0646\u0648\u0627\u062a\u0648"
+            },
             "ces": {
                 "official": "Republika Vanuatu",
                 "common": "Vanuatu"
@@ -37963,6 +38939,10 @@
             "fra": "French"
         },
         "translations": {
+            "ara": {
+                "official": "\u0625\u0642\u0644\u064a\u0645 \u062c\u0632\u0631 \u0648\u0627\u0644\u064a\u0633 \u0648\u0641\u0648\u062a\u0648\u0646\u0627",
+                "common": "\u0648\u0627\u0644\u064a\u0633 \u0648\u0641\u0648\u062a\u0648\u0646\u0627"
+            },
             "ces": {
                 "official": "Teritorium ostrov\u016f Wallis a Futuna",
                 "common": "Wallis a Futuna"
@@ -38115,6 +39095,10 @@
             "smo": "Samoan"
         },
         "translations": {
+            "ara": {
+                "official": "\u062f\u0648\u0644\u0629 \u0633\u0627\u0645\u0648\u0627 \u0627\u0644\u0645\u0633\u062a\u0642\u0644\u0629",
+                "common": "\u0633\u0627\u0645\u0648\u0627"
+            },
             "ces": {
                 "official": "Nez\u00e1visl\u00fd st\u00e1t Samoa",
                 "common": "Samoa"
@@ -38222,7 +39206,7 @@
             "native": {
                 "ara": {
                     "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u064a\u0645\u0646\u064a\u0629",
-                    "common": "\u0627\u0644\u064a\u064e\u0645\u064e\u0646"
+                    "common": "\u0627\u0644\u064a\u0645\u0646"
                 }
             }
         },
@@ -38262,6 +39246,10 @@
             "ara": "Arabic"
         },
         "translations": {
+            "ara": {
+                "official": "\u0627\u0644\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0627\u0644\u064a\u0645\u0646\u064a\u0629",
+                "common": "\u0627\u0644\u064a\u0645\u0646"
+            },
             "ces": {
                 "official": "Jemensk\u00e1 republika",
                 "common": "Jemen"
@@ -38465,6 +39453,10 @@
             "zul": "Zulu"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u062c\u0646\u0648\u0628 \u0623\u0641\u0631\u064a\u0642\u064a\u0627",
+                "common": "\u062c\u0646\u0648\u0628 \u0623\u0641\u0631\u064a\u0642\u064a\u0627"
+            },
             "ces": {
                 "official": "Jihoafrick\u00e1 republika",
                 "common": "Jihoafrick\u00e1 republika"
@@ -38618,6 +39610,10 @@
             "eng": "English"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0632\u0627\u0645\u0628\u064a\u0627",
+                "common": "\u0632\u0627\u0645\u0628\u064a\u0627"
+            },
             "ces": {
                 "official": "Zambijsk\u00e1 republika",
                 "common": "Zambie"
@@ -38875,6 +39871,10 @@
             "zib": "Zimbabwean Sign Language"
         },
         "translations": {
+            "ara": {
+                "official": "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0632\u064a\u0645\u0628\u0627\u0628\u0648\u064a",
+                "common": "\u0632\u064a\u0645\u0628\u0627\u0628\u0648\u064a"
+            },
             "ces": {
                 "official": "Zimbabwsk\u00e1 republika",
                 "common": "Zimbabwe"


### PR DESCRIPTION
>[!NOTE]
> All the common and official names of the countries were taken from the respective Wikipedia pages in Arabic.

### Description
This PR is a follow-up on #256

This PR adds Arabic translation to all the countries in `countries.json`
It also updates some of the native names in Arabic, as well as remove unnecessary characters, namely `\u200e` and `\u200f`


