### PR TITLE
CG common name = "Congo" fix #564

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -8081,7 +8081,7 @@
     },
     {
         "name": {
-            "common": "Republic of the Congo",
+            "common": "Congo",
             "official": "Republic of the Congo",
             "native": {
                 "fra": {


### PR DESCRIPTION
Change English common name of "Republic of the Congo" to "Congo" (iso CG) not to confuse with "the Democratic Republic of the Congo" (iso = CD)