### PR TITLE
Update currencies to current ISO 4217 (ANG→XCG, remove withdrawn CUC, ZWB→ZWG)

### DIFF
--- a/countries.json
+++ b/countries.json
@@ -9324,10 +9324,6 @@
         "unMember": true,
         "unRegionalGroup": "Latin American and Caribbean Group",
         "currencies": {
-            "CUC": {
-                "name": "Cuban convertible peso",
-                "symbol": "$"
-            },
             "CUP": {
                 "name": "Cuban peso",
                 "symbol": "$"
@@ -9500,9 +9496,9 @@
         "unMember": false,
         "unRegionalGroup": "",
         "currencies": {
-            "ANG": {
-                "name": "Netherlands Antillean guilder",
-                "symbol": "\u0192"
+            "XCG": {
+                "name": "Caribbean guilder",
+                "symbol": "Cg"
             }
         },
         "idd": {
@@ -36441,9 +36437,9 @@
         "unMember": false,
         "unRegionalGroup": "",
         "currencies": {
-            "ANG": {
-                "name": "Netherlands Antillean guilder",
-                "symbol": "\u0192"
+            "XCG": {
+                "name": "Caribbean guilder",
+                "symbol": "Cg"
             }
         },
         "idd": {
@@ -43076,9 +43072,9 @@
                 "name": "South African rand",
                 "symbol": "Rs"
             },
-            "ZWB": {
-                "name": "Zimbabwean bonds",
-                "symbol": "$"
+            "ZWG": {
+                "name": "Zimbabwe Gold",
+                "symbol": "ZiG"
             }
         },
         "idd": {


### PR DESCRIPTION
Following #602 (SLL→SLE, merged today), I audited every country's `currencies` in `countries.json` against the current ISO 4217 registry — pycountry / Debian `iso-codes` and the SIX Group `list-one.xml` — for codes ISO has withdrawn or superseded. The drift is bounded to four entries:

- **Curaçao (CW)** and **Sint Maarten (SX)**: `ANG` → `XCG`. The Netherlands Antillean guilder (ANG) was replaced by the Caribbean guilder (XCG) on 2025-03-31 and ceased to be legal tender on 2025-07-01 (Central Bank of Curaçao and Sint Maarten). Symbol `Cg`.
- **Cuba (CU)**: remove `CUC`, keep `CUP`. The Cuban convertible peso (CUC) was withdrawn in the 2021 monetary unification (Tarea Ordenamiento); the Cuban peso (CUP) remains the sole currency.
- **Zimbabwe (ZW)**: `ZWB` → `ZWG`. `ZWB` ("Zimbabwean bonds") is not an ISO 4217 code — it was a placeholder from the bond-note era. Zimbabwe's local unit now has an official ISO 4217 code, `ZWG` (Zimbabwe Gold / ZiG, numeric 924), assigned by ISO 4217 amendment 177 in June 2024.

Scope: this only changes codes ISO actually assigns. The deliberate non-ISO placeholders for currencies that have never had an ISO code (`CKD`, `FOK`, `GGP`, `IMP`, `JEP`, `KID`, `TVD`) are intentional and left untouched. No other drift was found across the 250 entries.

Source `countries.json` only; the `dist/` files can be regenerated with `php countries.php convert` at release time, as in #602.
