### PR TITLE
Change Sierra Leone to SLE

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -34229,7 +34229,7 @@
         "unMember": true,
         "unRegionalGroup": "African Group",
         "currencies": {
-            "SLL": {
+            "SLE": {
                 "name": "Sierra Leonean leone",
                 "symbol": "Le"
             }


### PR DESCRIPTION
The Leone was redenominated in July 2022 and the code change to SLE