### PR TITLE
Fix Serbian 'common' and 'official' name for Hungarian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Serbian 'common' and 'official' name for Hungarian
 
 ## [5.1.0] - 2024-11-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Serbian 'common' and 'official' name for Hungarian
+- Serbian 'common' and 'official' name for Hungarian (#570)
 
 ## [5.1.0] - 2024-11-30
 ### Added

--- a/countries.json
+++ b/countries.json
@@ -17148,8 +17148,8 @@
                 "common": "Hungr\u00eda"
             },
             "srp": {
-              "official": "Madjarska",
-              "common": "Madjarska"
+              "official": "Ma\u0111arska",
+              "common": "Ma\u0111arska"
             },
             "swe": {
                 "official": "Ungern",


### PR DESCRIPTION
Use the letter 'đ' instead of the two-letter combination 'dj'.
Same meaning, more correctly like this.

Sources:

- [The Ministry of Foreign Affairs of the Republic of Serbia: Bilateral Cooperation - Mađarska](https://www.mfa.gov.rs/lat/spoljna-politika/bilateralna-saradnja/madjarska)