### PR TITLE
Change Bulgaria's currency to EUR

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -3731,9 +3731,9 @@
         "unMember": true,
         "unRegionalGroup": "Eastern European Group",
         "currencies": {
-            "BGN": {
-                "name": "Bulgarian lev",
-                "symbol": "\u043b\u0432"
+            "EUR": {
+                "name": "Euro",
+                "symbol": "\u20ac"
             }
         },
         "idd": {


### PR DESCRIPTION
As of 1 January 2026, the euro is Bulgaria's official currency, replacing the Bulgarian lev (BGN). The Council of the European Union formally approved accession on 8 July 2025 at a conversion rate of 1.95583 BGN/EUR — see the [ECB press release](https://www.ecb.europa.eu/press/pr/date/2025/html/ecb.pr250708~b9676a9fa8.en.html).

Mirrors #472 (Croatia, 2023).