### PR TITLE
Fix Russian translation for Eswatini

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -36356,8 +36356,8 @@
                 "common": "Essuat\u00edni"
             },
             "rus": {
-                "official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u0421\u0432\u0430\u0437\u0438\u043b\u0435\u043d\u0434",
-                "common": "\u0421\u0432\u0430\u0437\u0438\u043b\u0435\u043d\u0434"
+                "official": "\u041a\u043e\u0440\u043e\u043b\u0435\u0432\u0441\u0442\u0432\u043e \u042d\u0441\u0432\u0430\u0442\u0438\u043d\u0438",
+                "common": "\u042d\u0441\u0432\u0430\u0442\u0438\u043d\u0438"
             },
             "slk": {
                 "official": "Svazijsk\u00e9 kr\u00e1\u013eovstvo",


### PR DESCRIPTION
The Russian translation still used the old name

Source: https://ru.wikipedia.org/wiki/Эсватини