### PR TITLE
Fix typo in Tanziania French translation

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -39398,7 +39398,7 @@
                 "common": "Tansania"
             },
             "fra": {
-                "official": "R\u00e9publique -Unie de Tanzanie",
+                "official": "R\u00e9publique unie de Tanzanie",
                 "common": "Tanzanie"
             },
             "hrv": {


### PR DESCRIPTION
change "République -Unie de Tanzanie" to "République unie de Tanzanie" see https://fr.wikipedia.org/wiki/Tanzanie