### PR TITLE
Change Swatziland (SZ) to the Eswatini fix #566

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -35448,27 +35448,27 @@
             },
             "ces": {
                 "official": "Svazijsk\u00e9 kr\u00e1lovstv\u00ed",
-                "common": "Svazijsko"
+                "common": "eSwatini"
             },
             "deu": {
                 "official": "K\u00f6nigreich Eswatini",
-                "common": "Swasiland"
+                "common": "Eswatini"
             },
             "est": {
                 "official": "eSwatini Kuningriik",
-                "common": "Svaasimaa"
+                "common": "eSwatini"
             },
             "fin": {
                 "official": "Swazimaan kuningaskunta",
-                "common": "Swazimaa"
+                "common": "Eswatini"
             },
             "fra": {
                 "official": "Royaume d\u2019Eswatini",
-                "common": "Swaziland"
+                "common": "Eswatini"
             },
             "hrv": {
                 "official": "Kraljevina eSwatini",
-                "common": "Svazi"
+                "common": "Esvatini"
             },
             "hun": {
                 "official": "Szv\u00e1zif\u00f6ldi Kir\u00e1lys\u00e1g",
@@ -35476,7 +35476,7 @@
             },
             "ita": {
                 "official": "Regno di eSwatini",
-                "common": "Swaziland"
+                "common": "ESwatini"
             },
             "jpn": {
                 "official": "\u30a8\u30b9\u30ef\u30c6\u30a3\u30cb\u738b\u56fd",
@@ -35496,11 +35496,11 @@
             },
             "pol": {
                 "official": "Kr\u00f3lestwo Suazi",
-                "common": "Suazi"
+                "common": "Eswatini"
             },
             "por": {
                 "official": "Reino de eSwatini",
-                "common": "Suazil\u00e2ndia"
+                "common": "Essuat\u00edni"
             },
             "rus": {
                 "official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0421\u0432\u0430\u0437\u0438\u043b\u0435\u043d\u0434",
@@ -35508,11 +35508,11 @@
             },
             "slk": {
                 "official": "Svazijsk\u00e9 kr\u00e1\u013eovstvo",
-                "common": "Svazijsko"
+                "common": "Eswatini"
             },
             "spa": {
                 "official": "Reino de eSwatini",
-                "common": "Suazilandia"
+                "common": "Esuatini"
             },
             "srp": {
               "official": "Kraljevina Esvatini",
@@ -35520,7 +35520,7 @@
             },
             "swe": {
                 "official": "Konungariket Eswatini",
-                "common": "Swaziland"
+                "common": "Eswatini"
             },
             "tur": {
 				"official": "Esvatini Krall\u0131\u011f\u0131",


### PR DESCRIPTION
Change the many occurrences of Swatziland (SZ) to the language version of Eswatini based on Wikidata page https://www.wikidata.org/wiki/Q1050 and each Wikipedia page