### PR TITLE
prepare release 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [5.1.1] - 2026-05-29
+### Changed
+- change Bulgaria's currency from BGN to EUR following euro adoption on 1 Jan 2026 (#597)
 ### Fixed
 - Serbian 'common' and 'official' name for Hungarian (#570)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "world-countries",
     "description": "List of world countries in JSON, CSV, XML and YAML",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "module": "./index.mjs",
     "main": "./index.cjs",
     "types": "index.d.ts",


### PR DESCRIPTION
Follow-up to #597 (Bulgaria's currency changed to EUR), which merged to `master` but hasn't been published.

This preps a patch release so the change reaches npm consumers of `world-countries`:

- **CHANGELOG.md** — add `## [5.1.1] - 2026-05-29` with the Bulgaria currency change (#597) plus the previously-unreleased Serbian name fix (#570).
- **package.json** — bump version `5.1.0` → `5.1.1`.

Patch bump since this is a data correction (Bulgaria adopted the euro on 1 Jan 2026). No `dist`/`index.*` rebuild is needed — `index.cjs`/`index.mjs` load `countries.json` at runtime.

Could you tag and publish `5.1.1` once merged? Happy to adjust the version or changelog wording to match your preferences.